### PR TITLE
Add make install/uninstall and sqlfmt -V/--version

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -75,7 +75,7 @@ uninstall:
 # "WebAssembly build" section of README.md for install instructions.
 wasm:
 	mkdir -p $(WASM_DIR)
-	$(TINYGO) build -o $(WASM_DIR)/sqlfmt.wasm -target=wasm -no-debug -opt=z ./wasm
+	$(TINYGO) build -ldflags "-X main.version=$(VERSION)" -o $(WASM_DIR)/sqlfmt.wasm -target=wasm -no-debug -opt=z ./wasm
 	$(WASM_OPT) -Oz -o $(WASM_DIR)/sqlfmt.wasm $(WASM_DIR)/sqlfmt.wasm
 	cp "$$($(TINYGO) env TINYGOROOT)/targets/wasm_exec.js" $(WASM_DIR)/wasm_exec.js
 	node wasm/compress.mjs

--- a/Makefile
+++ b/Makefile
@@ -3,14 +3,45 @@ WASM_DIR := dist/wasm
 GO       := go
 TINYGO   := tinygo
 WASM_OPT := wasm-opt
+INSTALL  := install
 CORPUS   := $(shell find testdata/corpus -name '*.sql')
 
-.PHONY: all build test wasm wasm-test clean
+# VERSION_BASE is bumped by hand on release. A build made exactly at a git
+# tag (a real release checkout) reports that bare version; any other build
+# -- a working branch, a random commit -- appends ".g<short-sha>" so its
+# provenance is traceable, the same "g<sha>" convention `git describe` itself
+# uses. A tree with no git metadata at all (e.g. a source tarball) falls
+# back to the bare version.
+VERSION_BASE := 0.1
+GIT_TAG      := $(shell git describe --tags --exact-match 2>/dev/null)
+GIT_SHA      := $(shell git rev-parse --short HEAD 2>/dev/null)
+ifneq ($(GIT_TAG),)
+VERSION := $(VERSION_BASE)
+else ifneq ($(GIT_SHA),)
+VERSION := $(VERSION_BASE).g$(GIT_SHA)
+else
+VERSION := $(VERSION_BASE)
+endif
+
+# PREFIX/DESTDIR follow the GNU Coding Standards / Debian Policy convention
+# (https://www.gnu.org/prep/standards/html_node/DESTDIR.html): PREFIX picks
+# the install tree (packagers override to /usr; left at /usr/local for a
+# plain `make install`), DESTDIR stages that tree under a build root without
+# baking the root into the installed binary's own path. A `debian/rules`
+# using debhelper's default `dh_auto_install` already invokes exactly
+# `make install DESTDIR=debian/<pkg>` for a plain Makefile like this one, so
+# no other packaging glue is needed for that half of it. The target
+# directory itself is not created here -- it's expected to already exist
+# (packaging tooling, or a standard /usr/local/bin on a real system).
+PREFIX  ?= /usr/local
+BINDIR  := $(DESTDIR)$(PREFIX)/bin
+
+.PHONY: all build test wasm wasm-test install uninstall clean
 
 all: build
 
 build:
-	$(GO) build -o $(BINARY) ./cmd/sqlfmt
+	$(GO) build -ldflags "-X main.version=$(VERSION)" -o $(BINARY) ./cmd/sqlfmt
 
 test: build
 	$(GO) test ./...
@@ -21,6 +52,12 @@ test: build
 		echo "$$dirty"; \
 		exit 1; \
 	fi
+
+install: build
+	$(INSTALL) -m 0755 $(BINARY) $(BINDIR)/sqlfmt
+
+uninstall:
+	rm -f $(BINDIR)/sqlfmt
 
 # Builds the browser WebAssembly module (globalThis.sqlfmt.format(sql)) plus
 # the wasm_exec.js glue it needs, into $(WASM_DIR), along with pre-compressed

--- a/README.md
+++ b/README.md
@@ -44,6 +44,7 @@ $ sqlfmt -w query.sql           # rewrite the file in place
 $ sqlfmt -l queries/**/*.sql    # list files whose formatting would change
 $ sqlfmt -d query.sql           # show a unified diff instead of full output
 $ cat query.sql | sqlfmt        # stdin -> stdout, pipeable
