### PR TITLE
Add Emacs and Vim editor integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,49 @@ queries in-process without shelling out to the binary. The library lives in
 its own `format/` subpackage (rather than at the module root) specifically
 so it stays easily importable on its own, independent of the CLI.
 
+## Editor integration
+
+### Emacs
+
+`editors/emacs/sqlfmt.el` provides `sqlfmt-mode`, a minor mode for
+`sql-mode` buffers:
+
+```elisp
+(add-to-list 'load-path "~/dev/PostgreSQL/sqlfmt/editors/emacs")
+(add-hook 'sql-mode-hook #'sqlfmt-mode)
+```
+
+With it enabled, `C-M-h` (`mark-defun`, as in `python-mode`) selects the SQL
+statement at point, and `TAB` on that selection reformats it via `sqlfmt` —
+`indent-for-tab-command` already calls `indent-region` whenever the region
+is active, and `sqlfmt-mode` sets `indent-region-function` to use `sqlfmt`,
+so this needs no new keybinding for `TAB` itself. `sqlfmt-buffer` and
+`sqlfmt-region` are also plain interactive commands, and
+`sqlfmt-before-save-hook` can be added to `before-save-hook` to format on
+save. See the commentary at the top of `sqlfmt.el` for details.
+
+### Vim
+
+`editors/vim/ftplugin/sql.vim` wires `sqlfmt` into Vim's `formatprg`/
+`equalprg` options — since `sqlfmt` with no arguments already reads stdin
+and writes formatted SQL to stdout, no plugin logic beyond setting those two
+options is needed. Add the directory to your `runtimepath`:
+
+```vim
+set runtimepath+=~/dev/PostgreSQL/sqlfmt/editors/vim
+```
+
+or copy/symlink `sql.vim` to `~/.vim/ftplugin/sql.vim`. This enables:
+
+```
+gqip / gqap / gqG    " reformat a paragraph/block/the whole buffer (gq)
+=ap / =G / gg=G       " same, via the = operator
+:%!sqlfmt              " reformat the whole buffer directly
+```
+
+Set `g:sqlfmt_command` before the file loads to point at a non-`$PATH`
+binary.
+
 ## Repository layout
 
 ```
@@ -60,6 +103,8 @@ format/                    — package format, the library (import "github.com/d
   format.go                — the library entry point (Format)
   format_test.go           — corpus round-trip test (reads ../testdata/corpus)
 cmd/sqlfmt/main.go         — the CLI binary
+editors/emacs/sqlfmt.el     — sql-mode minor mode (mark-defun/indent-region integration)
+editors/vim/ftplugin/sql.vim — formatprg/equalprg integration
 testdata/corpus/           — flat directory of real book queries, each one run through
                              sqlfmt and reviewed — the round-trip/regression fixtures,
                              also used by `make test`'s CLI-level check

--- a/editors/emacs/sqlfmt.el
+++ b/editors/emacs/sqlfmt.el
@@ -1,0 +1,226 @@
+;;; sqlfmt.el --- Format PostgreSQL SQL with sqlfmt -*- lexical-binding: t; -*-
+
+;; Copyright (c) 2026, Dimitri Fontaine
+
+;; Author: Dimitri Fontaine
+;; Keywords: languages, sql, tools
+;; URL: https://github.com/dimitri/sqlfmt
+;; Package-Requires: ((emacs "26.1"))
+;; Version: 0.1.0
+
+;; This file is not part of GNU Emacs.
+
+;; SPDX-License-Identifier: PostgreSQL
+;; See the LICENSE file at the root of https://github.com/dimitri/sqlfmt
+;; for the full PostgreSQL Licence text this file is distributed under.
+
+;;; Commentary:
+
+;; Minor mode wiring the `sqlfmt' command-line formatter
+;; (https://github.com/dimitri/sqlfmt) into `sql-mode' buffers.
+;;
+;; Enable it with:
+;;
+;;   (add-hook 'sql-mode-hook #'sqlfmt-mode)
+;;
+;; `sqlfmt-mode' does not define any new keybindings.  Instead it plugs
+;; `sqlfmt' into Emacs's own generic statement-navigation and
+;; region-indent machinery, so existing muscle memory keeps working:
+;;
+;; - `beginning-of-defun-function' / `end-of-defun-function' are set to
+;;   SQL statement boundaries (a top-level `;', skipping over string
+;;   and comment syntax), so `mark-defun' -- already bound to `C-M-h'
+;;   everywhere, exactly as in `python-mode' -- selects the statement
+;;   at point.
+;; - `indent-region-function' is set to reformat the selected region
+;;   through `sqlfmt'.  `indent-for-tab-command' (`TAB') already calls
+;;   `indent-region' whenever the region is active, so `C-M-h TAB'
+;;   selects the statement at point and reformats it in house style.
+;;
+;; `sqlfmt-buffer' and `sqlfmt-region' are also available as ordinary
+;; interactive commands, and `sqlfmt-before-save-hook' can be added to
+;; `before-save-hook' to format on save:
+;;
+;;   (add-hook 'sql-mode-hook #'sqlfmt-mode)
+;;   (add-hook 'sql-mode-hook
+;;             (lambda () (add-hook 'before-save-hook
+;;                                  #'sqlfmt-before-save-hook nil t)))
+
+;;; Code:
+
+(defgroup sqlfmt nil
+  "Format SQL with the external `sqlfmt' command-line tool."
+  :group 'sql
+  :link '(url-link "https://github.com/dimitri/sqlfmt"))
+
+(defcustom sqlfmt-command "sqlfmt"
+  "Name or path of the `sqlfmt' executable."
+  :type 'string
+  :group 'sqlfmt)
+
+(defcustom sqlfmt-show-errors t
+  "When non-nil, show `sqlfmt's stderr in *sqlfmt-errors* on failure."
+  :type 'boolean
+  :group 'sqlfmt)
+
+;;; Statement (top-level ";") boundaries, for beginning/end-of-defun.
+
+(defun sqlfmt--in-string-or-comment-p (pos)
+  "Non-nil if POS is inside a string or comment per the syntax table.
+Wrapped in `save-excursion': `sql-mode's `syntax-propertize-function'
+(for `''`-escaped strings) does not reliably preserve point, and
+`syntax-ppss' calls it as needed, so an unguarded call here can quietly
+move point out from under statement-boundary scanning callers."
+  (save-excursion
+    (let ((state (syntax-ppss pos)))
+      (or (nth 3 state) (nth 4 state)))))
+
+(defun sqlfmt--statement-terminator-at-p (pos)
+  "Non-nil if the character just before POS is a real statement `;'."
+  (and (> pos (point-min))
+       (eq (char-after (1- pos)) ?\;)
+       (not (sqlfmt--in-string-or-comment-p (1- pos)))))
+
+(defun sqlfmt-beginning-of-statement (&optional n)
+  "`beginning-of-defun-function' for SQL statements.
+Moves point to the start of the current top-level statement, or the
+Nth previous one.  Statements are delimited by a `;' outside of any
+string or comment.  Intended for `beginning-of-defun'/`mark-defun'."
+  (let ((n (or n 1)))
+    (dotimes (_ (max n 1))
+      ;; Step left of a semicolon point is already sitting right after,
+      ;; so repeated calls walk to the previous statement, not stay put.
+      (when (sqlfmt--statement-terminator-at-p (point))
+        (backward-char))
+      (let ((found nil))
+        (while (and (not found) (re-search-backward ";" nil t))
+          (unless (sqlfmt--in-string-or-comment-p (point))
+            (setq found t)))
+        (goto-char (if found (1+ (point)) (point-min))))
+      (skip-chars-forward " \t\n\r")))
+  t)
+
+(defun sqlfmt-end-of-statement ()
+  "`end-of-defun-function' for SQL statements.
+Moves point just past the terminating `;' of the current top-level
+statement, or to `point-max' if the statement is unterminated."
+  (let ((found nil))
+    (while (and (not found) (re-search-forward ";" nil t))
+      (unless (sqlfmt--in-string-or-comment-p (1- (point)))
+        (setq found t)))
+    (unless found (goto-char (point-max)))))
+
+;;; Running sqlfmt.
+
+(defun sqlfmt--replace-region (beg end)
+  "Replace BEG..END with the `sqlfmt' output for that text.
+Applies the result with `replace-buffer-contents', so only the spans
+that actually changed are touched -- point, markers and overlays
+elsewhere in the buffer are left alone.  Signals an error and leaves
+the buffer untouched if `sqlfmt' exits non-zero."
+  (let ((input (buffer-substring-no-properties beg end))
+        (out-buf (generate-new-buffer " *sqlfmt-output*"))
+        ;; call-process-region's (REAL-BUFFER STDERR-FILE) BUFFER form
+        ;; wants a *file name* for stderr, unlike call-process, which
+        ;; also accepts a buffer there.
+        (err-file (make-temp-file "sqlfmt-stderr")))
+    (unwind-protect
+        (let ((status (with-temp-buffer
+                         (insert input)
+                         (call-process-region (point-min) (point-max)
+                                               sqlfmt-command
+                                               nil (list out-buf err-file) nil))))
+          (if (not (eq status 0))
+              (progn
+                (when sqlfmt-show-errors
+                  (with-current-buffer (get-buffer-create "*sqlfmt-errors*")
+                    (erase-buffer)
+                    (insert-file-contents err-file)
+                    (display-buffer (current-buffer))))
+                (error "sqlfmt failed (%s), buffer left unchanged" status))
+            (save-restriction
+              (narrow-to-region beg end)
+              (goto-char (point-min))
+              (replace-buffer-contents out-buf))))
+      (kill-buffer out-buf)
+      (delete-file err-file))))
+
+(defun sqlfmt-region (beg end)
+  "Reformat the region BEG..END with `sqlfmt'."
+  (interactive "r")
+  (sqlfmt--replace-region beg end))
+
+(defun sqlfmt-buffer ()
+  "Reformat the current buffer with `sqlfmt'."
+  (interactive)
+  (sqlfmt--replace-region (point-min) (point-max)))
+
+(defun sqlfmt-indent-region (beg end)
+  "`indent-region-function' for `sqlfmt-mode': reformat BEG..END.
+This is what makes `TAB' on an active region -- e.g. one just marked
+with `C-M-h' -- reformat it via `sqlfmt' instead of re-indenting
+line-by-line, since `indent-for-tab-command' calls `indent-region'
+whenever the region is active, and `indent-region' defers to
+`indent-region-function' when it is set."
+  (sqlfmt--replace-region beg end))
+
+(defun sqlfmt-mark-statement (&optional _arg)
+  "Put point at the beginning of the SQL statement at point, mark at its end.
+A drop-in replacement for `mark-defun' in `sqlfmt-mode' buffers.
+Emacs's generic `mark-defun'/`end-of-defun' machinery layers in extra
+positional bookkeeping (repeat-count handling, \"were we between two
+defuns\" retries, trailing-comment skipping...) tuned for paren- or
+brace-delimited defuns; it does not compose cleanly with a simple
+`;'-delimited statement boundary, so this reimplements the one
+behavior actually wanted -- select the enclosing statement -- directly
+in terms of `sqlfmt-beginning-of-statement'/`sqlfmt-end-of-statement'."
+  (interactive "p")
+  (push-mark (point))
+  (sqlfmt-beginning-of-statement)
+  (let ((beg (point)))
+    (sqlfmt-end-of-statement)
+    (push-mark (point) nil t)
+    (goto-char beg)))
+
+(defvar sqlfmt-mode-map
+  (let ((map (make-sparse-keymap)))
+    (define-key map [remap mark-defun] #'sqlfmt-mark-statement)
+    map)
+  "Keymap for `sqlfmt-mode'.
+Remaps `mark-defun' (`C-M-h' by default, as in `python-mode') to
+`sqlfmt-mark-statement' rather than introducing a new binding.")
+
+;;;###autoload
+(define-minor-mode sqlfmt-mode
+  "Minor mode wiring the `sqlfmt' formatter into SQL statement
+navigation and region indentation.
+
+With `sqlfmt-mode' enabled, `C-M-h' (`mark-defun', remapped to
+`sqlfmt-mark-statement') selects the SQL statement at point, and `TAB'
+on the resulting active region reformats it via `sqlfmt' (through
+`indent-region-function', which `indent-for-tab-command' already
+consults whenever the region is active)."
+  :lighter " Sqlfmt"
+  :keymap sqlfmt-mode-map
+  (if sqlfmt-mode
+      (progn
+        (setq-local beginning-of-defun-function #'sqlfmt-beginning-of-statement)
+        (setq-local end-of-defun-function #'sqlfmt-end-of-statement)
+        (setq-local indent-region-function #'sqlfmt-indent-region))
+    (kill-local-variable 'beginning-of-defun-function)
+    (kill-local-variable 'end-of-defun-function)
+    (kill-local-variable 'indent-region-function)))
+
+;;;###autoload
+(defun sqlfmt-before-save-hook ()
+  "Reformat the buffer with `sqlfmt' before saving, if `sqlfmt-mode' is on.
+Add to `before-save-hook' buffer-locally to format on save.  Errors
+are reported but do not block the save."
+  (when sqlfmt-mode
+    (condition-case err
+        (sqlfmt-buffer)
+      (error (message "%s" (error-message-string err))))))
+
+(provide 'sqlfmt)
+
+;;; sqlfmt.el ends here

--- a/editors/vim/ftplugin/sql.vim
+++ b/editors/vim/ftplugin/sql.vim
@@ -1,0 +1,34 @@
+" sql.vim -- wire the sqlfmt formatter into Vim's format operators
+"
+" Install by adding this repository's editors/vim directory to your
+" 'runtimepath', e.g. in ~/.vimrc:
+"
+"   set runtimepath+=~/dev/PostgreSQL/sqlfmt/editors/vim
+"
+" or by copying/symlinking this file directly to ~/.vim/ftplugin/sql.vim.
+"
+" sqlfmt (https://github.com/dimitri/sqlfmt) reads SQL on stdin and
+" writes formatted SQL to stdout when given no arguments -- exactly
+" what Vim's 'formatprg'/'equalprg' options expect: they pipe the
+" affected lines through the given external command and replace them
+" with its output. No plugin logic is needed beyond setting them:
+"
+"   gqip / gqap / gqG    -- reformat a paragraph/block/the whole buffer
+"                            via 'formatprg' (the gq operator)
+"   =ap / =G / gg=G       -- same, via 'equalprg' (the = operator)
+"   :%!sqlfmt              -- reformat the whole buffer directly
+
+if exists('b:did_sqlfmt_ftplugin')
+  finish
+endif
+let b:did_sqlfmt_ftplugin = 1
+
+if !exists('g:sqlfmt_command')
+  let g:sqlfmt_command = 'sqlfmt'
+endif
+
+let &l:formatprg = g:sqlfmt_command
+let &l:equalprg = g:sqlfmt_command
+
+let b:undo_ftplugin = (exists('b:undo_ftplugin') ? b:undo_ftplugin . ' | ' : '')
+      \ . 'setlocal formatprg< equalprg<'


### PR DESCRIPTION
## Summary

Adds Emacs and Vim integration for `sqlfmt`, per the design discussed in the issue thread. Deliberately scoped to just these two — no `conform.nvim`/`none-ls`/ALE snippets in this PR.

### Emacs — `editors/emacs/sqlfmt.el`

A `sqlfmt-mode` minor mode for `sql-mode` buffers:

```elisp
(add-to-list 'load-path "~/dev/PostgreSQL/sqlfmt/editors/emacs")
(add-hook 'sql-mode-hook #'sqlfmt-mode)
```

- `C-M-h` (`mark-defun`, exactly as in `python-mode`) selects the SQL statement at point.
- `TAB` on that selection reformats it via `sqlfmt` — `indent-for-tab-command` already calls `indent-region` whenever the region is active, and `sqlfmt-mode` sets `indent-region-function` to run `sqlfmt`, so no new binding is needed for `TAB` itself.
- `sqlfmt-buffer`/`sqlfmt-region` are also plain interactive commands, and `sqlfmt-before-save-hook` can be added to `before-save-hook` for format-on-save.

Implementation notes:
- `beginning-of-defun-function`/`end-of-defun-function` are set to a `;`-boundary scanner (syntax-table-aware, so it doesn't stop at `;` inside strings/comments), but `C-M-h` itself is served by a dedicated `sqlfmt-mark-statement` remapped onto `mark-defun` — Emacs's generic `mark-defun`/`end-of-defun` machinery carries a lot of extra positional bookkeeping tuned for paren/brace-delimited defuns (repeat-count handling, "were we between two defuns" retries, trailing-blank-line skipping) that doesn't compose cleanly with a flat `;`-delimited statement boundary. I verified this empirically — the generic path mis-selected statements in several real test cases before I pivoted to the dedicated command.
- Along the way this also surfaced a real `sql-mode` bug: its `syntax-propertize-function` (for `''`-escaped string handling) doesn't preserve point, which was silently corrupting the statement-boundary scan until guarded with `save-excursion`.
- Byte-compiles clean (no warnings) and was exercised end-to-end against a real Emacs binary in batch mode: statement selection from several cursor positions, `TAB`-triggered reformatting, and the error path (nonzero `sqlfmt` exit leaves the buffer untouched, reports to `*sqlfmt-errors*`).

### Vim — `editors/vim/ftplugin/sql.vim`

Sets `formatprg`/`equalprg` to `sqlfmt`. Since `sqlfmt` with no arguments already reads stdin and writes formatted SQL to stdout, that's the entire integration — no plugin logic needed beyond the two `setlocal`s:

```
gqip / gqap / gqG    " reformat a paragraph/block/the whole buffer
=ap / =G / gg=G       " same, via the = operator
:%!sqlfmt              " reformat the whole buffer directly
```

`g:sqlfmt_command` overrides the binary path. Tested against a real `vim` binary — both `gq` and `=` correctly invoke `sqlfmt` and reformat in place.

### Docs

New "Editor integration" section in README.md, plus both files listed in the repository-layout tree.

## Test plan

- `go build ./...`, `go vet ./...`, `gofmt -l .`, `go test ./...` all clean (unaffected by this change, confirmed anyway).
- `sqlfmt.el` byte-compiled with a real Emacs (`Emacs.app` on this machine) — zero warnings.
- Exercised `sqlfmt-mark-statement` + `TAB`-reformat end-to-end in batch-mode Emacs against a real built `sqlfmt` binary, across multiple statements and cursor positions, plus the error (bad command) path.
- Exercised `gq`/`=`/`:%!sqlfmt` end-to-end in a real `vim` binary against a real built `sqlfmt` binary.