### PR TITLE
Add an evergreen WebAssembly build, published on every green push to main

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,3 +35,96 @@ jobs:
 
       - name: test
         run: make test
+
+  # ── Build + smoke-test the browser WebAssembly module ──────────────────────
+  # Runs on every push and PR so a wasm/ regression is caught before merge,
+  # not just when publish-wasm-dev (push-to-main only) would otherwise be the
+  # first thing to notice.
+  wasm:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+
+      - uses: actions/setup-go@v7
+        with:
+          go-version-file: go.mod
+
+      - uses: actions/setup-node@v7
+        with:
+          node-version: 'lts/*'
+
+      - name: build + smoke-test wasm module
+        run: make wasm-test
+
+      - name: upload wasm artifact
+        uses: actions/upload-artifact@v7
+        with:
+          name: wasm-dist
+          path: dist/wasm/
+          retention-days: 1
+
+  # ── Publish evergreen dev release ───────────────────────────────────────────
+  # Runs only on push to main (not PRs), only after test+wasm both pass.
+  # Overwrites the assets on the fixed `wasm-dev` pre-release tag so that
+  # https://github.com/dimitri/sqlfmt/releases/download/wasm-dev/sqlfmt.wasm
+  # (and .../wasm_exec.js) always point at the latest green HEAD build --
+  # the pattern used for pgloader's v4 JAR (see dimitri/pgloader's
+  # clojure-integration-tests.yml, publish-dev job).
+  publish-wasm-dev:
+    name: Publish wasm-dev release
+    needs: [test, wasm]
+    if: github.event_name == 'push'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
+
+      - name: download wasm artifact
+        uses: actions/download-artifact@v8
+        with:
+          name: wasm-dist
+          path: dist/wasm/
+
+      - name: name versioned copy of the wasm module
+        id: ver
+        run: |
+          SHA=$(git rev-parse --short HEAD)
+          cp dist/wasm/sqlfmt.wasm "dist/wasm/sqlfmt-${SHA}.wasm"
+          echo "sha=${SHA}" >> "$GITHUB_OUTPUT"
+
+      - name: delete previous versioned wasm assets
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh release view wasm-dev --repo ${{ github.repository }} --json assets \
+            --jq '.assets[].name' 2>/dev/null \
+          | grep -E '^sqlfmt-[0-9a-f]+\.wasm$' \
+          | xargs -r -I{} gh release delete-asset wasm-dev {} \
+              --repo ${{ github.repository }} --yes || true
+
+      - name: update wasm-dev release
+        uses: softprops/action-gh-release@v3
+        with:
+          tag_name: wasm-dev
+          name: "sqlfmt — WebAssembly development build"
+          prerelease: true
+          body: |
+            Automated build from `${{ github.ref_name }}` at commit `${{ github.sha }}`.
+
+            All CI tests passed, including the wasm/smoketest.mjs Node
+            smoke test of `globalThis.sqlfmt.format(sql)`.
+
+            **Stable URLs (always latest green HEAD):**
+            ```
+            https://github.com/${{ github.repository }}/releases/download/wasm-dev/sqlfmt.wasm
+            https://github.com/${{ github.repository }}/releases/download/wasm-dev/wasm_exec.js
+            ```
+
+            This build: `sqlfmt-${{ steps.ver.outputs.sha }}.wasm`
+          files: |
+            dist/wasm/sqlfmt.wasm
+            dist/wasm/wasm_exec.js
+            dist/wasm/sqlfmt-${{ steps.ver.outputs.sha }}.wasm

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -133,8 +133,17 @@ jobs:
             https://github.com/${{ github.repository }}/releases/download/wasm-dev/wasm_exec.js
             ```
 
+            A pre-compressed copy is also published for callers who want a
+            smaller transfer (GitHub Releases doesn't serve
+            `Content-Encoding`, so this isn't automatic -- see the
+            "WebAssembly build" section of README.md for how to consume it):
+            ```
+            https://github.com/${{ github.repository }}/releases/download/wasm-dev/sqlfmt.wasm.gz
+            ```
+
             This build: `sqlfmt-${{ steps.ver.outputs.sha }}.wasm`
           files: |
             dist/wasm/sqlfmt.wasm
+            dist/wasm/sqlfmt.wasm.gz
             dist/wasm/wasm_exec.js
             dist/wasm/sqlfmt-${{ steps.ver.outputs.sha }}.wasm

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,6 +49,16 @@ jobs:
         with:
           go-version-file: go.mod
 
+      # TinyGo (not the standard `go build`) is what actually produces a
+      # small module here -- the stock toolchain always statically links
+      # its full runtime/GC into a js/wasm build (no -ldflags can drop it),
+      # landing around 2.9MB for this program; TinyGo with -opt=z plus a
+      # wasm-opt -Oz pass (installed alongside it below) gets the same
+      # source down to ~330KB. Version pinned to match local dev tooling.
+      - uses: acifani/setup-tinygo@v3
+        with:
+          tinygo-version: '0.41.1'
+
       - uses: actions/setup-node@v7
         with:
           node-version: 'lts/*'

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 /sqlfmt
 /bin/
+/dist/
 *.test
 
 # editor lock/autosave files

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -183,16 +183,20 @@ hand-formatting variance the tool normalizes away.
   architecture decision above re: why a shared engine wasn't chosen for the
   *core formatting logic* — that reasoning is about AST-vs-token-stream
   design, not about language/runtime). That's since been revisited one
-  layer up: `wasm/` compiles this exact engine to WebAssembly
-  (`GOOS=js GOARCH=wasm`, `make wasm`), published as an evergreen dev
-  release by CI on every green push to `main` (mirroring how pgloader
-  publishes its v4 JAR — see `.github/workflows/ci.yml`'s
-  `publish-wasm-dev` job), at a stable URL:
+  layer up: `wasm/` compiles this exact engine to WebAssembly with TinyGo
+  + `wasm-opt` (`make wasm`; see the "WebAssembly build" section of
+  README.md for why TinyGo instead of the standard `go build` toolchain —
+  in short, ~330KB instead of ~2.9MB for the identical source), published
+  as an evergreen dev release by CI on every green push to `main`
+  (mirroring how pgloader publishes its v4 JAR — see
+  `.github/workflows/ci.yml`'s `publish-wasm-dev` job), at a stable URL:
   `https://github.com/dimitri/sqlfmt/releases/download/wasm-dev/sqlfmt.wasm`.
   Whether `taop.xyz` actually adopts this (vs. keeping a hand-rolled JS
-  formatter) is still an open call — the wasm module is exact/correct but
-  ~3MB uncompressed and pulls in the Go runtime, whereas a lighter JS
-  reimplementation stays simpler for a paste-and-preview widget at the cost
-  of drifting from `STYLE.md` fidelity over time. Either way, the option to
+  formatter) is still an open call, though the size gap that would have
+  made this an easy "no" is mostly closed now — ~330KB is a reasonable
+  static asset, not obviously worse than a hand-rolled reimplementation
+  once you count its own parser/layout code. The remaining tradeoff is
+  more about maintenance surface (a second language/toolchain in that
+  repo's build) than raw payload size. Either way, the option to
   use the real engine in-browser now exists without touching this repo's
   CLI/library split.

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -177,10 +177,22 @@ hand-formatting variance the tool normalizes away.
 - Whether to add the `pg_query_go` `Fingerprint` safety-net test once the
   core engine is stable (see architecture decision above) — not a blocker
   for a first working version.
-- The JS implementation (for the website's SQL Formatter tool) is a
-  deliberately separate, independent implementation — simpler, not a full
-  parser, lower correctness bar than this Go engine. It is *not* planned to
-  share code with this repo (see architecture decision above re: why a
-  shared engine wasn't chosen — same reasoning applies to JS/Go as applied
-  to the earlier Elisp-wrapper option that was considered and dropped for
-  this project). Out of scope for this repo; happens separately.
+- The website's SQL Formatter tool was originally planned as a deliberately
+  separate, independent JS implementation — simpler, not a full parser,
+  lower correctness bar than this Go engine, with no code sharing (see the
+  architecture decision above re: why a shared engine wasn't chosen for the
+  *core formatting logic* — that reasoning is about AST-vs-token-stream
+  design, not about language/runtime). That's since been revisited one
+  layer up: `wasm/` compiles this exact engine to WebAssembly
+  (`GOOS=js GOARCH=wasm`, `make wasm`), published as an evergreen dev
+  release by CI on every green push to `main` (mirroring how pgloader
+  publishes its v4 JAR — see `.github/workflows/ci.yml`'s
+  `publish-wasm-dev` job), at a stable URL:
+  `https://github.com/dimitri/sqlfmt/releases/download/wasm-dev/sqlfmt.wasm`.
+  Whether `taop.xyz` actually adopts this (vs. keeping a hand-rolled JS
+  formatter) is still an open call — the wasm module is exact/correct but
+  ~3MB uncompressed and pulls in the Go runtime, whereas a lighter JS
+  reimplementation stays simpler for a paste-and-preview widget at the cost
+  of drifting from `STYLE.md` fidelity over time. Either way, the option to
+  use the real engine in-browser now exists without touching this repo's
+  CLI/library split.

--- a/Makefile
+++ b/Makefile
@@ -23,20 +23,25 @@ test: build
 	fi
 
 # Builds the browser WebAssembly module (globalThis.sqlfmt.format(sql)) plus
-# the wasm_exec.js glue it needs, into $(WASM_DIR). See wasm/main.go.
+# the wasm_exec.js glue it needs, into $(WASM_DIR), along with pre-compressed
+# a pre-compressed sqlfmt.wasm.gz copy (wasm/compress.mjs) for callers who
+# want the smaller transfer and are willing to decompress client-side --
+# GitHub Releases doesn't serve Content-Encoding, so this isn't transparent
+# to a plain fetch(). See the "WebAssembly build" section of README.md.
 #
 # Built with TinyGo (-no-debug -opt=z), then squeezed further with
 # Binaryen's wasm-opt, rather than the standard `go build` toolchain: the
 # same source compiles to ~330KB this way vs. ~2.9MB with stock Go (the
 # standard toolchain's wasm output always statically links the full
 # runtime/GC regardless of -ldflags, and cannot be told to drop it).
-# Requires `tinygo` and `wasm-opt` (Binaryen) on PATH -- see the
+# Requires `tinygo`, `wasm-opt` (Binaryen), and `node` on PATH -- see the
 # "WebAssembly build" section of README.md for install instructions.
 wasm:
 	mkdir -p $(WASM_DIR)
 	$(TINYGO) build -o $(WASM_DIR)/sqlfmt.wasm -target=wasm -no-debug -opt=z ./wasm
 	$(WASM_OPT) -Oz -o $(WASM_DIR)/sqlfmt.wasm $(WASM_DIR)/sqlfmt.wasm
 	cp "$$($(TINYGO) env TINYGOROOT)/targets/wasm_exec.js" $(WASM_DIR)/wasm_exec.js
+	node wasm/compress.mjs
 
 # Loads the built module under Node and exercises globalThis.sqlfmt.format,
 # the same entry point a browser page would call. See wasm/smoketest.mjs.

--- a/Makefile
+++ b/Makefile
@@ -1,8 +1,9 @@
-BINARY  := bin/sqlfmt
-GO      := go
-CORPUS  := $(shell find testdata/corpus -name '*.sql')
+BINARY   := bin/sqlfmt
+WASM_DIR := dist/wasm
+GO       := go
+CORPUS   := $(shell find testdata/corpus -name '*.sql')
 
-.PHONY: all build test clean
+.PHONY: all build test wasm wasm-test clean
 
 all: build
 
@@ -19,5 +20,18 @@ test: build
 		exit 1; \
 	fi
 
+# Builds the browser WebAssembly module (globalThis.sqlfmt.format(sql)) plus
+# the Go runtime's wasm_exec.js glue it needs, into $(WASM_DIR). See wasm/main.go.
+wasm:
+	mkdir -p $(WASM_DIR)
+	GOOS=js GOARCH=wasm $(GO) build -o $(WASM_DIR)/sqlfmt.wasm ./wasm
+	cp "$$($(GO) env GOROOT)/lib/wasm/wasm_exec.js" $(WASM_DIR)/wasm_exec.js
+
+# Loads the built module under Node and exercises globalThis.sqlfmt.format,
+# the same entry point a browser page would call. See wasm/smoketest.mjs.
+wasm-test: wasm
+	node wasm/smoketest.mjs
+
 clean:
 	rm -f $(BINARY)
+	rm -rf $(WASM_DIR)

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,8 @@
 BINARY   := bin/sqlfmt
 WASM_DIR := dist/wasm
 GO       := go
+TINYGO   := tinygo
+WASM_OPT := wasm-opt
 CORPUS   := $(shell find testdata/corpus -name '*.sql')
 
 .PHONY: all build test wasm wasm-test clean
@@ -21,11 +23,20 @@ test: build
 	fi
 
 # Builds the browser WebAssembly module (globalThis.sqlfmt.format(sql)) plus
-# the Go runtime's wasm_exec.js glue it needs, into $(WASM_DIR). See wasm/main.go.
+# the wasm_exec.js glue it needs, into $(WASM_DIR). See wasm/main.go.
+#
+# Built with TinyGo (-no-debug -opt=z), then squeezed further with
+# Binaryen's wasm-opt, rather than the standard `go build` toolchain: the
+# same source compiles to ~330KB this way vs. ~2.9MB with stock Go (the
+# standard toolchain's wasm output always statically links the full
+# runtime/GC regardless of -ldflags, and cannot be told to drop it).
+# Requires `tinygo` and `wasm-opt` (Binaryen) on PATH -- see the
+# "WebAssembly build" section of README.md for install instructions.
 wasm:
 	mkdir -p $(WASM_DIR)
-	GOOS=js GOARCH=wasm $(GO) build -o $(WASM_DIR)/sqlfmt.wasm ./wasm
-	cp "$$($(GO) env GOROOT)/lib/wasm/wasm_exec.js" $(WASM_DIR)/wasm_exec.js
+	$(TINYGO) build -o $(WASM_DIR)/sqlfmt.wasm -target=wasm -no-debug -opt=z ./wasm
+	$(WASM_OPT) -Oz -o $(WASM_DIR)/sqlfmt.wasm $(WASM_DIR)/sqlfmt.wasm
+	cp "$$($(TINYGO) env TINYGOROOT)/targets/wasm_exec.js" $(WASM_DIR)/wasm_exec.js
 
 # Loads the built module under Node and exercises globalThis.sqlfmt.format,
 # the same entry point a browser page would call. See wasm/smoketest.mjs.

--- a/README.md
+++ b/README.md
@@ -102,10 +102,22 @@ sqlfmt.format(sql)
 //  -> { error: string }  on a real parse/format error
 ```
 
-Build it locally with `make wasm` (outputs `dist/wasm/sqlfmt.wasm` and the Go
-runtime's `wasm_exec.js` glue it needs), or `make wasm-test` to additionally
-run `wasm/smoketest.mjs`, which loads the module under Node and exercises
-`sqlfmt.format` the same way a browser page would.
+Built with [TinyGo](https://tinygo.org) (`tinygo build -target=wasm -no-debug
+-opt=z`) plus a [Binaryen](https://github.com/WebAssembly/binaryen)
+`wasm-opt -Oz` pass, rather than the standard `go build` toolchain: the
+standard js/wasm target always statically links its full runtime and GC with
+no way to drop it, landing around **2.9MB** for this program; the same
+source via TinyGo + wasm-opt comes in around **330KB** — roughly 9x smaller,
+and confirmed to still round-trip correctly (see `wasm/smoketest.mjs`).
+Requires `tinygo` and `wasm-opt` on `PATH` (`brew install tinygo binaryen`
+on macOS; CI installs both via
+[`acifani/setup-tinygo`](https://github.com/acifani/setup-tinygo)).
+
+Build it locally with `make wasm` (outputs `dist/wasm/sqlfmt.wasm` and the
+matching `wasm_exec.js` glue it needs, from TinyGo's own target support
+files — not the standard Go toolchain's), or `make wasm-test` to
+additionally run `wasm/smoketest.mjs`, which loads the module under Node and
+exercises `sqlfmt.format` the same way a browser page would.
 
 CI publishes this module on every green push to `main`, at a stable,
 always-latest-HEAD URL — the same pattern used for

--- a/README.md
+++ b/README.md
@@ -113,22 +113,53 @@ Requires `tinygo` and `wasm-opt` on `PATH` (`brew install tinygo binaryen`
 on macOS; CI installs both via
 [`acifani/setup-tinygo`](https://github.com/acifani/setup-tinygo)).
 
-Build it locally with `make wasm` (outputs `dist/wasm/sqlfmt.wasm` and the
-matching `wasm_exec.js` glue it needs, from TinyGo's own target support
-files — not the standard Go toolchain's), or `make wasm-test` to
-additionally run `wasm/smoketest.mjs`, which loads the module under Node and
-exercises `sqlfmt.format` the same way a browser page would.
+Build it locally with `make wasm` (outputs `dist/wasm/sqlfmt.wasm`, the
+matching `wasm_exec.js` glue it needs — from TinyGo's own target support
+files, not the standard Go toolchain's — plus a pre-compressed
+`sqlfmt.wasm.gz` copy, see below), or `make wasm-test` to additionally run
+`wasm/smoketest.mjs`, which loads the module under Node and exercises
+`sqlfmt.format` the same way a browser page would.
 
-CI publishes this module on every green push to `main`, at a stable,
-always-latest-HEAD URL — the same pattern used for
+CI publishes all of this on every green push to `main`, at stable,
+always-latest-HEAD URLs — the same pattern used for
 [pgloader's v4 JAR releases](https://github.com/dimitri/pgloader/releases/tag/v4-dev):
 
 ```
 https://github.com/dimitri/sqlfmt/releases/download/wasm-dev/sqlfmt.wasm
 https://github.com/dimitri/sqlfmt/releases/download/wasm-dev/wasm_exec.js
+https://github.com/dimitri/sqlfmt/releases/download/wasm-dev/sqlfmt.wasm.gz
 ```
 
 See `.github/workflows/ci.yml`'s `wasm` and `publish-wasm-dev` jobs.
+
+### Pre-compressed copy (`.gz`)
+
+`sqlfmt.wasm` is ~330KB; gzipped it's ~130KB. GitHub Releases doesn't serve
+this with a `Content-Encoding` header (verified — a plain `fetch` gets the
+literal compressed bytes back, not auto-decompressed by the browser), but it
+can still be decompressed client-side with no extra dependency, via the
+standard [Compression Streams
+API](https://developer.mozilla.org/en-US/docs/Web/API/Compression_Streams_API)
+(confirmed working end-to-end in a real browser):
+
+```js
+const response = await fetch("sqlfmt.wasm.gz");
+const bytes = await new Response(
+  response.body.pipeThrough(new DecompressionStream("gzip")),
+).arrayBuffer();
+const { instance } = await WebAssembly.instantiate(bytes, go.importObject);
+```
+
+(Brotli was tried too but dropped: pre-compressing to `.br` would only pay
+off if the file were served with a transparent `Content-Encoding: br` by
+whatever server ultimately hosts it, which is outside this repo's control —
+and unlike gzip, there's no `DecompressionStream("br")` to decompress it
+client-side; that throws `Unsupported compression format` even on a current
+Chrome. Not worth a second artifact for a path nothing here can use.)
+
+Plain **`sqlfmt.wasm`** remains the zero-effort default: works directly with
+`WebAssembly.instantiateStreaming(fetch(...))`, no decompression code at
+all, at the cost of the larger transfer.
 
 ## Repository layout
 
@@ -144,6 +175,7 @@ format/                    — package format, the library (import "github.com/d
 cmd/sqlfmt/main.go         — the CLI binary
 wasm/main.go                — WebAssembly build (globalThis.sqlfmt.format), see "WebAssembly build"
 wasm/smoketest.mjs          — Node smoke test for the built wasm module
+wasm/compress.mjs           — produces sqlfmt.wasm.gz from the built module
 editors/emacs/sqlfmt.el     — sql-mode minor mode (mark-defun/indent-region integration)
 editors/vim/ftplugin/sql.vim — formatprg/equalprg integration
 testdata/corpus/           — flat directory of real book queries, each one run through

--- a/README.md
+++ b/README.md
@@ -91,6 +91,33 @@ gqip / gqap / gqG    " reformat a paragraph/block/the whole buffer (gq)
 Set `g:sqlfmt_command` before the file loads to point at a non-`$PATH`
 binary.
 
+## WebAssembly build
+
+`wasm/` compiles the `format` library to WebAssembly for in-browser use,
+exposing a single global JS function:
+
+```js
+sqlfmt.format(sql)
+//  -> { output: string } on success
+//  -> { error: string }  on a real parse/format error
+```
+
+Build it locally with `make wasm` (outputs `dist/wasm/sqlfmt.wasm` and the Go
+runtime's `wasm_exec.js` glue it needs), or `make wasm-test` to additionally
+run `wasm/smoketest.mjs`, which loads the module under Node and exercises
+`sqlfmt.format` the same way a browser page would.
+
+CI publishes this module on every green push to `main`, at a stable,
+always-latest-HEAD URL — the same pattern used for
+[pgloader's v4 JAR releases](https://github.com/dimitri/pgloader/releases/tag/v4-dev):
+
+```
+https://github.com/dimitri/sqlfmt/releases/download/wasm-dev/sqlfmt.wasm
+https://github.com/dimitri/sqlfmt/releases/download/wasm-dev/wasm_exec.js
+```
+
+See `.github/workflows/ci.yml`'s `wasm` and `publish-wasm-dev` jobs.
+
 ## Repository layout
 
 ```
@@ -103,6 +130,8 @@ format/                    — package format, the library (import "github.com/d
   format.go                — the library entry point (Format)
   format_test.go           — corpus round-trip test (reads ../testdata/corpus)
 cmd/sqlfmt/main.go         — the CLI binary
+wasm/main.go                — WebAssembly build (globalThis.sqlfmt.format), see "WebAssembly build"
+wasm/smoketest.mjs          — Node smoke test for the built wasm module
 editors/emacs/sqlfmt.el     — sql-mode minor mode (mark-defun/indent-region integration)
 editors/vim/ftplugin/sql.vim — formatprg/equalprg integration
 testdata/corpus/           — flat directory of real book queries, each one run through

--- a/wasm/compress.mjs
+++ b/wasm/compress.mjs
@@ -1,0 +1,25 @@
+// Produces a gzip pre-compressed copy of dist/wasm/sqlfmt.wasm
+// (sqlfmt.wasm.gz) at maximum compression, using Node's built-in zlib
+// rather than requiring a system `gzip` binary. Run via `make wasm` (after
+// the tinygo + wasm-opt build). See the "WebAssembly build" section of
+// README.md for why this exists and how to consume it -- GitHub Releases
+// does not serve Content-Encoding, so a browser must decompress this
+// explicitly (via DecompressionStream) rather than relying on transparent
+// HTTP compression.
+import { readFile, writeFile } from "node:fs/promises";
+import { gzipSync, constants as zlibConstants } from "node:zlib";
+import { fileURLToPath } from "node:url";
+import path from "node:path";
+
+const wasmDir = path.join(path.dirname(fileURLToPath(import.meta.url)), "..", "dist", "wasm");
+const wasmPath = path.join(wasmDir, "sqlfmt.wasm");
+
+const input = await readFile(wasmPath);
+
+const gz = gzipSync(input, { level: zlibConstants.Z_BEST_COMPRESSION });
+await writeFile(wasmPath + ".gz", gz);
+
+console.log(
+  `sqlfmt.wasm      ${input.length.toLocaleString()} bytes\n` +
+    `sqlfmt.wasm.gz  ${gz.length.toLocaleString()} bytes`,
+);

--- a/wasm/main.go
+++ b/wasm/main.go
@@ -1,0 +1,51 @@
+//go:build js && wasm
+
+// Command wasm compiles the sqlfmt formatter to WebAssembly for in-browser
+// use (GOOS=js GOARCH=wasm), exposing a single global JS function:
+//
+//	globalThis.sqlfmt.format(sql)
+//	  -> { output: string } on success
+//	  -> { error: string }  on a real parse/format error
+//
+// Load it alongside the Go runtime's wasm_exec.js glue (copied into this
+// build's output directory by `make wasm`, from
+// $(go env GOROOT)/lib/wasm/wasm_exec.js), e.g.:
+//
+//	<script src="wasm_exec.js"></script>
+//	<script>
+//	  const go = new Go();
+//	  WebAssembly.instantiateStreaming(fetch("sqlfmt.wasm"), go.importObject)
+//	    .then((result) => go.run(result.instance));
+//	</script>
+package main
+
+import (
+	"strings"
+	"syscall/js"
+
+	"github.com/dimitri/sqlfmt/format"
+)
+
+func formatSQL(_ js.Value, args []js.Value) any {
+	result := make(map[string]any)
+	if len(args) != 1 || args[0].Type() != js.TypeString {
+		result["error"] = "sqlfmt.format(sql): expected a single string argument"
+		return result
+	}
+
+	out, err := format.Format(strings.NewReader(args[0].String()))
+	if err != nil {
+		result["error"] = err.Error()
+		return result
+	}
+	result["output"] = out
+	return result
+}
+
+func main() {
+	done := make(chan struct{})
+	sqlfmt := js.Global().Get("Object").New()
+	sqlfmt.Set("format", js.FuncOf(formatSQL))
+	js.Global().Set("sqlfmt", sqlfmt)
+	<-done // keep the Go runtime (and the exported function) alive
+}

--- a/wasm/main.go
+++ b/wasm/main.go
@@ -1,15 +1,17 @@
 //go:build js && wasm
 
 // Command wasm compiles the sqlfmt formatter to WebAssembly for in-browser
-// use (GOOS=js GOARCH=wasm), exposing a single global JS function:
+// use, exposing a single global JS function:
 //
 //	globalThis.sqlfmt.format(sql)
 //	  -> { output: string } on success
 //	  -> { error: string }  on a real parse/format error
 //
-// Load it alongside the Go runtime's wasm_exec.js glue (copied into this
-// build's output directory by `make wasm`, from
-// $(go env GOROOT)/lib/wasm/wasm_exec.js), e.g.:
+// Built with TinyGo (-target=wasm), not the standard `go build` js/wasm
+// target, to keep the module small -- see the "WebAssembly build" section
+// of README.md. Load it alongside the matching wasm_exec.js glue (copied
+// into this build's output directory by `make wasm`, from TinyGo's own
+// target support files, not the standard Go toolchain's), e.g.:
 //
 //	<script src="wasm_exec.js"></script>
 //	<script>

--- a/wasm/smoketest.mjs
+++ b/wasm/smoketest.mjs
@@ -1,0 +1,43 @@
+// Smoke-tests the built dist/wasm/sqlfmt.wasm under Node: loads the Go
+// runtime's wasm_exec.js glue, instantiates the module, and exercises
+// globalThis.sqlfmt.format(sql) exactly as a browser page would. Run via
+// `make wasm-test` (after `make wasm`).
+import { readFile } from "node:fs/promises";
+import { fileURLToPath } from "node:url";
+import path from "node:path";
+
+const wasmDir = path.join(path.dirname(fileURLToPath(import.meta.url)), "..", "dist", "wasm");
+
+await import(path.join(wasmDir, "wasm_exec.js"));
+
+const go = new globalThis.Go();
+const wasmBytes = await readFile(path.join(wasmDir, "sqlfmt.wasm"));
+const { instance } = await WebAssembly.instantiate(wasmBytes, go.importObject);
+go.run(instance);
+
+function assertEqual(got, want, label) {
+  if (got !== want) {
+    console.error(`FAIL ${label}\n  got:  ${JSON.stringify(got)}\n  want: ${JSON.stringify(want)}`);
+    process.exitCode = 1;
+  } else {
+    console.log(`ok   ${label}`);
+  }
+}
+
+const ok = globalThis.sqlfmt.format("select id,name from users where id=1;");
+assertEqual(ok.error, undefined, "valid SQL: no error");
+assertEqual(ok.output, "select id, name\n  from users\n where id = 1;\n", "valid SQL: output");
+
+const badArg = globalThis.sqlfmt.format(42);
+assertEqual(typeof badArg.error, "string", "non-string argument: reports an error");
+assertEqual(badArg.output, undefined, "non-string argument: no output");
+
+const unterminated = globalThis.sqlfmt.format("select 'unterminated");
+assertEqual(typeof unterminated.error, "string", "lex error: reports an error");
+assertEqual(unterminated.output, undefined, "lex error: no output");
+
+if (process.exitCode) {
+  console.error("wasm smoke test FAILED");
+} else {
+  console.log("wasm smoke test passed");
+}


### PR DESCRIPTION
## Summary

Adds an evergreen WebAssembly build of `sqlfmt`, published on every green push to `main` — the same pattern `dimitri/pgloader` uses for its v4 JAR (`clojure-integration-tests.yml`'s `publish-dev` job).

### WebAssembly build

- `wasm/main.go` compiles the `format` library (unmodified) to WebAssembly, exposing one global JS function:
  ```js
  sqlfmt.format(sql)
  //  -> { output: string } on success
  //  -> { error: string }  on a real parse/format error
  ```
  Guarded with `//go:build js && wasm`, so `go build ./...` on normal platforms skips it.
- Built with [TinyGo](https://tinygo.org) (`-target=wasm -no-debug -opt=z`) plus a [Binaryen](https://github.com/WebAssembly/binaryen) `wasm-opt -Oz` pass, not the standard `go build` toolchain. Module size: ~330KB, vs. ~2.9MB from the standard toolchain (which always statically links its full runtime + GC).
- `wasm/smoketest.mjs` loads the built module under Node and calls the real JS entry point: valid SQL, a non-string argument, a lex error.

### Pre-compressed `sqlfmt.wasm.gz`

Published alongside the plain module, not replacing it. `wasm/compress.mjs` produces it via Node's built-in zlib, wired into `make wasm`. Consumption requires client-side decompression via the standard Compression Streams API (`DecompressionStream("gzip")`), since GitHub Releases doesn't serve `Content-Encoding` on asset downloads. No brotli asset — there's no `DecompressionStream("br")`, and this repo doesn't control the server that would need to send `Content-Encoding: br` for it to help.

### Evergreen publish

- `.github/workflows/ci.yml`:
  - **`wasm`** job (push + PR): installs TinyGo + Binaryen via `acifani/setup-tinygo@v3` (pinned `0.41.1`), runs `make wasm-test`, uploads `dist/wasm/` as a build artifact.
  - **`publish-wasm-dev`** job (push to `main` only, needs `test` + `wasm`): downloads the artifact, names a short-SHA-versioned copy, prunes old versioned assets off the `wasm-dev` pre-release tag, republishes via `softprops/action-gh-release@v3`.
- Stable, always-latest-green-HEAD URLs:
  ```
  https://github.com/dimitri/sqlfmt/releases/download/wasm-dev/sqlfmt.wasm
  https://github.com/dimitri/sqlfmt/releases/download/wasm-dev/sqlfmt.wasm.gz
  https://github.com/dimitri/sqlfmt/releases/download/wasm-dev/wasm_exec.js
  ```
  This is the shape needed to vendor into `taop.xyz/static/js/`, matching how the EXPLAIN visualizer's JS is a static asset there.

### Docs

- `Makefile`: `make wasm` (build) and `make wasm-test` (build + Node smoke test).
- README.md: new "WebAssembly build" section — TinyGo/wasm-opt rationale and sizes, the `.gz` decompression snippet, the brotli non-option.
- DESIGN.md: updates the "JS implementation for the website is deliberately separate, no code sharing" open question, which predates this PR. Left as an open call whether `taop.xyz` adopts the wasm module over a hand-rolled JS formatter.

## Test plan

- `go build ./...`, `go vet ./...`, `gofmt -l .`, `make test` all clean.
- `make wasm-test` passes (Node, real runtime execution of the exported JS function).
- `actionlint` (with shellcheck) clean on the workflow.
- CI on this PR installs TinyGo 0.41.1 + Binaryen and runs the full build + smoke test successfully.