### PR TITLE
Preserve and properly format comments (rule 18)

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -116,6 +116,15 @@ format/
                          genuinely different formatting mode from the query
                          clauses — column-name-width alignment, not clause-keyword
                          alignment)
+  comments.go      — rule 18: attachComments (a single pass over the full lexed
+                     stream that removes every comment token and re-expresses it
+                     as metadata -- Comments/TrailingComment -- on a neighboring
+                     real token, so the rest of the engine never sees a raw
+                     comment token in the middle of an expression), reflow of
+                     leading "--" comments to the line-length target with
+                     blank-line/dash-divider preservation, C-style rewrap of
+                     "/* ... */" blocks, and the shared-column alignment pass
+                     for trailing comments
   format_test.go   — corpus round-trip test: format() every file under
                      ../testdata/corpus/, diff against the file's own content.
                      Files under testdata/excluded/ must NOT be included.

--- a/README.md
+++ b/README.md
@@ -170,6 +170,7 @@ Makefile                   — build/test entry points
 format/                    — package format, the library (import "github.com/dimitri/sqlfmt/format")
   lexer.go                 — tokenizer
   layout.go                — river-alignment layout engine
+  comments.go              — comment attachment, reflow, and C-style block rewrap (rule 18)
   format.go                — the library entry point (Format)
   format_test.go           — corpus round-trip test (reads ../testdata/corpus)
 cmd/sqlfmt/main.go         — the CLI binary

--- a/STYLE.md
+++ b/STYLE.md
@@ -281,14 +281,35 @@ fixture's current content.
     when a single unbreakable token (long string literal, dense expression)
     forces it.
 
-18. **Comments**: rare (~5% of files). Header comments: 1–3 lines at the top,
-    `-- ` prefix, sentence case, wrapped near the line-length target.
-    Trailing inline comments: padded so multiple comments in the same block
-    share a common start column:
+18. **Comments**: rare (~5% of files), always preserved, never discarded.
+    A "--" comment sitting on its own source line, not preceded by real
+    code on that line, is a leading comment — attached to whatever
+    statement, clause, or list item follows it, reindented to that
+    context's column, and reflowed to the ~78–80 col line-length target
+    (rule 17). A blank source line between two leading comments is kept as
+    a paragraph break; a comment line that's nothing but dashes (e.g.
+    `-----------`) is a divider and is preserved verbatim, never merged
+    into surrounding prose. A comment on the same source line as preceding
+    real code is a trailing comment; multiple trailing comments in the same
+    contiguous block of lines are padded so they all start at a shared
+    column:
     ```sql
       select geom, ord_stra from mainstem          -- 155 high-order channels
     ...
          and r.ord_stra < 6;                       -- 161 direct tributaries
+    ```
+    Block comments (`/* ... */`) are rewritten into the C style: an opening
+    line with only `/*`, each content line reflowed to the line-length
+    target and starting with a `*` aligned under `/*`'s own `*` (its second
+    character), and a closing line with only `*/` aligned the same way —
+    regardless of how the original was formatted, so re-running the
+    formatter on its own output is a no-op:
+    ```sql
+    /*
+     * Generate the target month's calendar then LEFT JOIN each day
+     * against the factbook dataset, so as to have every day in the
+     * result set, whether or not we have a book entry for the day.
+     */
     ```
     A formatter's tokenizer must be comment-aware from the start (preserve
     and reposition comments, don't discard them) — this is the main reason