+$ sqlfmt -V                     # print the version and exit
 ```
 
 As a library: `import "github.com/dimitri/sqlfmt/format"` (module path TBD —
@@ -52,6 +53,30 @@ like `app.taop.xyz`'s `cmd/sqlbuild` book-build tool can format embedded
 queries in-process without shelling out to the binary. The library lives in
 its own `format/` subpackage (rather than at the module root) specifically
 so it stays easily importable on its own, independent of the CLI.
+
+## Building and installing
+
+```console
+$ make build              # -> bin/sqlfmt
+$ make test                # build + go test + corpus canonical-formatting check
+$ make install              # install bin/sqlfmt to $(DESTDIR)$(PREFIX)/bin
+$ make uninstall             # remove it again
+```
+
+`PREFIX` defaults to `/usr/local`; `DESTDIR` stages that tree under a build
+root without baking the root into the installed binary's own path, the
+standard GNU Coding Standards / Debian Policy convention. A `debian/rules`
+using debhelper's default `dh_auto_install` already invokes exactly
+`make install DESTDIR=debian/<pkg>` for a plain Makefile like this one, so no
+further packaging glue is needed on that side. `install` does not create the
+target directory itself — it's expected to already exist (packaging tooling
+creates it, or it's a standard path like `/usr/local/bin` on a real system).
+
+`sqlfmt -V` reports the version: `0.1` for a build made exactly at a git tag,
+or `0.1.g<short-sha>` for any other build (a working branch, an arbitrary
+commit) — the same `g<sha>` convention `git describe` itself uses, so a
+report of unexpected formatter behavior can always be tied back to the exact
+commit that produced it.
 
 ## Editor integration
 

--- a/README.md
+++ b/README.md
@@ -124,13 +124,20 @@ binary.
 ## WebAssembly build
 
 `wasm/` compiles the `format` library to WebAssembly for in-browser use,
-exposing a single global JS function:
+exposing:
 
 ```js
 sqlfmt.format(sql)
 //  -> { output: string } on success
 //  -> { error: string }  on a real parse/format error
