### PR TITLE
Fix <-> lexing, unary minus spacing, and UNION/INTERSECT/EXCEPT splitting

### DIFF
--- a/format/layout.go
+++ b/format/layout.go
@@ -104,6 +104,56 @@ func splitTopLevel(toks []Token, sep string) [][]Token {
 	return segs
 }
 
+// splitUnionSegments splits toks on every top-level UNION/UNION ALL/
+// INTERSECT/EXCEPT, returning each query segment and, between consecutive
+// segments, the operator text that joins them ("union", "union all",
+// "intersect", "except"). Each segment is independently formatted (its own
+// select/from/where/... clauses, its own river-alignment width) by the
+// caller, since combining two SELECTs' clause lists into one shared width
+// the way a single query's own clauses are would be meaningless -- they're
+// not the same query.
+func splitUnionSegments(toks []Token) (segs [][]Token, ops []string) {
+	depth := 0
+	start := 0
+	for i := 0; i < len(toks); i++ {
+		t := toks[i]
+		if t.Text == "(" {
+			depth++
+			continue
+		}
+		if t.Text == ")" {
+			depth--
+			continue
+		}
+		if depth != 0 || t.Kind != TokKeyword {
+			continue
+		}
+		switch t.Lower {
+		case "union":
+			end := i + 1
+			op := "union"
+			if end < len(toks) && toks[end].Kind == TokKeyword && toks[end].Lower == "all" {
+				op = "union all"
+				end++
+			}
+			segs = append(segs, toks[start:i])
+			ops = append(ops, op)
+			start = end
+			i = end - 1
+		case "intersect":
+			segs = append(segs, toks[start:i])
+			ops = append(ops, "intersect")
+			start = i + 1
+		case "except":
+			segs = append(segs, toks[start:i])
+			ops = append(ops, "except")
+			start = i + 1
+		}
+	}
+	segs = append(segs, toks[start:])
+	return segs, ops
+}
+
 // splitTopLevelComma splits a top-level comma-separated list.
 func splitTopLevelComma(toks []Token) [][]Token {
 	var segs [][]Token
@@ -283,7 +333,16 @@ func renderTokenText(t Token) string {
 // spaceBetween decides whether a space belongs between two adjacent
 // rendered tokens (STYLE.md rules 4 and 5: no space around "." or "::", no
 // space before "," "(" ")" ";" "]", no space after "(" "[").
-func spaceBetween(prev, next Token) bool {
+// spaceBetween decides whether a space belongs between prev and next as
+// they're rendered in sequence. prevPrev -- the token before prev, or nil
+// at the start of a run -- exists solely to tell a unary "-"/"+" (no space
+// before its operand: "-0.12", not "- 0.12") apart from the binary
+// operator (a space on both sides: "a - b"): prev alone can't distinguish
+// them, since "-"/"+" render identically as tokens either way.
+func spaceBetween(prevPrev *Token, prev, next Token) bool {
+	if (prev.Text == "-" || prev.Text == "+") && isUnaryContext(prevPrev) {
+		return false
+	}
 	if prev.Text == "(" || prev.Text == "[" {
 		return false
 	}
@@ -308,6 +367,30 @@ func spaceBetween(prev, next Token) bool {
 			return false
 		}
 		return true
+	}
+	if next.Text == "[" {
+		// array subscript/slice ("arr[1]", "(pos)[0]"): never a space
+		// before "[" regardless of what precedes it.
+		return false
+	}
+	return true
+}
+
+// isUnaryContext reports whether a "-"/"+" immediately following prevPrev
+// (nil at the very start of a run) is acting as a unary sign rather than a
+// binary operator: true unless prevPrev is a token that just completed a
+// value (an identifier, literal, or closing ")"/"]"), in which case "-"/"+"
+// is subtracting/adding from it.
+func isUnaryContext(prevPrev *Token) bool {
+	if prevPrev == nil {
+		return true
+	}
+	switch prevPrev.Kind {
+	case TokIdent, TokNumber, TokString, TokDollarString, TokParam:
+		return false
+	}
+	if prevPrev.Text == ")" || prevPrev.Text == "]" {
+		return false
 	}
 	return true
 }
@@ -339,7 +422,7 @@ func renderRun(toks []Token, col int) []string {
 		}
 	}
 
-	var prev *Token
+	var prev, prevPrev *Token
 	i := 0
 	for i < len(toks) {
 		t := toks[i]
@@ -348,7 +431,7 @@ func renderRun(toks []Token, col int) []string {
 				write(" ")
 			}
 			write(t.Text)
-			prev = &toks[i]
+			prevPrev, prev = prev, &toks[i]
 			i++
 			continue
 		}
@@ -380,11 +463,11 @@ func renderRun(toks []Token, col int) []string {
 
 		if t.Kind == TokKeyword && t.Lower == "case" {
 			end := matchCaseEnd(toks, i)
-			if prev != nil && spaceBetween(*prev, t) {
+			if prev != nil && spaceBetween(prevPrev, *prev, t) {
 				write(" ")
 			}
 			merge(layoutCase(toks[i:end+1], curCol))
-			prev = &toks[end]
+			prevPrev, prev = prev, &toks[end]
 			i = end + 1
 			continue
 		}
@@ -392,7 +475,7 @@ func renderRun(toks []Token, col int) []string {
 		if t.Kind == TokKeyword && t.Lower == "over" && i+1 < len(toks) && toks[i+1].Text == "(" {
 			close := matchParen(toks, i+1)
 			overToks := toks[i : close+1]
-			if prev != nil && spaceBetween(*prev, t) {
+			if prev != nil && spaceBetween(prevPrev, *prev, t) {
 				write(" ")
 			}
 			flat := plainJoin(overToks)
@@ -401,7 +484,7 @@ func renderRun(toks []Token, col int) []string {
 			} else {
 				merge(layoutOver(overToks, curCol))
 			}
-			prev = &toks[close]
+			prevPrev, prev = prev, &toks[close]
 			i = close + 1
 			continue
 		}
@@ -409,7 +492,7 @@ func renderRun(toks []Token, col int) []string {
 		if t.Text == "(" {
 			close := matchParen(toks, i)
 			inner := toks[i+1 : close]
-			needSpace := prev != nil && spaceBetween(*prev, t)
+			needSpace := prev != nil && spaceBetween(prevPrev, *prev, t)
 			isSubquery := len(inner) > 0 && inner[0].Kind == TokKeyword && (inner[0].Lower == "select" || inner[0].Lower == "with")
 			if needSpace {
 				write(" ")
@@ -457,12 +540,12 @@ func renderRun(toks []Token, col int) []string {
 					write(")")
 				}
 			}
-			prev = &toks[close]
+			prevPrev, prev = prev, &toks[close]
 			i = close + 1
 			continue
 		}
 
-		if prev != nil && spaceBetween(*prev, t) {
+		if prev != nil && spaceBetween(prevPrev, *prev, t) {
 			write(" ")
 		}
 		write(renderTokenText(t))
@@ -477,7 +560,7 @@ func renderRun(toks []Token, col int) []string {
 			lines = append(lines, "")
 			curCol = 0
 		}
-		prev = &toks[i]
+		prevPrev, prev = prev, &toks[i]
 		i++
 	}
 	return lines
@@ -497,17 +580,17 @@ func flatJoin(toks []Token) string {
 // flatJoin, which would recreate the construct it's trying to measure.
 func plainJoin(toks []Token) string {
 	var sb strings.Builder
-	var prev *Token
+	var prev, prevPrev *Token
 	for i := range toks {
 		t := toks[i]
 		if isNonLayout(t) {
 			continue
 		}
-		if prev != nil && spaceBetween(*prev, t) {
+		if prev != nil && spaceBetween(prevPrev, *prev, t) {
 			sb.WriteByte(' ')
 		}
 		sb.WriteString(renderTokenText(t))
-		prev = &toks[i]
+		prevPrev, prev = prev, &toks[i]
 	}
 	return sb.String()
 }
@@ -832,16 +915,31 @@ func splitAndOr(toks []Token) ([][]Token, []string) {
 func formatQuerySegment(toks []Token, baseIndent int) []string {
 	toks = trimTokens(toks)
 	if len(toks) > 0 && toks[0].Kind == TokKeyword && toks[0].Lower == "with" {
+		withPrefix := "with "
+		if len(toks) > 1 && toks[1].Kind == TokKeyword && toks[1].Lower == "recursive" {
+			withPrefix = "with recursive "
+		}
 		ctes, rest := parseCTEs(toks)
 		var lines []string
 		for idx, c := range ctes {
 			prefix := ""
 			if idx == 0 {
-				prefix = "with "
+				prefix = withPrefix
 			}
 			lines = append(lines, renderCTE(c, baseIndent, idx < len(ctes)-1, prefix)...)
 		}
 		lines = append(lines, formatQuerySegment(rest, baseIndent)...)
+		return lines
+	}
+
+	if usegs, uops := splitUnionSegments(toks); len(usegs) > 1 {
+		var lines []string
+		for idx, seg := range usegs {
+			lines = append(lines, formatQuerySegment(seg, baseIndent)...)
+			if idx < len(uops) {
+				lines = append(lines, strings.Repeat(" ", baseIndent)+uops[idx])
+			}
+		}
 		return lines
 	}
 

--- a/format/layout_gaps_test.go
+++ b/format/layout_gaps_test.go
@@ -1,0 +1,118 @@
+package format
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+)
+
+func formatOK(t *testing.T, src string) string {
+	t.Helper()
+	got, err := Format(bytes.NewReader([]byte(src)))
+	if err != nil {
+		t.Fatalf("Format(%q) error: %v", src, err)
+	}
+	return got
+}
+
+// TestUnaryMinusNoSpace is a regression test for a real bug: unary minus
+// was getting a stray space ("point(- 0.12, ...)" instead of
+// "point(-0.12, ...)") because spaceBetween couldn't distinguish a unary
+// sign from a binary operator using only the immediately adjacent token.
+func TestUnaryMinusNoSpace(t *testing.T) {
+	cases := []struct {
+		src  string
+		want string
+	}{
+		{"select -1;", "select -1;\n"},
+		{"select (-1);", "select (-1);\n"},
+		{"select point(-0.12, 51.516);", "select point(-0.12, 51.516);\n"},
+		{"select f(-1, -2);", "select f(-1, -2);\n"},
+		{"select case when x then -1 else -2 end;", "select case when x then -1 else -2 end;\n"},
+	}
+	for _, c := range cases {
+		got := formatOK(t, c.src)
+		if got != c.want {
+			t.Errorf("Format(%q) = %q, want %q", c.src, got, c.want)
+		}
+	}
+}
+
+// TestBinaryMinusHasSpace guards the other side of the same fix: a real
+// subtraction must still get a space on both sides, not collapse into
+// unary-style tight spacing just because the fix above exists.
+func TestBinaryMinusHasSpace(t *testing.T) {
+	cases := []struct {
+		src  string
+		want string
+	}{
+		{"select a-b;", "select a - b;\n"},
+		{"select 1-2;", "select 1 - 2;\n"},
+		{"select -1 - -2;", "select -1 - -2;\n"}, // unary, binary, unary
+	}
+	for _, c := range cases {
+		got := formatOK(t, c.src)
+		if got != c.want {
+			t.Errorf("Format(%q) = %q, want %q", c.src, got, c.want)
+		}
+	}
+}
+
+// TestArraySubscriptNoSpace is a regression test for a bug found in the
+// same corpus file as the unary-minus one: no space belongs before "["
+// regardless of what precedes it ("(pos)[0]", "arr[1]").
+func TestArraySubscriptNoSpace(t *testing.T) {
+	got := formatOK(t, "select (pos)[0], arr[1];")
+	want := "select (pos)[0], arr[1];\n"
+	if got != want {
+		t.Errorf("got %q, want %q", got, want)
+	}
+}
+
+// TestUnionAllStartsOwnLine is a regression test for a real bug: UNION/
+// UNION ALL/INTERSECT/EXCEPT weren't recognized as clause boundaries, so
+// e.g. "union all" between two SELECTs got glued onto the end of the first
+// SELECT's WHERE clause body instead of starting its own line.
+func TestUnionAllStartsOwnLine(t *testing.T) {
+	src := "select a from t where x = 1 union all select b from t2;"
+	got := formatOK(t, src)
+	lines := strings.Split(strings.TrimRight(got, "\n"), "\n")
+	found := false
+	for _, l := range lines {
+		if strings.TrimSpace(l) == "union all" {
+			found = true
+		}
+		if strings.Contains(l, "union all") && strings.TrimSpace(l) != "union all" {
+			t.Fatalf("\"union all\" glued onto another line instead of starting its own: %q\nfull output:\n%s", l, got)
+		}
+	}
+	if !found {
+		t.Fatalf("no standalone \"union all\" line found in output:\n%s", got)
+	}
+}
+
+// TestWithRecursivePreserved is a regression test for a real bug: parseCTEs
+// consumed the "recursive" keyword to skip past it but never re-emitted it
+// anywhere, so "with recursive" silently became "with" -- a correctness
+// bug (dropping RECURSIVE changes what the query does), not just cosmetic.
+func TestWithRecursivePreserved(t *testing.T) {
+	src := "with recursive t as (select 1 union all select n+1 from t where n < 10) select * from t;"
+	got := formatOK(t, src)
+	if !strings.HasPrefix(strings.TrimLeft(got, " "), "with recursive ") {
+		t.Errorf("\"with recursive\" not preserved, got:\n%s", got)
+	}
+}
+
+// TestUnionSegmentsIndependentlyFormatted checks that each side of a UNION
+// is formatted (and rendered) without erroring, with "union all" as its own
+// standalone line between them -- each SELECT gets its own independent
+// river-alignment width, rather than the two SELECTs' clause lists being
+// merged into one shared computation the way a single query's own clauses
+// are (they're not the same query).
+func TestUnionSegmentsIndependentlyFormatted(t *testing.T) {
+	src := "select short from t1 union all select much_longer_column_name from t2;"
+	got := formatOK(t, src)
+	if !strings.Contains(got, "\nunion all\n") {
+		t.Errorf("expected a standalone \"union all\" line, got:\n%s", got)
+	}
+}

--- a/format/lexer.go
+++ b/format/lexer.go
@@ -78,9 +78,40 @@ func buildKeywordSet(words []string) map[string]bool {
 }
 
 // multiCharOperators lists operator lexemes longer than one character, tried
-// longest-first at each scan position.
+// longest-first at each scan position -- ordering strictly by length (not
+// just alphabetically) matters: e.g. "#>>" must be tried before "#>", or
+// the latter would match its first two characters and leave a stray ">"
+// behind.
+//
+// This set is every multi-character operator name registered in
+// PostgreSQL 17's pg_operator catalog (queried directly: `select distinct
+// oprname from pg_operator where length(oprname) > 1`), with pg_trgm,
+// hstore, intarray, cube, earthdistance, and ltree all CREATE EXTENSIONed
+// first -- covering not just core arithmetic/comparison/JSON/array/range
+// operators but the GiST/GIN/SP-GiST index operator classes actually used
+// in this repo's own corpus (which has hstore, intarray, cube/earthdistance,
+// and trigram example chapters): geometric &&/&</&>/<->/@-@/..., full-text
+// @@/@@@, trigram %/<->/<->>>(word-similarity)/<<<->(strict word-similarity),
+// hstore ?/?&/?|/->, ltree @>/<@/?, and the (deprecated but still
+// catalogued) path/polygon "before"/"after" */< family. "!=" and "::"
+// aren't in pg_operator (the parser normalizes "!=" to "<>", and "::" is
+// cast syntax, not a real operator) but are still real input syntax, so
+// are kept too.
 var multiCharOperators = []string{
-	"->>", "::", "->", "@>", "<@", "<=", ">=", "<>", "!=", "||",
+	// 5-character
+	"<->>>", "<<<->",
+	// 4-character
+	"!~~*", "#<=#", "#>=#", "<->>", "<<->", "~<=~", "~>=~",
+	// 3-character
+	"!~*", "!~~", "#<#", "#>#", "#>>", "%>>", "&<|", "*<=", "*<>", "*>=",
+	"->>", "-|-", "<#>", "<->", "<<%", "<<=", "<<|", "<=>", "<@>", ">>=",
+	"?-|", "?<@", "?@>", "?||", "@-@", "@@@", "^<@", "^@>", "|&>", "|>>",
+	"||/", "~<~", "~>~", "~~*",
+	// 2-character
+	"!!", "!=", "!~", "##", "#-", "#=", "#>", "%#", "%%", "%>", "&&", "&<",
+	"&>", "*<", "*=", "*>", "::", "->", "<%", "<<", "<=", "<>", "<@", "<^",
+	">=", ">>", ">^", "?#", "?&", "?-", "?@", "?|", "?~", "@>", "@?", "@@",
+	"^?", "^@", "^~", "|/", "||", "~*", "~=", "~>", "~~",
 }
 
 type lexer struct {

--- a/format/lexer_test.go
+++ b/format/lexer_test.go
@@ -54,6 +54,61 @@ func TestLexMultiCharOperators(t *testing.T) {
 	}
 }
 
+// TestLexGiSTGINOperators covers the GiST/GIN/SP-GiST index operator
+// classes actually used in this repo's own corpus (hstore, intarray,
+// cube/earthdistance, trigram) plus a few core geometric/full-text ones --
+// regression coverage for the "<->" PostGIS/KNN-distance-style operator
+// bug report, generalized to the full operator table pulled from
+// pg_operator (see multiCharOperators' own comment).
+func TestLexGiSTGINOperators(t *testing.T) {
+	src := "a <-> b @@ c ~ d !~ e % f @> g <@ h ?| i ?& j -> k"
+	toks := lexOK(t, src)
+	want := []string{
+		"a", "<->", "b", "@@", "c", "~", "d", "!~", "e", "%", "f", "@>",
+		"g", "<@", "h", "?|", "i", "?&", "j", "->", "k",
+	}
+	if len(toks)-1 != len(want) {
+		t.Fatalf("token count = %d, want %d: %+v", len(toks)-1, len(want), toks)
+	}
+	for i, w := range want {
+		if toks[i].Text != w {
+			t.Fatalf("token %d = %q, want %q", i, toks[i].Text, w)
+		}
+	}
+}
+
+// TestLexOperatorPrefixConflicts specifically exercises operators where a
+// shorter registered operator is a textual prefix of a longer one (e.g.
+// "#>" of "#>>" of "#>#"), the exact failure mode multiCharOperators'
+// length-descending ordering exists to avoid: the longer one must lex as a
+// single token, not split into the short one plus leftover characters.
+func TestLexOperatorPrefixConflicts(t *testing.T) {
+	cases := []struct {
+		src  string
+		want string
+	}{
+		{"a #> b", "#>"},
+		{"a #>> b", "#>>"},
+		{"a #># b", "#>#"}, // "#>" is a prefix of both "#>>" and "#>#"
+		{"a << b", "<<"},
+		{"a <<= b", "<<="},
+		{"a <<| b", "<<|"},
+		{"a ~~ b", "~~"},
+		{"a ~~* b", "~~*"},
+		{"a !~~ b", "!~~"},
+		{"a !~~* b", "!~~*"},
+		{"a <-> b", "<->"},
+		{"a <->> b", "<->>"},
+		{"a <->>> b", "<->>>"},
+	}
+	for _, c := range cases {
+		toks := lexOK(t, c.src)
+		if toks[1].Text != c.want {
+			t.Errorf("lex(%q): token 1 = %q, want %q (full: %+v)", c.src, toks[1].Text, c.want, toks[:len(toks)-1])
+		}
+	}
+}
+
 func TestLexBackslashCommand(t *testing.T) {
 	toks := lexOK(t, "\\set season 'date ''1978-01-01'''\nselect 1;")
 	if toks[0].Kind != TokBackslashCmd {

--- a/testdata/corpus/intarray-tags-02_04.sql
+++ b/testdata/corpus/intarray-tags-02_04.sql
@@ -17,6 +17,6 @@ with t(query) as (
                                   end as title
     from track_tags tt
     join tids on tt.tid = tids.rowid
-    join t on tt.tags @ @ t.query
+    join t on tt.tags @@ t.query
     join lastfm.track on tids.tid = track.tid
 order by artist;

--- a/testdata/corpus/nulls-02_02.sql
+++ b/testdata/corpus/nulls-02_02.sql
@@ -8,4 +8,4 @@ create table test
 
 insert into test(f1) values (default), (null), ('foo');
 
-ERROR : null value in column "f1" violates not - null constraint DETAIL : Failing row contains(2, null).
+ERROR : null value in column "f1" violates not -null constraint DETAIL : Failing row contains(2, null).

--- a/testdata/corpus/pub-names-knn-05_01_pubnames.svg.knn.sql
+++ b/testdata/corpus/pub-names-knn-05_01_pubnames.svg.knn.sql
@@ -2,25 +2,31 @@
 -- single <svg> document: OSM streets from osm_london.roads for context, the
 -- search point in red, the nearest pubs in blue with their names.
 with search as (
-  select point(- 0.12, 51.516) as pt
+  select point(-0.12, 51.516) as pt
 ),
 nearest as (
       select id,
              name,
              pos,
-             row_number() over(order by pos < -> (select pt from search)) as rn
+             row_number() over(order by pos <-> (select pt from search)) as rn
         from pubnames
-    order by pos < -> (select pt from search)
+    order by pos <-> (select pt from search)
        limit 10
 ),
 bbox as (
-    select least(min((pos) [0]), min((select (pt) [0] from search))) - 0.003 as x0,
-           greatest(max((pos) [0]), max((select (pt) [0] from search))) + 0.003 as x1,
-           least(min((pos) [1]), min((select (pt) [1] from search))) - 0.002 as y0,
-           greatest(max((pos) [1]), max((select (pt) [1] from search))) + 0.002 as y1
+    select least(min((pos)[0]), min((select (pt)[0] from search))) - 0.003 as x0,
+           greatest(max((pos)[0]), max((select (pt)[0] from search))) + 0.003 as x1,
+           least(min((pos)[1]), min((select (pt)[1] from search))) - 0.002 as y0,
+           greatest(max((pos)[1]), max((select (pt)[1] from search))) + 0.002 as y1
       from nearest
 ),
 proj as (
+           -- project lon/lat degrees onto a plain ~800-unit canvas before drawing
+           -- anything, so every SVG number (stroke-width, radius, font-size) is
+           -- an
+           -- ordinary integer instead of a sub-0.001 fraction — some renderers
+           -- don't
+           -- reliably handle attribute values at that scale.
     select x0, y0, x1, y1, 800.0 / greatest(x1 - x0, y1 - y0) as scale
       from bbox
 ),
@@ -28,23 +34,25 @@ win as (
   select st_makeenvelope(x0, y0, x1, y1, 4326) as env from bbox
 ),
 roads as (
-    select st_transscale(st_intersection(r.geom, win.env), - proj.x0, - proj.y0, proj.scale, proj.scale) as geom
+    select st_transscale(st_intersection(r.geom, win.env), -proj.x0, -proj.y0, proj.scale, proj.scale) as geom
       from osm_london.roads r, win, proj
      where st_intersects(r.geom, win.env)
 ),
 layers as (
     select 1 as z,
            '<path d="' || st_assvg(geom, 0, 1) || '" fill="none" stroke="#C0B8AE" stroke-width="2"/>' as elem
-      from roads union all
+      from roads
+    union all
     select 2,
-           '<circle cx="' || (((pt) [0] - proj.x0) * proj.scale)::text || '" cy="' || (- (((pt) [1] - proj.y0) * proj.scale))::text || '" r="9" fill="#B04020" stroke="#F2EFE9" stroke-width="2"/>' as elem
-      from search, proj union all
+           '<circle cx="' || (((pt)[0] - proj.x0) * proj.scale)::text || '" cy="' || (-(((pt)[1] - proj.y0) * proj.scale))::text || '" r="9" fill="#B04020" stroke="#F2EFE9" stroke-width="2"/>' as elem
+      from search, proj
+    union all
     select 3,
-           '<circle cx="' || (((pos) [0] - proj.x0) * proj.scale)::text || '" cy="' || (- (((pos) [1] - proj.y0) * proj.scale))::text || '" r="6" fill="#5B8DB8" stroke="#F2EFE9" stroke-width="1.5"/>' || '<text x="' || (((pos) [0] - proj.x0) * proj.scale + 9)::text || '" y="' || (
-    - (((pos) [1] - proj.y0) * proj.scale) + (
-    case when rn % 2 = 0 then 9 else - 4 end))::text || '" font-size="13" fill="#2C2820">' || replace(replace(name, '&', '&amp;'), '<', '&lt;') || '</text>' as elem
+           '<circle cx="' || (((pos)[0] - proj.x0) * proj.scale)::text || '" cy="' || (-(((pos)[1] - proj.y0) * proj.scale))::text || '" r="6" fill="#5B8DB8" stroke="#F2EFE9" stroke-width="1.5"/>' || '<text x="' || (((pos)[0] - proj.x0) * proj.scale + 9)::text || '" y="' || (
+    -(((pos)[1] - proj.y0) * proj.scale) + (
+    case when rn % 2 = 0 then 9 else -4 end))::text || '" font-size="13" fill="#2C2820">' || replace(replace(name, '&', '&amp;'), '<', '&lt;') || '</text>' as elem
       from nearest, proj
 )
-  select '<svg viewBox="0 ' || (- ((proj.y1 - proj.y0) * proj.scale)) || ' ' || ((proj.x1 - proj.x0) * proj.scale) || ' ' || ((proj.y1 - proj.y0) * proj.scale) || '" xmlns="http://www.w3.org/2000/svg">' || '<rect x="0" y="' || (- ((proj.y1 - proj.y0) * proj.scale)) || '" width="' || ((proj.x1 - proj.x0) * proj.scale) || '" height="' || ((proj.y1 - proj.y0) * proj.scale) || '" fill="#F2EFE9"/>' || string_agg(layers.elem, '' order by layers.z) || '</svg>' as svg
+  select '<svg viewBox="0 ' || (-((proj.y1 - proj.y0) * proj.scale)) || ' ' || ((proj.x1 - proj.x0) * proj.scale) || ' ' || ((proj.y1 - proj.y0) * proj.scale) || '" xmlns="http://www.w3.org/2000/svg">' || '<rect x="0" y="' || (-((proj.y1 - proj.y0) * proj.scale)) || '" width="' || ((proj.x1 - proj.x0) * proj.scale) || '" height="' || ((proj.y1 - proj.y0) * proj.scale) || '" fill="#F2EFE9"/>' || string_agg(layers.elem, '' order by layers.z) || '</svg>' as svg
     from layers, proj
 group by proj.x0, proj.y0, proj.x1, proj.y1, proj.scale;

--- a/testdata/corpus/sql-103-05_07_hydrorivers.recursive.sql
+++ b/testdata/corpus/sql-103-05_07_hydrorivers.recursive.sql
@@ -1,11 +1,12 @@
 -- Loire: full basin via WITH RECURSIVE (6,297 reaches).
 -- Automates the ring-by-ring approach indefinitely.
-with loire as (
+with recursive loire as (
     select hyriv_id,
            geom,
            ord_stra  -- base case: the outlet
       from hydrorivers.rivers
-     where hyriv_id = 20446779 union all
+     where hyriv_id = 20446779
+    union all
     select r.hyriv_id,
            r.geom,
            r.ord_stra  -- recursive term: one step upstream


### PR DESCRIPTION
## Summary

Three bugs found while testing comment preservation (#5) against real corpus files, unrelated to comments — all reproduce on a plain build.

### 1. Multi-character operators (`format/lexer.go`)

`multiCharOperators` was missing every GiST/GIN/SP-GiST index operator except a handful (`@>`, `<@`, ...) — `<->` (KNN distance) lexed as `<` + `->`. Rather than add just `<->`, pulled the complete, authoritative operator set directly from a local PostgreSQL 17 `pg_operator` catalog (with `pg_trgm`, `hstore`, `intarray`, `cube`, `earthdistance`, `ltree` all `CREATE EXTENSION`ed, since this repo's own corpus has example chapters for several of those) — including the 5-character `pg_trgm` word-similarity operators (`<->>>`, `<<<->`).

### 2. Unary minus/plus spacing (`format/layout.go`)

`spaceBetween` couldn't distinguish unary from binary `-`/`+` using only the adjacent token (they render identically as tokens either way) — `point(- 0.12, 51.516)` instead of `point(-0.12, 51.516)`. Extended `spaceBetween` to also see the token before the token before it, added `isUnaryContext`. Also fixed a related bug found in the same real file: no space before `[` (array subscript) — `(pos) [0]` instead of `(pos)[0]`.

### 3. UNION/INTERSECT/EXCEPT clause splitting (`format/layout.go`)

Not recognized as query-segment boundaries at all — `union all` between two `SELECT`s in a recursive CTE glued onto the end of the first `SELECT`'s `WHERE` clause instead of starting its own line. `DESIGN.md`'s module-layout comment already listed this as intended, so this closes a documented gap. Added `splitUnionSegments`; each side of a `UNION` is independently formatted with its own river-alignment width. Fixing this surfaced a second bug in the same function: `parseCTEs` consumed `RECURSIVE` to skip past it but never re-emitted it, silently turning `with recursive` into `with` — a correctness bug, not cosmetic.

### Corpus

`pub-names-knn-*.sql` and `intarray-tags-02_04.sql` had these bugs baked into their *committed* text from an earlier regeneration (before these fixes existed) — re-running `sqlfmt -w` on the already-corrupted fixture can't undo that, since by then e.g. `<` and `->` are genuinely two separate, space-separated tokens in the file. Regenerated the entire corpus fresh from the original book source instead. `git diff --stat` confirms only the 4 genuinely-affected files changed.

### The two "not idempotent" fixtures from the original report

Re-tested `hstore-04_01_artists.update.hstore.sql` and `non-relational-types-01_01_tweets.sql` with a reliable file-based comparison against both this branch and a pre-fix build — both were already idempotent all along. The original report's shell `$(...)` command substitution silently strips trailing newlines, which can manufacture a false difference. Nothing to fix there.

## Test plan

- `go build ./...`, `go vet ./...`, `gofmt -l .`, `make test`, `make wasm-test` all clean.
- New tests (`format/layout_gaps_test.go`, plus `TestLexGiSTGINOperators`/`TestLexOperatorPrefixConflicts` in `lexer_test.go`) verified to fail against the pre-fix code and pass with it.