--- a/format/comments.go
+++ b/format/comments.go
@@ -1,0 +1,252 @@
+package format
+
+import (
+	"regexp"
+	"strings"
+)
+
+// commentWidth is the reflow target for comment text (STYLE.md rule 17's
+// line-length target applies to comments too).
+const commentWidth = 80
+
+// commentMarker is a sentinel inserted between a rendered line's real
+// content and a pending trailing comment. alignTrailingComments (run once,
+// over the whole formatted statement) replaces it with padding that lines
+// up every trailing comment in a contiguous run at a shared column, per
+// STYLE.md rule 18. Chosen because it can never appear in real SQL source
+// (the lexer never produces it).
+const commentMarker = "\x00"
+
+var dashOnlyRe = regexp.MustCompile(`^-+$`)
+
+// attachComments walks the full lexed token stream once and returns an
+// equivalent stream with every comment token removed and re-expressed as
+// metadata on a neighboring real token: a comment on the same source line
+// as the preceding real token becomes that token's TrailingComment: any
+// other comment becomes a leading Comments entry on the next real token.
+//
+// This is what makes it safe for the rest of the layout engine to never see
+// a raw TokLineComment/TokBlockComment again -- previously, comments were
+// left in the token stream and just echoed inline wherever encountered,
+// which for a "--" comment silently absorbed every following token on the
+// same physical output line into the comment text (a real correctness bug:
+// `select id -- inline\nfrom users` rendered as `select id -- inline from
+// users`, an entirely different query).
+//
+// Comments with no following real token (trailing content at EOF) have
+// nowhere to attach; those are returned separately in eofComments, in
+// source order, for the caller to render as a trailing block.
+func attachComments(toks []Token) (out []Token, eofComments []Token) {
+	var pending []Token
+	var lastReal *Token
+
+	flushPendingAsEOF := func() {
+		eofComments = append(eofComments, pending...)
+		pending = nil
+	}
+
+	for i := range toks {
+		t := toks[i]
+		switch t.Kind {
+		case TokLineComment, TokBlockComment:
+			// A multi-line block comment starting on the same source line
+			// as the preceding real token (e.g. "from /*\n * ...\n */") is
+			// not a short same-line annotation the way a "--" comment or a
+			// one-line "/* ... */" is; treat it as leading on whatever
+			// comes next instead. This also sidesteps a real gap: a clause
+			// keyword token (e.g. "from") is never retained anywhere past
+			// splitClauses (clauseSeg keeps only its name), so a
+			// TrailingComment attached to it would be silently
+			// unreachable by any renderer.
+			sameLine := lastReal != nil && t.Line == lastReal.Line && lastReal.TrailingComment == nil
+			if sameLine && strings.Contains(t.Text, "\n") {
+				sameLine = false
+			}
+			if sameLine {
+				c := t
+				lastReal.TrailingComment = &c
+				continue
+			}
+			pending = append(pending, t)
+		case TokEOF:
+			flushPendingAsEOF()
+			out = append(out, t)
+		default:
+			if len(pending) > 0 {
+				t.Comments = pending
+				pending = nil
+			}
+			out = append(out, t)
+			lastReal = &out[len(out)-1]
+		}
+	}
+	return out, eofComments
+}
+
+// isDashOnly reports whether a line-comment token's full text is nothing
+// but dashes (e.g. "--", "-----------") -- a visual divider, preserved
+// verbatim rather than reflowed as prose.
+func isDashOnly(text string) bool {
+	return dashOnlyRe.MatchString(text)
+}
+
+// renderLeadingComments renders a token's attached leading comment group as
+// complete, standalone lines at the given indent: line comments reflowed to
+// commentWidth (blank source lines and dash-only divider lines preserved,
+// not merged into surrounding prose), block comments rewrapped into the
+// "/*" / " * text" / " */" C style.
+func renderLeadingComments(comments []Token, indent int) []string {
+	var out []string
+	for i, c := range comments {
+		if i > 0 && c.LeadingBlank {
+			out = append(out, "")
+		}
+		switch c.Kind {
+		case TokBlockComment:
+			out = append(out, formatBlockComment(c, indent)...)
+		default:
+			out = append(out, formatLineComment(c, indent)...)
+		}
+	}
+	return out
+}
+
+// formatLineComment renders one "--" comment token as one or more reflowed
+// lines. Dash-only dividers are preserved verbatim (just re-indented).
+func formatLineComment(c Token, indent int) []string {
+	if isDashOnly(c.Text) {
+		return []string{strings.Repeat(" ", indent) + c.Text}
+	}
+	content := strings.TrimSpace(strings.TrimPrefix(c.Text, "--"))
+	if content == "" {
+		return []string{strings.Repeat(" ", indent) + "--"}
+	}
+	return wrapWords(strings.Fields(content), indent, "-- ")
+}
+
+// formatBlockComment rewraps a "/* ... */" token into the C-style form: an
+// opening line with only "/*", each content line starting with a "*"
+// aligned under "/*"'s own "*" (its second character), and a closing line
+// with only "*/" similarly aligned. Blank lines inside the original
+// comment are preserved as paragraph breaks; any pre-existing "*" bullet
+// prefix per line is stripped before rewrapping, so re-running the
+// formatter on its own output is a no-op.
+func formatBlockComment(c Token, indent int) []string {
+	inner := strings.TrimSuffix(strings.TrimPrefix(c.Text, "/*"), "*/")
+	out := []string{strings.Repeat(" ", indent) + "/*"}
+
+	var para []string
+	pendingBlank := false
+	flush := func() {
+		if len(para) == 0 {
+			return
+		}
+		out = append(out, wrapWords(para, indent, " * ")...)
+		para = nil
+	}
+	for _, l := range strings.Split(inner, "\n") {
+		l = strings.TrimSpace(l)
+		l = strings.TrimPrefix(l, "*")
+		l = strings.TrimSpace(l)
+		if l == "" {
+			if len(para) > 0 {
+				flush()
+				pendingBlank = true
+			}
+			continue
+		}
+		// The blank output line is only inserted once it's confirmed there
+		// really is another paragraph following it -- otherwise a
+		// perfectly ordinary blank line right before the comment's own
+		// closing "*/" (every block comment has one) would read as a
+		// trailing empty paragraph that was never actually there.
+		if pendingBlank {
+			out = append(out, "")
+			pendingBlank = false
+		}
+		para = append(para, strings.Fields(l)...)
+	}
+	flush()
+	out = append(out, strings.Repeat(" ", indent)+" */")
+	return out
+}
+
+// wrapWords greedily word-wraps words onto lines of at most commentWidth
+// columns, each line indented spaces then prefix (e.g. "-- " or " * ").
+func wrapWords(words []string, indent int, prefix string) []string {
+	var lines []string
+	var cur []string
+	curLen := indent + len(prefix)
+	for _, w := range words {
+		add := len(w)
+		if len(cur) > 0 {
+			add++ // separating space
+		}
+		if curLen+add > commentWidth && len(cur) > 0 {
+			lines = append(lines, strings.Repeat(" ", indent)+prefix+strings.Join(cur, " "))
+			cur = nil
+			curLen = indent + len(prefix)
+		}
+		if len(cur) > 0 {
+			curLen++
+		}
+		cur = append(cur, w)
+		curLen += len(w)
+	}
+	if len(cur) > 0 {
+		lines = append(lines, strings.Repeat(" ", indent)+prefix+strings.Join(cur, " "))
+	}
+	return lines
+}
+
+// trailingCommentText renders a token's TrailingComment (if any) as inline
+// comment text with no leading padding of its own -- the caller appends
+// commentMarker + this to the line under construction; alignTrailingComments
+// supplies the padding later.
+func trailingCommentText(tc *Token) string {
+	if tc == nil {
+		return ""
+	}
+	if tc.Kind == TokBlockComment {
+		// A block comment trailing on the same line as code can't be
+		// re-flowed into the multi-line C style without breaking that
+		// line's structure; flatten it to a single line instead.
+		flat := strings.Join(strings.Fields(tc.Text), " ")
+		return flat
+	}
+	return tc.Text
+}
+
+// alignTrailingComments replaces each commentMarker with padding so every
+// trailing comment in a maximal run of consecutive comment-bearing lines
+// starts at the same column (STYLE.md rule 18), then strips the marker.
+func alignTrailingComments(text string) string {
+	lines := strings.Split(text, "\n")
+	i := 0
+	for i < len(lines) {
+		if !strings.Contains(lines[i], commentMarker) {
+			i++
+			continue
+		}
+		j := i
+		maxLen := 0
+		for j < len(lines) && strings.Contains(lines[j], commentMarker) {
+			content := strings.SplitN(lines[j], commentMarker, 2)[0]
+			if len(content) > maxLen {
+				maxLen = len(content)
+			}
+			j++
+		}
+		col := maxLen + 2
+		for k := i; k < j; k++ {
+			parts := strings.SplitN(lines[k], commentMarker, 2)
+			pad := col - len(parts[0])
+			if pad < 1 {
+				pad = 1
+			}
+			lines[k] = parts[0] + strings.Repeat(" ", pad) + parts[1]
+		}
+		i = j
+	}
+	return strings.Join(lines, "\n")
+}

