### PR TITLE
Fix JOIN river alignment: a wide join phrase must widen every clause

### DIFF
--- a/format/layout.go
+++ b/format/layout.go
@@ -170,11 +170,94 @@ func matchWords(toks []Token, i int, words []string) bool {
 	return true
 }
 
+func isJoinModifier(lower string) bool {
+	switch lower {
+	case "left", "right", "full", "inner", "outer", "cross":
+		return true
+	}
+	return false
+}
+
+// splitJoinSegments splits a FROM clause's tokens into the leading table
+// expression and each subsequent JOIN segment (starting at its modifier, if
+// any, else at "join" itself).
+func splitJoinSegments(toks []Token) [][]Token {
+	var segs [][]Token
+	depth := 0
+	start := 0
+	for i, t := range toks {
+		if t.Text == "(" {
+			depth++
+			continue
+		}
+		if t.Text == ")" {
+			depth--
+			continue
+		}
+		if depth != 0 || t.Kind != TokKeyword {
+			continue
+		}
+		if isJoinModifier(t.Lower) {
+			segs = append(segs, toks[start:i])
+			start = i
+			continue
+		}
+		if t.Lower == "join" {
+			prevIsModifier := i > 0 && toks[i-1].Kind == TokKeyword && isJoinModifier(toks[i-1].Lower)
+			if !prevIsModifier {
+				segs = append(segs, toks[start:i])
+				start = i
+			}
+		}
+	}
+	segs = append(segs, toks[start:])
+	return segs
+}
+
+// joinKeywordEnd returns the index just past a join segment's leading
+// keyword phrase (left/right/.../join).
+func joinKeywordEnd(seg []Token) int {
+	kEnd := 0
+	for kEnd < len(seg) && seg[kEnd].Kind == TokKeyword {
+		kEnd++
+	}
+	return kEnd
+}
+
+// maxJoinPhraseLen scans a FROM clause's tokens for the longest join-keyword
+// phrase ("join", "left join", ...) actually present.
+func maxJoinPhraseLen(fromBody []Token) int {
+	max := 0
+	segs := splitJoinSegments(fromBody)
+	for _, seg := range segs[1:] {
+		seg = trimTokens(seg)
+		if len(seg) == 0 {
+			continue
+		}
+		if n := len(flatJoin(seg[:joinKeywordEnd(seg)])); n > max {
+			max = n
+		}
+	}
+	return max
+}
+
+// riverWidth computes the STYLE.md "unifying rule" column width for a query
+// level: the longest clause keyword actually present, or -- when a FROM
+// clause contains a JOIN longer than any clause keyword -- the longest JOIN
+// phrase (plus headroom) instead, so the whole clause list (select/from/
+// where/...) pads consistently with where JOIN's own table names end up.
+// An unindented "left join" would otherwise read as a mistake, not as
+// intentional flush-left alignment the way a bare wide clause keyword does.
 func riverWidth(segs []clauseSeg) int {
 	w := 0
 	for _, s := range segs {
 		if len(s.name) > w {
 			w = len(s.name)
+		}
+		if s.name == "from" {
+			if j := maxJoinPhraseLen(s.body) + 2; j > w {
+				w = j
+			}
 		}
 	}
 	return w
@@ -699,81 +782,17 @@ func renderClause(s clauseSeg, baseIndent, width int) []string {
 // layoutFrom renders a FROM clause: the first table stays on the FROM line,
 // each JOIN starts a new line. Multiple AND-ed ON predicates are right
 // aligned to the join-keyword-phrase's own end column.
+//
+// width is the same river width riverWidth already computed for every
+// other clause at this level (select/from/where/...), which by
+// construction is wide enough to fit the longest JOIN phrase here too (see
+// riverWidth) -- layoutFrom must reuse it as-is rather than recomputing its
+// own, or its JOIN lines would align to a different column than the "from"
+// keyword itself actually prints at.
 func layoutFrom(toks []Token, baseIndent, width int) []string {
-	isJoinModifier := func(lower string) bool {
-		switch lower {
-		case "left", "right", "full", "inner", "outer", "cross":
-			return true
-		}
-		return false
-	}
-	var segs [][]Token
-	depth := 0
-	start := 0
-	for i, t := range toks {
-		if t.Text == "(" {
-			depth++
-			continue
-		}
-		if t.Text == ")" {
-			depth--
-			continue
-		}
-		if depth != 0 || t.Kind != TokKeyword {
-			continue
-		}
-		if isJoinModifier(t.Lower) {
-			segs = append(segs, toks[start:i])
-			start = i
-			continue
-		}
-		if t.Lower == "join" {
-			prevIsModifier := i > 0 && toks[i-1].Kind == TokKeyword && isJoinModifier(toks[i-1].Lower)
-			if !prevIsModifier {
-				segs = append(segs, toks[start:i])
-				start = i
-			}
-		}
-	}
-	segs = append(segs, toks[start:])
+	segs := splitJoinSegments(toks)
 
-	// join keyword phrase = leading keyword tokens (left/right/.../join) of
-	// each join segment.
-	joinKeywordEnd := func(seg []Token) int {
-		kEnd := 0
-		for kEnd < len(seg) && seg[kEnd].Kind == TokKeyword {
-			kEnd++
-		}
-		return kEnd
-	}
-
-	// The join-phrase column is its own mini river alignment: every join
-	// phrase present ends at the same column, one column left of where
-	// table names start (STYLE.md rule 9's multi-predicate ON example).
-	// That column is never narrower than the query-clause river width, so
-	// FROM's own table and every JOIN's table start in the same column.
-	maxPhraseLen := 0
-	for _, seg := range segs[1:] {
-		seg = trimTokens(seg)
-		if len(seg) == 0 {
-			continue
-		}
-		if n := len(flatJoin(seg[:joinKeywordEnd(seg)])); n > maxPhraseLen {
-			maxPhraseLen = n
-		}
-	}
-	// A join phrase that happens to be the single widest word in the local
-	// alignment gets a couple of columns of headroom rather than landing
-	// flush at baseIndent -- unlike the top-level clause river, an
-	// unindented "left join" reads as a mistake, not as intentional
-	// alignment (STYLE.md rule 9 corpus examples always show JOIN
-	// indented relative to FROM).
-	effectiveWidth := width
-	if maxPhraseLen+2 > effectiveWidth {
-		effectiveWidth = maxPhraseLen + 2
-	}
-
-	joinCol := baseIndent + effectiveWidth + 1
+	joinCol := baseIndent + width + 1
 	phraseEndCol := joinCol - 1
 	firstLines := renderRun(trimTokens(segs[0]), joinCol)
 	out := firstLines

--- a/format/layout_test.go
+++ b/format/layout_test.go
@@ -1,0 +1,65 @@
+package format
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+)
+
+// twoWordLeaders are leading words that, on a rendered line, are always
+// followed by a second word still part of the same keyword/JOIN phrase
+// ("order by", "group by", "left join", ...).
+var twoWordLeaders = map[string]bool{
+	"left": true, "right": true, "full": true, "inner": true, "outer": true, "cross": true,
+	"order": true, "group": true,
+}
+
+// riverEndCol returns the column (0-indexed) that the leading clause
+// keyword (or JOIN phrase, e.g. "left join") on a rendered line ends at, or
+// -1 for a blank line.
+func riverEndCol(line string) int {
+	trimmed := strings.TrimLeft(line, " ")
+	if trimmed == "" {
+		return -1
+	}
+	indent := len(line) - len(trimmed)
+	fields := strings.Fields(trimmed)
+	phrase := fields[0]
+	if twoWordLeaders[phrase] && len(fields) > 1 {
+		phrase += " " + fields[1]
+	}
+	return indent + len(phrase)
+}
+
+// TestJoinRiverAlignment is a regression test for a real formatter bug: a
+// JOIN phrase longer than every other clause keyword (e.g. "left join")
+// must widen the whole clause river so select/from/where/group by/order by
+// all still end at the same column as the JOIN line -- not just pad itself
+// wider in isolation while the other clause keywords stay narrow.
+func TestJoinRiverAlignment(t *testing.T) {
+	src := "select title, name from album left join track using(album_id) where album_id = 1 order by 2;"
+	got, err := Format(bytes.NewReader([]byte(src)))
+	if err != nil {
+		t.Fatalf("Format error: %v", err)
+	}
+
+	lines := strings.Split(strings.TrimRight(got, "\n"), "\n")
+	if len(lines) != 5 {
+		t.Fatalf("expected 5 lines (select/from/left join/where/order by), got %d:\n%s", len(lines), got)
+	}
+
+	var cols []int
+	for _, l := range lines {
+		col := riverEndCol(l)
+		if col < 0 {
+			t.Fatalf("line has no leading keyword: %q", l)
+		}
+		cols = append(cols, col)
+	}
+	for i := 1; i < len(cols); i++ {
+		if cols[i] != cols[0] {
+			t.Errorf("river misaligned: line %d (%q) ends its keyword at column %d, line 0 (%q) ends at column %d\nfull output:\n%s",
+				i, lines[i], cols[i], lines[0], cols[0], got)
+		}
+	}
+}

--- a/testdata/corpus/application-use-case-03_01.sql
+++ b/testdata/corpus/application-use-case-03_01.sql
@@ -1,5 +1,5 @@
-  select genre.name, count(*) as count
-    from genre
+     select genre.name, count(*) as count
+       from genre
   left join track using(genre_id)
-group by genre.name
-order by count desc;
+   group by genre.name
+   order by count desc;

--- a/testdata/corpus/application-use-case-04_01_artist.sql
+++ b/testdata/corpus/application-use-case-04_01_artist.sql
@@ -1,6 +1,6 @@
-  select artist.name, count(*) as albums
-    from artist
+     select artist.name, count(*) as albums
+       from artist
   left join album using(artist_id)
-group by artist.name
-order by albums desc
-   limit :n;
+   group by artist.name
+   order by albums desc
+      limit :n;

--- a/testdata/corpus/application-use-case-05_01_album-by-artist.sql
+++ b/testdata/corpus/application-use-case-05_01_album-by-artist.sql
@@ -1,7 +1,8 @@
-  select album.title as album, sum(milliseconds) * interval '1 ms' as duration
-    from album
+     select album.title as album,
+            sum(milliseconds) * interval '1 ms' as duration
+       from album
        join artist using(artist_id)
   left join track using(album_id)
-   where artist.name = :name
-group by album
-order by album;
+      where artist.name = :name
+   group by album
+   order by album;

--- a/testdata/corpus/relations-02_01.sql
+++ b/testdata/corpus/relations-02_01.sql
@@ -1,12 +1,12 @@
-  select results.positionorder as position,
-         drivers.code,
-         count(behind.*) as behind
-    from results
+     select results.positionorder as position,
+            drivers.code,
+            count(behind.*) as behind
+       from results
        join drivers using(driverid)
   left join results behind
          on results.raceid = behind.raceid
         and results.positionorder < behind.positionorder
-   where results.raceid = 972
-     and results.positionorder <= 3
-group by results.positionorder, drivers.code
-order by results.positionorder;
+      where results.raceid = 972
+        and results.positionorder <= 3
+   group by results.positionorder, drivers.code
+   order by results.positionorder;

--- a/testdata/corpus/repl-01_03_schema.sql
+++ b/testdata/corpus/repl-01_03_schema.sql
@@ -53,13 +53,13 @@ group by article.id
 order by count desc
    limit 5;
 
-  select category.name,
-         count(distinct article.id) as articles,
-         count(*) as comments
-    from sandbox.category
+     select category.name,
+            count(distinct article.id) as articles,
+            count(*) as comments
+       from sandbox.category
   left join sandbox.article on article.category = category.id
   left join sandbox.comment on comment.article = article.id
-group by category.name
-order by category.name;
+   group by category.name
+   order by category.name;
 
 rollback;

--- a/testdata/corpus/sql-101-04_01.sql
+++ b/testdata/corpus/sql-101-04_01.sql
@@ -2,11 +2,11 @@
 
 \set months 3
 
-select date, name, drivers.surname as winner
-  from races
+     select date, name, drivers.surname as winner
+       from races
   left join results
          on results.raceid = races.raceid
         and results.position = 1
   left join drivers using(driverid)
- where date >= date : 'beginning'
-   and date < date : 'beginning' + :months * interval '1 month';
+      where date >= date : 'beginning'
+        and date < date : 'beginning' + :months * interval '1 month';

--- a/testdata/corpus/sql-102-03_01_f1db.decade.top3.sql
+++ b/testdata/corpus/sql-102-03_01_f1db.decade.top3.sql
@@ -3,11 +3,11 @@ with decades as (
         from races
     group by decade
 )
-  select decade,
-         rank() over(partition by decade order by wins desc) as rank,
-         forename,
-         surname,
-         wins
-    from decades
+             select decade,
+                    rank() over(partition by decade order by wins desc) as rank,
+                    forename,
+                    surname,
+                    wins
+               from decades
   left join lateral (       select code, forename, surname, count(*) as wins       from drivers       join results         on results.driverid = drivers.driverid        and results.position = 1       join races using(raceid)      where extract('year' from date_trunc('decade', races.date)) = decades.decade   group by decades.decade, drivers.driverid   order by wins desc      limit 3 ) as winners on true
-order by decade asc, wins desc;
+           order by decade asc, wins desc;

--- a/testdata/corpus/usecase-07_01.sql
+++ b/testdata/corpus/usecase-07_01.sql
@@ -1,9 +1,9 @@
 \set start '2017-02-01'
 
-  select cast (calendar.entry as date) as date,
-         coalesce(shares, 0) as shares,
-         coalesce(trades, 0) as trades,
-         to_char(coalesce(dollars, 0), 'L99G999G999G999') as dollars
-    from generate_series(date : 'start', date : 'start' + interval '1 month' - interval '1 day', interval '1 day') as calendar(entry)
+     select cast (calendar.entry as date) as date,
+            coalesce(shares, 0) as shares,
+            coalesce(trades, 0) as trades,
+            to_char(coalesce(dollars, 0), 'L99G999G999G999') as dollars
+       from generate_series(date : 'start', date : 'start' + interval '1 month' - interval '1 day', interval '1 day') as calendar(entry)
   left join factbook on factbook.date = calendar.entry
-order by date;
+   order by date;


### PR DESCRIPTION
## Summary

Reported bug: `left join` wasn't aligned to the same river column as select/from/where/order by:

```
  select title, name
    from album
  left join track using(album_id)
   where album_id = 1
order by 2;
```

`left join` ends 3 columns further right than everything else.

## Root cause

`riverWidth()` — which computes the column every clause keyword at a query level pads to — only looked at clause names (`select`/`from`/`where`/...), never at JOIN phrases inside the FROM clause. `layoutFrom()` separately computed its own wider "effectiveWidth" so its own JOIN lines wouldn't land flush-left, but that width was never fed back into `riverWidth()`. Two independently-computed widths for what's supposed to be one shared river: `from`/`select`/`where`/etc kept padding against the narrower clause-name-only width, while `layoutFrom`'s JOIN lines aligned to a wider column it invented on its own.

## Fix

Fold JOIN phrase length into `riverWidth()` itself, so every clause at that level pads against the same width. `layoutFrom()` now just uses the width `riverWidth` already computed instead of recomputing a competing one. All five keywords now end at the same column:

```
     select title, name
       from album
  left join track using(album_id)
      where album_id = 1
   order by 2;
```

## Changes

- `format/layout.go`: extracted `isJoinModifier`/`splitJoinSegments`/`joinKeywordEnd`/`maxJoinPhraseLen` as shared helpers; `riverWidth` now considers the FROM clause's join phrases; `layoutFrom` simplified to just use the passed-in `width`.
- `format/layout_test.go`: new `TestJoinRiverAlignment` regression test, asserting every clause line's own keyword-end column against the reported query. Verified it actually catches the bug — reverted the `layout.go` fix, confirmed the test fails with the exact reported misalignment, restored the fix.
- `testdata/corpus/*.sql`: 8 fixtures containing JOINs regenerated via `sqlfmt -w` (corpus holds sqlfmt's own canonical output, per this repo's established convention).

## Test plan

- `go build ./...`, `go vet ./...`, `gofmt -l .` clean.
- `make test` clean (unit tests + corpus round-trip + CLI-level `-l` check).
- New regression test verified to fail without the fix and pass with it.