+
+sqlfmt.version
+//  -> "0.1" or "0.1.g<short-sha>", same value and scheme as `sqlfmt -V`
 ```
+
+`sqlfmt.version` follows the same convention several other JS libraries use
+for a top-level version string on their namespace object — `React.version`,
+`Vue.version`, `d3.version`.
 
 Built with [TinyGo](https://tinygo.org) (`tinygo build -target=wasm -no-debug
 -opt=z`) plus a [Binaryen](https://github.com/WebAssembly/binaryen)

--- a/cmd/sqlfmt/main.go
+++ b/cmd/sqlfmt/main.go
@@ -15,10 +15,16 @@ import (
 	"github.com/dimitri/sqlfmt/format"
 )
 
+// version is overridden at build time via -ldflags "-X main.version=...";
+// see the VERSION computation in the Makefile.
+var version = "0.1"
+
 var (
-	write  = flag.Bool("w", false, "write result to (source) file instead of stdout")
-	list   = flag.Bool("l", false, "list files whose formatting differs from sqlfmt's")
-	doDiff = flag.Bool("d", false, "display diffs instead of rewriting files")
+	write      = flag.Bool("w", false, "write result to (source) file instead of stdout")
+	list       = flag.Bool("l", false, "list files whose formatting differs from sqlfmt's")
+	doDiff     = flag.Bool("d", false, "display diffs instead of rewriting files")
+	showVer    = flag.Bool("V", false, "print version and exit")
+	showVerLon = flag.Bool("version", false, "print version and exit")
 )
 
 func main() {
@@ -27,6 +33,11 @@ func main() {
 		flag.PrintDefaults()
 	}
 	flag.Parse()
+
+	if *showVer || *showVerLon {
+		fmt.Println("sqlfmt", version)
+		return
+	}
 
 	if flag.NArg() == 0 {
 		if err := processReader(os.Stdin, "<standard input>"); err != nil {

--- a/wasm/main.go
+++ b/wasm/main.go
@@ -1,11 +1,16 @@
 //go:build js && wasm
 
 // Command wasm compiles the sqlfmt formatter to WebAssembly for in-browser
-// use, exposing a single global JS function:
+// use, exposing:
 //
 //	globalThis.sqlfmt.format(sql)
 //	  -> { output: string } on success
 //	  -> { error: string }  on a real parse/format error
+//	globalThis.sqlfmt.version
+//	  -> the sqlfmt version string, e.g. "0.1" or "0.1.gd986ff7" -- same
+//	     string and same convention as `sqlfmt -V`, and the same
+//	     "Library.version" convention used by e.g. React.version,
+//	     Vue.version, and d3.version
 //
 // Built with TinyGo (-target=wasm), not the standard `go build` js/wasm
 // target, to keep the module small -- see the "WebAssembly build" section
@@ -28,6 +33,11 @@ import (
 	"github.com/dimitri/sqlfmt/format"
 )
 
+// version is overridden at build time via -ldflags "-X main.version=...";
+// see the VERSION computation in the Makefile (same value `sqlfmt -V`
+// reports for the same build).
+var version = "0.1"
+
 func formatSQL(_ js.Value, args []js.Value) any {
 	result := make(map[string]any)
 	if len(args) != 1 || args[0].Type() != js.TypeString {
@@ -48,6 +58,7 @@ func main() {
 	done := make(chan struct{})
 	sqlfmt := js.Global().Get("Object").New()
 	sqlfmt.Set("format", js.FuncOf(formatSQL))
+	sqlfmt.Set("version", version)
 	js.Global().Set("sqlfmt", sqlfmt)
 	<-done // keep the Go runtime (and the exported function) alive
 }

--- a/wasm/smoketest.mjs
+++ b/wasm/smoketest.mjs
@@ -24,6 +24,9 @@ function assertEqual(got, want, label) {
   }
 }
 
+assertEqual(typeof globalThis.sqlfmt.version, "string", "version: is a string");
+assertEqual(globalThis.sqlfmt.version.length > 0, true, "version: is non-empty");
+
 const ok = globalThis.sqlfmt.format("select id,name from users where id=1;");
 assertEqual(ok.error, undefined, "valid SQL: no error");
 assertEqual(ok.output, "select id, name\n  from users\n where id = 1;\n", "valid SQL: output");


### PR DESCRIPTION
## What

- `make install` / `make uninstall`, Debian-packaging compatible via
  `DESTDIR`.
- `sqlfmt -V` / `--version`.

## make install/uninstall

`PREFIX` (default `/usr/local`) picks the install tree; `DESTDIR` stages
that tree under a build root without baking the root into the installed
binary's own path — the standard GNU Coding Standards / Debian Policy
convention. A `debian/rules` using debhelper's default `dh_auto_install`
already invokes exactly `make install DESTDIR=debian/<pkg>` for a plain
Makefile like this one.

`install` uses `install -m 0755` (not `cp`) for correct permissions, and
does **not** create the target directory — it's expected to already exist
(packaging tooling creates it, or it's a standard path like
`/usr/local/bin`). `uninstall` removes just that one file.

## sqlfmt -V / --version

Version is `0.1` (bumped by hand on release) for a build made exactly at a
git tag, or `0.1.g<short-sha>` for any other build — the same `g<sha>`
convention `git describe` itself uses. Computed in the Makefile and
injected at build time via `-ldflags -X main.version=...`; `main.go`
defaults to the bare `0.1` when built outside `make` (e.g. plain
`go build`/`go install`).

## Testing

- `go build ./...`, `go vet ./...`, `gofmt -l .` all clean.
- `make test` and `make wasm-test` both pass.
- Manually verified: `make -n install` resolves to exactly `install -m 0755
  bin/sqlfmt /usr/local/bin/sqlfmt`; staged a real install under a scratch
  `DESTDIR` and ran the installed binary; verified `uninstall` removes
  exactly that file; verified `install` fails (rather than silently
  creating the directory) when the target directory doesn't exist yet;
  verified the DESTDIR+PREFIX=/usr combination a real `debian/rules` would
  use.
- Verified `-V`/`--version` output for both the tagged-commit case (`0.1`)
  and the normal branch-commit case (`0.1.g<sha>`).

README.md updated: `-V` documented in Usage, new "Building and installing"
section.