--- a/format/comments_integration_test.go
+++ b/format/comments_integration_test.go
@@ -1,0 +1,94 @@
+package format
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+)
+
+// TestLineCommentDoesNotSwallowFollowingTokens is a regression test for a
+// real correctness bug: a "--" comment not at the end of a statement used
+// to be echoed inline with no line break, silently absorbing every token
+// that followed it on the same rendered line into the comment text --
+// `select id -- inline\nfrom users;` rendered as `select id -- inline from
+// users;`, an entirely different (and, if re-parsed, differently-behaving)
+// query. "from"/"users" must appear as real, uncommented tokens.
+func TestLineCommentDoesNotSwallowFollowingTokens(t *testing.T) {
+	src := "select id -- inline\nfrom users;"
+	got, err := Format(bytes.NewReader([]byte(src)))
+	if err != nil {
+		t.Fatalf("Format error: %v", err)
+	}
+	for _, line := range strings.Split(got, "\n") {
+		if idx := strings.Index(line, "--"); idx >= 0 {
+			if strings.Contains(line[idx:], "from") || strings.Contains(line[idx:], "users") {
+				t.Fatalf("comment absorbed following tokens: %q\nfull output:\n%s", line, got)
+			}
+		}
+	}
+	if !strings.Contains(got, "from users") {
+		t.Errorf("from/users clause missing from output entirely:\n%s", got)
+	}
+}
+
+func TestHeaderCommentPreserved(t *testing.T) {
+	src := "-- a header comment\nselect id from users;"
+	got, err := Format(bytes.NewReader([]byte(src)))
+	if err != nil {
+		t.Fatalf("Format error: %v", err)
+	}
+	if !strings.HasPrefix(got, "-- a header comment\n") {
+		t.Errorf("header comment not preserved as the first line, got:\n%s", got)
+	}
+}
+
+func TestTrailingCommentPreserved(t *testing.T) {
+	src := "select id from users; -- note"
+	got, err := Format(bytes.NewReader([]byte(src)))
+	if err != nil {
+		t.Fatalf("Format error: %v", err)
+	}
+	if !strings.Contains(got, "-- note") {
+		t.Errorf("trailing comment not preserved, got:\n%s", got)
+	}
+}
+
+func TestBlockCommentPreservedAndReformatted(t *testing.T) {
+	src := "/* a block comment */\nselect id from users;"
+	got, err := Format(bytes.NewReader([]byte(src)))
+	if err != nil {
+		t.Fatalf("Format error: %v", err)
+	}
+	want := "/*\n * a block comment\n */\nselect id from users;\n"
+	if got != want {
+		t.Errorf("got:\n%q\nwant:\n%q", got, want)
+	}
+}
+
+// TestFormatIsIdempotentWithComments guards against a real bug found during
+// development: a leading comment attached to a clause KEYWORD's own token
+// (which is what a second formatting pass produces -- by then the comment
+// already sits on its own line directly before "from" rather than before
+// the first token of its body) must still be found and rendered, not
+// silently dropped, or Format(Format(x)) != Format(x).
+func TestFormatIsIdempotentWithComments(t *testing.T) {
+	cases := []string{
+		"-- header\nselect id from users;",
+		"select id, name -- trailing\n  from users;",
+		"select id\n  /* a block comment about the from clause */\n  from users;",
+		"select id from users; -- trailing on the statement",
+	}
+	for _, src := range cases {
+		once, err := Format(bytes.NewReader([]byte(src)))
+		if err != nil {
+			t.Fatalf("Format(%q) error: %v", src, err)
+		}
+		twice, err := Format(bytes.NewReader([]byte(once)))
+		if err != nil {
+			t.Fatalf("Format(Format(%q)) error: %v", src, err)
+		}
+		if once != twice {
+			t.Errorf("not idempotent for %q:\n--- once ---\n%s\n--- twice ---\n%s", src, once, twice)
+		}
+	}
+}

--- a/format/comments_test.go
+++ b/format/comments_test.go
@@ -1,0 +1,138 @@
+package format
+
+import (
+	"strings"
+	"testing"
+)
+
+func lineComment(text string, leadingBlank bool) Token {
+	return Token{Kind: TokLineComment, Text: text, Lower: text, LeadingBlank: leadingBlank}
+}
+
+func TestFormatLineCommentReflow(t *testing.T) {
+	long := "-- " + strings.Repeat("word ", 30)
+	got := formatLineComment(lineComment(long, false), 2)
+	for _, l := range got {
+		if len(l) > commentWidth {
+			t.Errorf("line exceeds %d cols (%d): %q", commentWidth, len(l), l)
+		}
+		if !strings.HasPrefix(l, "  -- ") {
+			t.Errorf("line missing indent+prefix: %q", l)
+		}
+	}
+	if len(got) < 2 {
+		t.Fatalf("expected reflow to produce multiple lines, got %d: %v", len(got), got)
+	}
+}
+
+func TestFormatLineCommentDashDivider(t *testing.T) {
+	got := formatLineComment(lineComment("-----------", false), 2)
+	if len(got) != 1 || got[0] != "  -----------" {
+		t.Fatalf("dash divider should be preserved verbatim, got %v", got)
+	}
+}
+
+func TestFormatLineCommentEmpty(t *testing.T) {
+	got := formatLineComment(lineComment("--", false), 0)
+	if len(got) != 1 || got[0] != "--" {
+		t.Fatalf("empty comment should render as bare --, got %v", got)
+	}
+}
+
+func TestRenderLeadingCommentsBlankLineParagraphBreak(t *testing.T) {
+	comments := []Token{
+		lineComment("-- first paragraph", false),
+		lineComment("-- second paragraph", true), // blank source line before it
+	}
+	got := renderLeadingComments(comments, 0)
+	want := []string{"-- first paragraph", "", "-- second paragraph"}
+	if len(got) != len(want) {
+		t.Fatalf("got %v, want %v", got, want)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Errorf("line %d: got %q want %q", i, got[i], want[i])
+		}
+	}
+}
+
+func TestFormatBlockCommentCStyle(t *testing.T) {
+	c := Token{Kind: TokBlockComment, Text: "/* one two three */"}
+	got := formatBlockComment(c, 2)
+	want := []string{
+		"  /*",
+		"   * one two three",
+		"   */",
+	}
+	if len(got) != len(want) {
+		t.Fatalf("got %v, want %v", got, want)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Errorf("line %d: got %q want %q", i, got[i], want[i])
+		}
+	}
+	// star alignment: "/*"'s '*' and content lines' '*' must share a column.
+	starCol := strings.IndexByte(got[0], '*')
+	for _, l := range got[1:] {
+		if strings.IndexByte(l, '*') != starCol {
+			t.Errorf("star misaligned in %q (want col %d)", l, starCol)
+		}
+	}
+}
+
+func TestFormatBlockCommentReflowAndParagraphs(t *testing.T) {
+	c := Token{Kind: TokBlockComment, Text: "/*\n * " + strings.Repeat("word ", 30) + "\n *\n * second paragraph\n */"}
+	got := formatBlockComment(c, 0)
+	if got[0] != "/*" || got[len(got)-1] != " */" {
+		t.Fatalf("first/last line must contain only comment markers, got first=%q last=%q", got[0], got[len(got)-1])
+	}
+	for _, l := range got[1 : len(got)-1] {
+		if l != "" && !strings.HasPrefix(l, " * ") {
+			t.Errorf("content line missing ' * ' prefix: %q", l)
+		}
+		if len(l) > commentWidth {
+			t.Errorf("line exceeds %d cols: %q", commentWidth, l)
+		}
+	}
+	found := false
+	for _, l := range got {
+		if l == "" {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("expected a blank line between paragraphs, got %v", got)
+	}
+}
+
+func TestAlignTrailingComments(t *testing.T) {
+	text := "where a = 1" + commentMarker + "-- short\n" +
+		"  and b = 22" + commentMarker + "-- also short\n"
+	got := alignTrailingComments(text)
+	lines := strings.Split(strings.TrimRight(got, "\n"), "\n")
+	if len(lines) != 2 {
+		t.Fatalf("got %v", lines)
+	}
+	col1 := strings.Index(lines[0], "--")
+	col2 := strings.Index(lines[1], "--")
+	if col1 != col2 {
+		t.Errorf("trailing comments not aligned: %q vs %q", lines[0], lines[1])
+	}
+	if strings.Contains(got, commentMarker) {
+		t.Errorf("marker not fully stripped: %q", got)
+	}
+}
+
+func TestAlignTrailingCommentsBreaksAtNonCommentLine(t *testing.T) {
+	text := "a" + commentMarker + "-- c1\n" +
+		"gap line with no comment\n" +
+		"bb" + commentMarker + "-- c2\n"
+	got := alignTrailingComments(text)
+	lines := strings.Split(strings.TrimRight(got, "\n"), "\n")
+	col1 := strings.Index(lines[0], "--")
+	col2 := strings.Index(lines[2], "--")
+	if col1 == col2 {
+		t.Errorf("non-contiguous comment lines should NOT share a column: %q vs %q", lines[0], lines[2])
+	}
+}

--- a/format/format.go
+++ b/format/format.go
@@ -17,16 +17,21 @@ func Format(r io.Reader) (string, error) {
 	if err != nil {
 		return "", fmt.Errorf("sqlfmt: %w", err)
 	}
+	toks, eofComments := attachComments(toks)
 
 	stmts := splitStatements(toks)
 	var out []string
 	for _, s := range stmts {
 		out = append(out, formatStatement(s))
 	}
+	if trailing := renderLeadingComments(eofComments, 0); len(trailing) > 0 {
+		out = append(out, strings.Join(trailing, "\n"))
+	}
 	if len(out) == 0 {
 		return "", nil
 	}
-	return strings.Join(out, "\n\n") + "\n", nil
+	result := strings.Join(out, "\n\n") + "\n"
+	return alignTrailingComments(result), nil
 }
 
 // splitStatements splits the token stream on top-level ";" tokens. Each
@@ -91,6 +96,15 @@ func formatStatement(toks []Token) string {
 		return ""
 	}
 
+	var leading []string
+	if len(toks[0].Comments) > 0 {
+		leading = renderLeadingComments(toks[0].Comments, 0)
+		toks[0].Comments = nil
+	}
+	if len(leading) > 0 {
+		return strings.Join(leading, "\n") + "\n" + formatStatement(toks)
+	}
+
 	// A leading psql meta-command (e.g. "\copy ... from ... with csv") is
 	// only ever a prefix line, never the whole statement -- whatever
 	// tokens follow it are a real SQL statement in their own right and
@@ -125,6 +139,11 @@ func formatStatement(toks []Token) string {
 	out := strings.Join(lines, "\n")
 	if hasSemi {
 		out += ";"
+		if tc := toks[len(toks)-1].TrailingComment; tc != nil {
+			out += commentMarker + trailingCommentText(tc)
+		}
+	} else if tc := toks[len(toks)-1].TrailingComment; tc != nil {
+		out += commentMarker + trailingCommentText(tc)
 	}
 	return out
 }

--- a/format/layout.go
+++ b/format/layout.go
@@ -31,6 +31,13 @@ var clauseWords = []struct {
 type clauseSeg struct {
 	name string
 	body []Token
+	// kwTok is the clause keyword's own first token (e.g. "from", "group"
+	// for "group by"). Kept around solely so a comment attached to it --
+	// which happens whenever a leading comment sits on its own line(s)
+	// directly before the keyword, rather than before the first token of
+	// its body -- isn't silently unreachable; body alone doesn't cover
+	// that position.
+	kwTok Token
 }
 
 // isNonLayout reports whether a token carries no layout weight of its own
@@ -156,7 +163,7 @@ func splitClauses(toks []Token) []clauseSeg {
 		if bi+1 < len(bounds) {
 			end = bounds[bi+1].idx
 		}
-		segs = append(segs, clauseSeg{name: b.name, body: toks[b.kwEnd:end]})
+		segs = append(segs, clauseSeg{name: b.name, body: toks[b.kwEnd:end], kwTok: toks[b.idx]})
 	}
 	return segs
 }
@@ -234,7 +241,9 @@ func maxJoinPhraseLen(fromBody []Token) int {
 		if len(seg) == 0 {
 			continue
 		}
-		if n := len(flatJoin(seg[:joinKeywordEnd(seg)])); n > max {
+		// plainJoin: measurement only, see fitsInline's comment on why not
+		// flatJoin.
+		if n := len(plainJoin(seg[:joinKeywordEnd(seg)])); n > max {
 			max = n
 		}
 	}
@@ -344,6 +353,31 @@ func renderRun(toks []Token, col int) []string {
 			continue
 		}
 
+		// Safety net: a token whose leading comment wasn't already
+		// consumed by an outer per-item wrapper (layoutCommaList,
+		// layoutPredicateList, ...) -- because it's buried inside a
+		// sub-expression those don't look inside, e.g. a function-call
+		// argument -- still needs somewhere safe to go, rather than being
+		// silently dropped (the previous behavior) or glued onto whatever
+		// text precedes it on the current line. Not attempting precise
+		// fidelity here (this path is rare); just guaranteed-safe: each
+		// leading comment on its own line, at whatever column the current
+		// line is already at.
+		if len(toks[i].Comments) > 0 {
+			indent := curCol
+			lead := renderLeadingComments(toks[i].Comments, indent)
+			toks[i].Comments = nil
+			if strings.TrimSpace(lines[len(lines)-1]) == "" {
+				lines[len(lines)-1] = lead[0]
+				lead = lead[1:]
+			}
+			lines = append(lines, lead...)
+			lines = append(lines, strings.Repeat(" ", indent))
+			curCol = indent
+			prev = nil
+		}
+		t = toks[i]
+
 		if t.Kind == TokKeyword && t.Lower == "case" {
 			end := matchCaseEnd(toks, i)
 			if prev != nil && spaceBetween(*prev, t) {
@@ -432,6 +466,17 @@ func renderRun(toks []Token, col int) []string {
 			write(" ")
 		}
 		write(renderTokenText(t))
+		// Safety net, mirroring the leading-comment one above: a trailing
+		// comment not already consumed by an outer per-item wrapper still
+		// forces a line break here (a "--" comment silently absorbing
+		// whatever token would otherwise follow it on the same line is
+		// exactly the corruption bug this whole mechanism exists to avoid).
+		if toks[i].TrailingComment != nil {
+			write(commentMarker + trailingCommentText(toks[i].TrailingComment))
+			toks[i].TrailingComment = nil
+			lines = append(lines, "")
+			curCol = 0
+		}
 		prev = &toks[i]
 		i++
 	}
@@ -598,13 +643,25 @@ func layoutOver(toks []Token, overCol int) []string {
 // previous line.
 func layoutCommaList(toks []Token, startCol int) []string {
 	items := splitTopLevelComma(trimTokens(toks))
-	flat := flatJoin(trimTokens(toks))
-	if startCol+len(flat) <= targetWidth && len(items) > 0 {
-		return []string{flat}
+	// Comment check first, and short-circuits before flatJoin ever runs:
+	// flatJoin's underlying renderRun call consumes/clears any comment
+	// metadata on these tokens as a side effect, which the multi-line path
+	// below still needs intact if this fast path doesn't end up taking it.
+	if len(items) > 0 && !anyItemComments(items) {
+		if flat := flatJoin(trimTokens(toks)); startCol+len(flat) <= targetWidth {
+			return []string{flat}
+		}
 	}
 	var lines []string
 	for idx, it := range items {
 		it = trimTokens(it)
+		// Cleared before renderRun runs, not after: renderRun has its own
+		// safety-net handling for a token whose comment metadata is still
+		// set (for tokens no per-item wrapper reaches), and calling it
+		// after would make that safety net fire redundantly on the very
+		// comment this loop is about to render properly itself.
+		lead := leadingCommentLines(it, startCol)
+		trailing := trailingCommentSuffix(it)
 		itLines := renderRun(it, startCol)
 		if idx < len(items)-1 {
 			// The separating comma belongs on the item's own last rendered
@@ -613,14 +670,81 @@ func layoutCommaList(toks []Token, startCol int) []string {
 			// lines by this point.
 			itLines[len(itLines)-1] += ","
 		}
+		itLines[len(itLines)-1] += trailing
 		if idx == 0 {
+			lines = append(lines, lead...)
 			lines = append(lines, itLines[0])
 		} else {
+			lines = append(lines, lead...)
 			lines = append(lines, strings.Repeat(" ", startCol)+itLines[0])
 		}
 		lines = append(lines, itLines[1:]...)
 	}
 	return lines
+}
+
+// anyTokenComments reports whether any token in toks carries a leading or
+// trailing comment -- used to force a multi-line layout even when a
+// flattened single-line render would otherwise fit, since that fast path
+// has nowhere to put a comment.
+func anyTokenComments(toks []Token) bool {
+	for _, t := range toks {
+		if len(t.Comments) > 0 || t.TrailingComment != nil {
+			return true
+		}
+	}
+	return false
+}
+
+// anyItemComments reports whether any item in a comma/predicate/join list
+// carries a leading or trailing comment -- used to force the multi-line
+// layout even when the flattened form would otherwise fit inline, since the
+// single-line fast path has nowhere to put a comment.
+func anyItemComments(items [][]Token) bool {
+	for _, it := range items {
+		it = trimTokens(it)
+		if len(it) == 0 {
+			continue
+		}
+		if len(it[0].Comments) > 0 || it[len(it)-1].TrailingComment != nil {
+			return true
+		}
+	}
+	return false
+}
+
+// leadingCommentLines renders any leading comments on item's first token as
+// complete lines at indent -- for the caller to splice in before its own
+// prefix+first-content-line composition.
+func leadingCommentLines(item []Token, indent int) []string {
+	item = trimTokens(item)
+	if len(item) == 0 || len(item[0].Comments) == 0 {
+		return nil
+	}
+	lines := renderLeadingComments(item[0].Comments, indent)
+	// Cleared once rendered here, so renderRun's own safety-net handling
+	// (for comments on tokens no per-item wrapper reaches, e.g. deep inside
+	// a function call) never double-renders what this call already emitted.
+	item[0].Comments = nil
+	return lines
+}
+
+// trailingCommentSuffix returns commentMarker+text for item's last token's
+// trailing comment, if any, else "" -- appended to whatever line ends up
+// holding that token; alignTrailingComments pads it later. Clears the field
+// once read, for the same reason leadingCommentLines does.
+func trailingCommentSuffix(item []Token) string {
+	item = trimTokens(item)
+	if len(item) == 0 {
+		return ""
+	}
+	last := &item[len(item)-1]
+	if last.TrailingComment == nil {
+		return ""
+	}
+	text := commentMarker + trailingCommentText(last.TrailingComment)
+	last.TrailingComment = nil
+	return text
 }
 
 func leadingSpaces(s string) int {
@@ -652,11 +776,17 @@ func layoutPredicateList(toks []Token, endCol int) []string {
 	startCol := endCol + 1
 	for idx, p := range preds {
 		p = trimTokens(p)
+		// Cleared before renderRun runs -- see layoutCommaList's identical
+		// ordering concern.
+		lead := leadingCommentLines(p, startCol)
+		trailing := trailingCommentSuffix(p)
+		pLines := renderRun(p, startCol)
+		pLines[len(pLines)-1] += trailing
 		// idx 0's line is appended directly after the clause keyword by the
-		// caller (renderClause), so it carries no prefix of its own here;
-		// only continuation lines get a right-aligned AND/OR prefix.
+		// caller (renderClause, which also strips its leading comment), so
+		// it carries no prefix of its own here; only continuation lines get
+		// a right-aligned AND/OR prefix and their own leading comments.
 		if idx == 0 {
-			pLines := renderRun(p, startCol)
 			lines = append(lines, pLines...)
 			continue
 		}
@@ -665,7 +795,7 @@ func layoutPredicateList(toks []Token, endCol int) []string {
 		if pad < 0 {
 			pad = 0
 		}
-		pLines := renderRun(p, startCol)
+		lines = append(lines, lead...)
 		prefix := strings.Repeat(" ", pad) + kw + " "
 		lines = append(lines, prefix+pLines[0])
 		lines = append(lines, pLines[1:]...)
@@ -705,11 +835,11 @@ func formatQuerySegment(toks []Token, baseIndent int) []string {
 		ctes, rest := parseCTEs(toks)
 		var lines []string
 		for idx, c := range ctes {
-			cteLines := renderCTE(c, baseIndent, idx < len(ctes)-1)
+			prefix := ""
 			if idx == 0 {
-				cteLines[0] = strings.Repeat(" ", baseIndent) + "with " + strings.TrimSpace(cteLines[0])
+				prefix = "with "
 			}
-			lines = append(lines, cteLines...)
+			lines = append(lines, renderCTE(c, baseIndent, idx < len(ctes)-1, prefix)...)
 		}
 		lines = append(lines, formatQuerySegment(rest, baseIndent)...)
 		return lines
@@ -721,7 +851,7 @@ func formatQuerySegment(toks []Token, baseIndent int) []string {
 	}
 	width := riverWidth(segs)
 
-	if fitsInline(segs, baseIndent, width) {
+	if fitsInline(segs, baseIndent, width) && !anyTokenComments(toks) {
 		return []string{flatJoin(toks)}
 	}
 
@@ -747,7 +877,12 @@ func fitsInline(segs []clauseSeg, baseIndent, width int) bool {
 				return false
 			}
 		}
-		total += len(s.name) + 1 + len(flatJoin(trimTokens(s.body))) + 1
+		// plainJoin, not flatJoin: this is a width estimate whose returned
+		// string is discarded, and flatJoin's underlying renderRun call has
+		// a side effect (consuming/clearing any comment metadata on these
+		// tokens) that a later, real render pass over the same tokens
+		// still needs intact.
+		total += len(s.name) + 1 + len(plainJoin(trimTokens(s.body))) + 1
 	}
 	return baseIndent+total <= targetWidth
 }
@@ -758,6 +893,25 @@ func renderClause(s clauseSeg, baseIndent, width int) []string {
 	kwText := strings.Repeat(" ", pad) + s.name
 	bodyCol := baseIndent + width + 1
 	body := trimTokens(s.body)
+
+	// A leading comment on the clause keyword's own token (e.g. it sits on
+	// its own line directly before "from") or on the clause body's very
+	// first token would otherwise get glued onto the "select "/"from "/etc.
+	// keyword line by the concatenation below (bodyLines[0] is assumed to
+	// be real content). Strip and render it separately, at the same column
+	// the body's own content will start at, before that concatenation
+	// happens. Both positions matter: the keyword-token case is what a
+	// second formatting pass over this package's own output produces,
+	// since by then the comment already sits on its own line right before
+	// the keyword rather than before the first body token.
+	var lead []string
+	switch {
+	case len(s.kwTok.Comments) > 0:
+		lead = renderLeadingComments(s.kwTok.Comments, bodyCol)
+	case len(body) > 0 && len(body[0].Comments) > 0:
+		lead = renderLeadingComments(body[0].Comments, bodyCol)
+		body[0].Comments = nil
+	}
 
 	var bodyLines []string
 	switch s.name {
@@ -774,7 +928,7 @@ func renderClause(s clauseSeg, baseIndent, width int) []string {
 	}
 
 	first := strings.Repeat(" ", kwCol) + kwText + " " + bodyLines[0]
-	out := []string{first}
+	out := append(lead, first)
 	out = append(out, bodyLines[1:]...)
 	return out
 }
@@ -794,7 +948,11 @@ func layoutFrom(toks []Token, baseIndent, width int) []string {
 
 	joinCol := baseIndent + width + 1
 	phraseEndCol := joinCol - 1
+	// Cleared before renderRun runs -- see layoutCommaList's identical
+	// ordering concern.
+	firstTrailing := trailingCommentSuffix(segs[0])
 	firstLines := renderRun(trimTokens(segs[0]), joinCol)
+	firstLines[len(firstLines)-1] += firstTrailing
 	out := firstLines
 
 	for _, seg := range segs[1:] {
@@ -802,6 +960,8 @@ func layoutFrom(toks []Token, baseIndent, width int) []string {
 		if len(seg) == 0 {
 			continue
 		}
+		out = append(out, leadingCommentLines(seg, joinCol)...)
+		segTrailing := trailingCommentSuffix(seg)
 		kEnd := joinKeywordEnd(seg)
 		phrase := flatJoin(seg[:kEnd])
 		rest := seg[kEnd:]
@@ -824,7 +984,7 @@ func layoutFrom(toks []Token, baseIndent, width int) []string {
 			phrasePad = 0
 		}
 		if onIdx == -1 {
-			line := strings.Repeat(" ", phrasePad) + phrase + " " + flatJoin(rest)
+			line := strings.Repeat(" ", phrasePad) + phrase + " " + flatJoin(rest) + segTrailing
 			out = append(out, line)
 			continue
 		}
@@ -833,7 +993,7 @@ func layoutFrom(toks []Token, baseIndent, width int) []string {
 		preds, ops := splitAndOr(condPart)
 		if len(preds) == 1 {
 			// Single-condition ON stays inline after the join keyword phrase.
-			line := strings.Repeat(" ", phrasePad) + phrase + " " + flatJoin(tablePart) + " on " + flatJoin(preds[0])
+			line := strings.Repeat(" ", phrasePad) + phrase + " " + flatJoin(tablePart) + " on " + flatJoin(preds[0]) + segTrailing
 			out = append(out, line)
 			continue
 		}
@@ -851,6 +1011,9 @@ func layoutFrom(toks []Token, baseIndent, width int) []string {
 				pad = 0
 			}
 			pLines := renderRun(trimTokens(p), phraseEndCol+1)
+			if idx == len(preds)-1 {
+				pLines[len(pLines)-1] += segTrailing
+			}
 			out = append(out, strings.Repeat(" ", pad)+kw+" "+pLines[0])
 			out = append(out, pLines[1:]...)
 		}
@@ -897,8 +1060,14 @@ func parseCTEs(toks []Token) ([][]Token, []Token) {
 	return ctes, toks[i:]
 }
 
-func renderCTE(cte []Token, baseIndent int, more bool) []string {
-	name := renderTokenText(cte[0])
+// renderCTE renders one "name [(cols)] as ( body )" CTE entry. withPrefix,
+// when non-empty ("with "), is prepended to the CTE's own "name as (" line
+// -- never to a leading comment line that might precede it -- since only
+// the first CTE in a WITH prologue carries it.
+func renderCTE(cte []Token, baseIndent int, more bool, withPrefix string) []string {
+	lead := renderLeadingComments(cte[0].Comments, baseIndent)
+	cte[0].Comments = nil
+	name := withPrefix + renderTokenText(cte[0])
 	i := 1
 	// optional output-column list: name(col, ...) as (...)
 	if i < len(cte) && cte[i].Text == "(" {
@@ -916,13 +1085,13 @@ func renderCTE(cte []Token, baseIndent int, more bool) []string {
 		open = i
 	}
 	if open == -1 {
-		return []string{strings.Repeat(" ", baseIndent) + name}
+		return append(lead, strings.Repeat(" ", baseIndent)+name)
 	}
 	close := matchParen(cte, open)
 	inner := cte[open+1 : close]
 	bodyIndent := baseIndent + 2
 	bodyLines := formatQuerySegment(inner, bodyIndent)
-	var lines []string
+	lines := lead
 	lines = append(lines, strings.Repeat(" ", baseIndent)+name+" as (")
 	for _, l := range bodyLines {
 		lines = append(lines, strings.Repeat(" ", bodyIndent)+l)
@@ -931,6 +1100,7 @@ func renderCTE(cte []Token, baseIndent int, more bool) []string {
 	if more {
 		closing += ","
 	}
+	closing += trailingCommentSuffix(cte)
 	lines = append(lines, closing)
 	return lines
 }

--- a/testdata/corpus/application-use-case-04_01_artist.sql
+++ b/testdata/corpus/application-use-case-04_01_artist.sql
@@ -1,3 +1,5 @@
+-- name: top-artists-by-album
+-- Get the list of the N artists with the most albums
      select artist.name, count(*) as albums
        from artist
   left join album using(artist_id)

--- a/testdata/corpus/application-use-case-05_01_album-by-artist.sql
+++ b/testdata/corpus/application-use-case-05_01_album-by-artist.sql
@@ -1,3 +1,5 @@
+-- name: list-albums-by-artist
+-- List the album titles and duration of a given artist
      select album.title as album,
             sum(milliseconds) * interval '1 ms' as duration
        from album

--- a/testdata/corpus/pub-names-knn-05_01_pubnames.svg.knn.sql
+++ b/testdata/corpus/pub-names-knn-05_01_pubnames.svg.knn.sql
@@ -1,3 +1,6 @@
+-- The 10 nearest pubs to Holborn (03_01, extended to limit 10) rendered as a
+-- single <svg> document: OSM streets from osm_london.roads for context, the
+-- search point in red, the nearest pubs in blue with their names.
 with search as (
   select point(- 0.12, 51.516) as pt
 ),

--- a/testdata/corpus/sql-103-05_04_hydrorivers.mainstem.sql
+++ b/testdata/corpus/sql-103-05_04_hydrorivers.mainstem.sql
@@ -1,4 +1,7 @@
+-- Loire main channels: flat query on stream order.
+-- Seed for the manual ring-by-ring approach that leads to WITH RECURSIVE.
+-- 155 reaches: the trunk and its biggest branches.
 select hyriv_id, geom, ord_stra
   from hydrorivers.rivers
- where main_riv = 20446779
-   and ord_stra >= 6;
+ where main_riv = 20446779  -- the Loire basin
+   and ord_stra >= 6;       -- trunk and major tributaries only

--- a/testdata/corpus/sql-103-05_07_hydrorivers.recursive.sql
+++ b/testdata/corpus/sql-103-05_07_hydrorivers.recursive.sql
@@ -1,8 +1,14 @@
+-- Loire: full basin via WITH RECURSIVE (6,297 reaches).
+-- Automates the ring-by-ring approach indefinitely.
 with loire as (
-    select hyriv_id, geom, ord_stra
+    select hyriv_id,
+           geom,
+           ord_stra  -- base case: the outlet
       from hydrorivers.rivers
      where hyriv_id = 20446779 union all
-    select r.hyriv_id, r.geom, r.ord_stra
+    select r.hyriv_id,
+           r.geom,
+           r.ord_stra  -- recursive term: one step upstream
       from hydrorivers.rivers as r
       join loire on r.next_down = loire.hyriv_id
 )

--- a/testdata/corpus/usecase-07_01.sql
+++ b/testdata/corpus/usecase-07_01.sql
@@ -4,6 +4,11 @@
             coalesce(shares, 0) as shares,
             coalesce(trades, 0) as trades,
             to_char(coalesce(dollars, 0), 'L99G999G999G999') as dollars
+            /*
+             * Generate the target month's calendar then LEFT JOIN each day
+             * against the factbook dataset, so as to have every day in the
+             * result set, whether or not we have a book entry for the day.
+             */
        from generate_series(date : 'start', date : 'start' + interval '1 month' - interval '1 day', interval '1 day') as calendar(entry)
   left join factbook on factbook.date = calendar.entry
    order by date;


### PR DESCRIPTION
## Summary

Comments were being silently dropped instead of conserved and formatted. `attachComments` was scaffolded (the `Token` struct already had `Comments`/`TrailingComment` fields) but never implemented — raw comment tokens were left in the stream and echoed inline wherever encountered, which for a `--` comment not at the end of a statement is a real correctness bug, not just cosmetic:

```
select id -- inline        select id -- inline from users;
from users;           ->   (from/users silently absorbed into the
                             comment text -- a different query)
```

## Changes

- **`format/comments.go`** (new):
  - `attachComments`: one pass over the lexed token stream that removes every comment token and re-expresses it as metadata on a neighboring real token — `TrailingComment` if on the same source line as preceding code, else a leading `Comments` entry on the next real token. The rest of the engine never sees a raw comment token again.
  - Line comments reflow to 80 columns; blank source lines and dash-only divider lines (`-----------`) are preserved verbatim, not merged into prose.
  - Block comments are rewritten into the C style — opening `/*`-only line, each content line's `*` aligned under `/*`'s own second character, closing `*/`-only line aligned the same way — regardless of the original's formatting.
  - `alignTrailingComments`: pads every trailing comment in a maximal contiguous run of comment-bearing lines to a shared column (STYLE.md rule 18).

- **`format/layout.go`, `format/format.go`**: wire `attachComments` into `Format`, and consume the resulting metadata at every place a statement/clause/item starts or ends a line, plus a safety net in `renderRun`'s own token loop for anything not covered elsewhere (e.g. a comment inside a function-call argument) — always forcing a line break rather than letting a `--` comment merge with what follows.

  Two supporting bugs fixed along the way:
  - `clauseSeg` only kept a clause's name (string), never its actual keyword token — so a comment attached to that token (which is what a second formatting pass over this tool's own output produces) was unreachable. Added `clauseSeg.kwTok`.
  - Several call sites (`fitsInline`, `layoutCommaList`'s inline-fits check, `maxJoinPhraseLen`) called `flatJoin` purely to measure a string's length and discard it — but `flatJoin`'s underlying `renderRun` now has a side effect (consuming comment metadata as part of rendering). A measurement-only call running before the real render pass was silently eating the comment. Switched those to the existing side-effect-free `plainJoin`, and reordered `layoutCommaList` so its comment-presence check runs before `flatJoin` at all.

- **`format/comments_test.go`**: unit tests for the reflow/divider/paragraph-break/C-style-rewrap/alignment primitives.
- **`format/comments_integration_test.go`**: end-to-end tests via `Format()` — the exact reported corruption case, header/trailing/block comment preservation, idempotency with comments present.
- **`testdata/corpus/*.sql`**: restored original comments to the 6 fixtures that had them in the book source (dropped during an earlier corpus-regeneration pass, before comment support existed), regenerated through the now-comment-aware formatter.
- **`STYLE.md`** rule 18: rewritten to document the actually-implemented behavior.

## Known follow-ups (unrelated, pre-existing, out of scope here)

Found while testing against real corpus files with comments:
- `<->` (PostGIS distance operator) lexes as two separate operators instead of one.
- Unary minus gets a stray space (`- 0.12` instead of `-0.12`).
- `UNION`/`INTERSECT`/`EXCEPT` aren't recognized as their own clause boundary, so `union all` between two `SELECT`s in a recursive CTE glues onto the end of the first `SELECT`'s `WHERE` clause.
- Two corpus fixtures (unrelated to comments) aren't idempotent: `hstore-04_01_artists.update.hstore.sql`, `non-relational-types-01_01_tweets.sql`.

## Test plan

- `go build ./...`, `go vet ./...`, `gofmt -l .`, `make test`, `make wasm-test` all clean.
- New regression tests verified to fail against the pre-fix code (temporarily swapped `format.go`/`layout.go` back to `main` while keeping the new tests) before trusting them.
- Manually verified against 6 real corpus files with header comments, trailing-aligned comments, and a multi-line block comment inside a `FROM` clause.