### PR TITLE
Format EXPLAIN, aligned into the clause river

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -116,6 +116,11 @@ format/
                          genuinely different formatting mode from the query
                          clauses — column-name-width alignment, not clause-keyword
                          alignment)
+                       - EXPLAIN (rule 19, in format.go's layoutExplain): a
+                         prefix line plus a recursive formatStatement call on
+                         the statement it wraps, so the wrapped query gets
+                         whichever layout it would have had on its own rather
+                         than a second EXPLAIN-specific code path
   comments.go      — rule 18: attachComments (a single pass over the full lexed
                      stream that removes every comment token and re-expresses it
                      as metadata -- Comments/TrailingComment -- on a neighboring

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -116,11 +116,17 @@ format/
                          genuinely different formatting mode from the query
                          clauses — column-name-width alignment, not clause-keyword
                          alignment)
-                       - EXPLAIN (rule 19, in format.go's layoutExplain): a
-                         prefix line plus a recursive formatStatement call on
-                         the statement it wraps, so the wrapped query gets
-                         whichever layout it would have had on its own rather
-                         than a second EXPLAIN-specific code path
+                       - EXPLAIN (rule 19): "explain" is simply an entry in
+                         clauseWords, so splitClauses yields it as an ordinary
+                         segment (body = the option list), riverWidth sizes the
+                         river with it included, and renderClause pads it --
+                         no EXPLAIN-specific layout code at all. It is the one
+                         clauseWords entry marked leadingOnly, since EXPLAIN is
+                         only ever a statement prefix and "select explain from
+                         t" must stay one clause. format.go's layoutExplain
+                         only handles the payloads that have no river to join
+                         (EXECUTE, WITH), falling back to a prefix line plus a
+                         recursive formatStatement call
   comments.go      — rule 18: attachComments (a single pass over the full lexed
                      stream that removes every comment token and re-expresses it
                      as metadata -- Comments/TrailingComment -- on a neighboring

--- a/STYLE.md
+++ b/STYLE.md
@@ -317,6 +317,35 @@ fixture's current content.
     pretty-printer built on a parser that discards comments (see
     `DESIGN.md`).
 
+19. **EXPLAIN**: the `EXPLAIN` prefix — with its option list, if any — sits
+    alone on the first line, and the statement it wraps is formatted
+    exactly as it would be on its own, with its own clause river and no
+    extra indentation (185 of 192 corpus occurrences; 167 of those carry a
+    parenthesized option list):
+    ```sql
+    explain (analyze, buffers)
+    select res.raceid, res.driverid, res.points
+      from f1db.results res
+     where res.points >= 10;
+    ```
+    Because the wrapped statement keeps its own river, a long clause
+    keyword inside it still sets the alignment for the whole query, exactly
+    as if the `EXPLAIN` line were not there:
+    ```sql
+    explain (costs off, buffers, analyze)
+      select name, location, country
+        from circuits
+    order by position <-> point(2.349014, 48.864716);
+    ```
+    Unlike rule 4, a space *is* written between `explain` and its `(`: the
+    option list is not a function call. Both spellings of the prefix are
+    accepted — the parenthesized list above, and the legacy bare form the
+    grammar still allows (`explain analyze verbose select ...`), which is
+    preserved as written rather than rewritten into the parenthesized form,
+    per rule 1's "never change content, only whitespace". The wrapped
+    statement need not be a `SELECT`; `explain (analyze) execute p(1)` is
+    laid out the same way.
+
 ## Summary of genuinely ambiguous areas
 
 Be forgiving on these when validating/parsing input; pick the stated default

--- a/STYLE.md
+++ b/STYLE.md
@@ -317,34 +317,45 @@ fixture's current content.
     pretty-printer built on a parser that discards comments (see
     `DESIGN.md`).
 
-19. **EXPLAIN**: the `EXPLAIN` prefix — with its option list, if any — sits
-    alone on the first line, and the statement it wraps is formatted
-    exactly as it would be on its own, with its own clause river and no
-    extra indentation (185 of 192 corpus occurrences; 167 of those carry a
-    parenthesized option list):
+19. **EXPLAIN**: `EXPLAIN` is a clause keyword, not a prefix bolted on above
+    the statement. It takes a line of its own — with its option list, if
+    any — and is right-padded into the same river as the clauses of the
+    statement it wraps, exactly like `select` or `order by`:
     ```sql
     explain (analyze, buffers)
-    select res.raceid, res.driverid, res.points
-      from f1db.results res
-     where res.points >= 10;
+     select res.raceid, res.driverid, res.points
+       from f1db.results res
+      where res.points >= 10;
     ```
-    Because the wrapped statement keeps its own river, a long clause
-    keyword inside it still sets the alignment for the whole query, exactly
-    as if the `EXPLAIN` line were not there:
+    `explain` is 7 characters, so it sets the river above. When the wrapped
+    statement has a wider clause keyword, that one sets the river and the
+    `EXPLAIN` line indents under it like any other short keyword would:
     ```sql
-    explain (costs off, buffers, analyze)
+     explain (costs off, buffers, analyze)
       select name, location, country
         from circuits
     order by position <-> point(2.349014, 48.864716);
     ```
-    Unlike rule 4, a space *is* written between `explain` and its `(`: the
+    A JOIN phrase wide enough to set the river (per rule 9) moves it too.
+    The option list is the clause's body, so its length never affects the
+    river — only the word `explain` does.
+
+    The `EXPLAIN` line always breaks, even where the whole statement would
+    otherwise fit inline per rule 17: what is being explained should read as
+    a statement, not as an argument.
+
+    Unlike rule 4, a space *is* written between `explain` and its `(` — the
     option list is not a function call. Both spellings of the prefix are
-    accepted — the parenthesized list above, and the legacy bare form the
+    accepted: the parenthesized list above, and the legacy bare form the
     grammar still allows (`explain analyze verbose select ...`), which is
     preserved as written rather than rewritten into the parenthesized form,
-    per rule 1's "never change content, only whitespace". The wrapped
-    statement need not be a `SELECT`; `explain (analyze) execute p(1)` is
-    laid out the same way.
+    per rule 1. Those extra words are body, so they do not widen the river
+    either.
+
+    Two payloads have no single top-level river to join — `EXECUTE`, and
+    anything starting with `WITH` (whose CTE list has a layout of its own,
+    rule 13). Those keep an unpadded `EXPLAIN` line followed by the
+    statement formatted as it would be on its own.
 
 ## Summary of genuinely ambiguous areas
 

--- a/format/explain_test.go
+++ b/format/explain_test.go
@@ -1,0 +1,120 @@
+package format
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+)
+
+// TestExplainPrefixIsItsOwnLine covers STYLE.md rule 19. Before EXPLAIN was
+// handled, "explain" lexed as a bare identifier, statementKeyword returned
+// "", and formatStatement's default arm flattened the whole statement --
+// EXPLAIN silently cost you every clause break in the query it wrapped.
+func TestExplainPrefixIsItsOwnLine(t *testing.T) {
+	cases := []struct {
+		name string
+		src  string
+		want string
+	}{
+		{
+			name: "bare explain",
+			src:  "explain select a, b from t where c = 1;",
+			want: "explain\nselect a, b\n  from t\n where c = 1;\n",
+		},
+		{
+			name: "parenthesized option list",
+			src:  "explain (analyze, buffers) select a, b from t where c = 1;",
+			want: "explain (analyze, buffers)\nselect a, b\n  from t\n where c = 1;\n",
+		},
+		{
+			name: "legacy bare analyze verbose",
+			src:  "explain analyze verbose select a, b from t where c = 1;",
+			want: "explain analyze verbose\nselect a, b\n  from t\n where c = 1;\n",
+		},
+		{
+			name: "option list with a two-word option",
+			src:  "explain (costs off, analyze) select a, b from t where c = 1;",
+			want: "explain (costs off, analyze)\nselect a, b\n  from t\n where c = 1;\n",
+		},
+		{
+			// The wrapped statement need not be a SELECT; whatever it is,
+			// it gets formatted the way it would be on its own.
+			name: "non-select payload",
+			src:  "explain (analyze) execute p(1);",
+			want: "explain (analyze)\nexecute p(1);\n",
+		},
+		{
+			name: "explain with nothing to wrap",
+			src:  "explain;",
+			want: "explain;\n",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := Format(bytes.NewReader([]byte(tc.src)))
+			if err != nil {
+				t.Fatalf("Format error: %v", err)
+			}
+			if got != tc.want {
+				t.Errorf("got:\n%s\nwant:\n%s", got, tc.want)
+			}
+		})
+	}
+}
+
+// TestExplainKeepsInnerRiver is the regression the bug report was actually
+// about: the river alignment of the wrapped query must survive, including
+// the case where the longest clause keyword ("order by") indents "select".
+func TestExplainKeepsInnerRiver(t *testing.T) {
+	src := "explain (costs off, buffers, analyze) select name, location, country from circuits order by position <-> point(2.349014, 48.864716);"
+	got, err := Format(bytes.NewReader([]byte(src)))
+	if err != nil {
+		t.Fatalf("Format error: %v", err)
+	}
+	want := "explain (costs off, buffers, analyze)\n" +
+		"  select name, location, country\n" +
+		"    from circuits\n" +
+		"order by position <-> point(2.349014, 48.864716);\n"
+	if got != want {
+		t.Errorf("got:\n%s\nwant:\n%s", got, want)
+	}
+}
+
+// TestExplainIdempotent guards the property the pre-commit/CI use depends
+// on: formatting already-formatted EXPLAIN output changes nothing.
+func TestExplainIdempotent(t *testing.T) {
+	srcs := []string{
+		"explain select a, b from t where c = 1;",
+		"explain (analyze, buffers) select a from t;",
+		"explain analyze select a from t;",
+	}
+	for _, src := range srcs {
+		once, err := Format(bytes.NewReader([]byte(src)))
+		if err != nil {
+			t.Fatalf("Format error: %v", err)
+		}
+		twice, err := Format(bytes.NewReader([]byte(once)))
+		if err != nil {
+			t.Fatalf("Format error on second pass: %v", err)
+		}
+		if once != twice {
+			t.Errorf("not idempotent for %q:\nfirst:\n%s\nsecond:\n%s", src, once, twice)
+		}
+	}
+}
+
+// TestExplainPreservesComments checks that a comment header above an
+// EXPLAIN -- the shape every course example uses -- still survives.
+func TestExplainPreservesComments(t *testing.T) {
+	src := "-- why this plan matters\nexplain (analyze) select a from t;"
+	got, err := Format(bytes.NewReader([]byte(src)))
+	if err != nil {
+		t.Fatalf("Format error: %v", err)
+	}
+	if !strings.HasPrefix(got, "-- why this plan matters\n") {
+		t.Errorf("leading comment lost:\n%s", got)
+	}
+	if !strings.Contains(got, "explain (analyze)\nselect a from t;") {
+		t.Errorf("explain not laid out on its own line:\n%s", got)
+	}
+}

--- a/format/explain_test.go
+++ b/format/explain_test.go
@@ -6,42 +6,156 @@ import (
 	"testing"
 )
 
-// TestExplainPrefixIsItsOwnLine covers STYLE.md rule 19. Before EXPLAIN was
-// handled, "explain" lexed as a bare identifier, statementKeyword returned
-// "", and formatStatement's default arm flattened the whole statement --
-// EXPLAIN silently cost you every clause break in the query it wrapped.
-func TestExplainPrefixIsItsOwnLine(t *testing.T) {
+// fmtOne is a Format() wrapper for the single-statement cases below.
+func fmtOne(t *testing.T, src string) string {
+	t.Helper()
+	got, err := Format(bytes.NewReader([]byte(src)))
+	if err != nil {
+		t.Fatalf("Format(%q) error: %v", src, err)
+	}
+	return got
+}
+
+// TestExplainJoinsTheRiver is the core of STYLE.md rule 19: "explain" is a
+// clause keyword like "select" or "order by", padded into the same river as
+// the statement it wraps -- not a prefix bolted on above it.
+//
+// Before EXPLAIN was handled at all, "explain" lexed as a bare identifier,
+// statementKeyword returned "", and formatStatement's default arm ran
+// flatJoin over the whole statement: any EXPLAIN cost you every clause break
+// in the query underneath it, silently and with exit status 0.
+func TestExplainJoinsTheRiver(t *testing.T) {
 	cases := []struct {
 		name string
 		src  string
 		want string
 	}{
 		{
-			name: "bare explain",
-			src:  "explain select a, b from t where c = 1;",
-			want: "explain\nselect a, b\n  from t\n where c = 1;\n",
-		},
-		{
-			name: "parenthesized option list",
+			// "explain" (7) is itself the widest keyword here, so it sets
+			// the river and the query's own clauses indent under it.
+			name: "explain sets the river",
 			src:  "explain (analyze, buffers) select a, b from t where c = 1;",
-			want: "explain (analyze, buffers)\nselect a, b\n  from t\n where c = 1;\n",
+			want: "explain (analyze, buffers)\n" +
+				" select a, b\n" +
+				"   from t\n" +
+				"  where c = 1;\n",
 		},
 		{
+			// "order by" (8) is wider, so it sets the river instead and the
+			// EXPLAIN line indents by one -- the whole point of aligning it
+			// rather than pinning it to column 0.
+			name: "order by is wider and sets the river",
+			src:  "explain (costs off, buffers, analyze) select name, location, country from circuits order by position <-> point(2.349014, 48.864716);",
+			want: " explain (costs off, buffers, analyze)\n" +
+				"  select name, location, country\n" +
+				"    from circuits\n" +
+				"order by position <-> point(2.349014, 48.864716);\n",
+		},
+		{
+			name: "group by and order by together",
+			src:  "explain (analyze, buffers) select a, b from t group by a order by b;",
+			want: " explain (analyze, buffers)\n" +
+				"  select a, b\n" +
+				"    from t\n" +
+				"group by a\n" +
+				"order by b;\n",
+		},
+		{
+			// A JOIN phrase can widen the river past every clause keyword
+			// (riverWidth's maxJoinPhraseLen arm); EXPLAIN follows it.
+			name: "a join phrase widens the river",
+			src:  "explain select title, name from album left join track using(album_id) where album_id = 1;",
+			want: "    explain\n" +
+				"     select title, name\n" +
+				"       from album\n" +
+				"  left join track using(album_id)\n" +
+				"      where album_id = 1;\n",
+		},
+		{
+			name: "bare explain, no option list",
+			src:  "explain select a, b from t where c = 1;",
+			want: "explain\n select a, b\n   from t\n  where c = 1;\n",
+		},
+		{
+			// The legacy spelling the grammar still accepts. It is preserved
+			// as written, not rewritten into the parenthesized form (rule 1:
+			// never change content). Its extra words are the clause's body,
+			// so they do not widen the river.
 			name: "legacy bare analyze verbose",
 			src:  "explain analyze verbose select a, b from t where c = 1;",
-			want: "explain analyze verbose\nselect a, b\n  from t\n where c = 1;\n",
+			want: "explain analyze verbose\n select a, b\n   from t\n  where c = 1;\n",
 		},
 		{
-			name: "option list with a two-word option",
-			src:  "explain (costs off, analyze) select a, b from t where c = 1;",
-			want: "explain (costs off, analyze)\nselect a, b\n  from t\n where c = 1;\n",
+			name: "long option list does not widen the river",
+			src:  "explain (analyze, buffers, costs off, timing off, summary off) select a from t;",
+			want: "explain (analyze, buffers, costs off, timing off, summary off)\n" +
+				" select a\n" +
+				"   from t;\n",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := fmtOne(t, tc.src); got != tc.want {
+				t.Errorf("got:\n%s\nwant:\n%s", got, tc.want)
+			}
+		})
+	}
+}
+
+// TestExplainNonSelectPayloads covers the DML statements EXPLAIN accepts:
+// each still forms a clause river, so EXPLAIN aligns into it the same way.
+func TestExplainNonSelectPayloads(t *testing.T) {
+	cases := []struct {
+		name string
+		src  string
+		want string
+	}{
+		{
+			name: "insert",
+			src:  "explain (analyze) insert into t (a) values (1);",
+			want: "    explain (analyze)\ninsert into t(a)\n     values (1);\n",
 		},
 		{
-			// The wrapped statement need not be a SELECT; whatever it is,
-			// it gets formatted the way it would be on its own.
-			name: "non-select payload",
+			name: "update",
+			src:  "explain (analyze) update t set a = 1 where b = 2;",
+			want: "explain (analyze)\n update t\n    set a = 1\n  where b = 2;\n",
+		},
+		{
+			name: "delete",
+			src:  "explain (analyze) delete from t where b = 2;",
+			want: "explain (analyze)\n delete\n   from t\n  where b = 2;\n",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := fmtOne(t, tc.src); got != tc.want {
+				t.Errorf("got:\n%s\nwant:\n%s", got, tc.want)
+			}
+		})
+	}
+}
+
+// TestExplainPayloadsWithNoRiver covers the statements that have no single
+// top-level clause river for EXPLAIN to join. They fall back to an unpadded
+// prefix line plus the statement formatted as it would be on its own.
+func TestExplainPayloadsWithNoRiver(t *testing.T) {
+	cases := []struct {
+		name string
+		src  string
+		want string
+	}{
+		{
+			// EXECUTE is not a clause keyword at all.
+			name: "execute",
 			src:  "explain (analyze) execute p(1);",
 			want: "explain (analyze)\nexecute p(1);\n",
+		},
+		{
+			// A CTE list gets its own per-CTE layout; there is no top-level
+			// river to align with.
+			name: "with",
+			src:  "explain (analyze) with x as (select 1 as n) select n from x;",
+			want: "explain (analyze)\nwith x as (\n  select 1 as n\n)\nselect n from x;\n",
 		},
 		{
 			name: "explain with nothing to wrap",
@@ -51,52 +165,61 @@ func TestExplainPrefixIsItsOwnLine(t *testing.T) {
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			got, err := Format(bytes.NewReader([]byte(tc.src)))
-			if err != nil {
-				t.Fatalf("Format error: %v", err)
-			}
-			if got != tc.want {
+			if got := fmtOne(t, tc.src); got != tc.want {
 				t.Errorf("got:\n%s\nwant:\n%s", got, tc.want)
 			}
 		})
 	}
 }
 
-// TestExplainKeepsInnerRiver is the regression the bug report was actually
-// about: the river alignment of the wrapped query must survive, including
-// the case where the longest clause keyword ("order by") indents "select".
-func TestExplainKeepsInnerRiver(t *testing.T) {
-	src := "explain (costs off, buffers, analyze) select name, location, country from circuits order by position <-> point(2.349014, 48.864716);"
-	got, err := Format(bytes.NewReader([]byte(src)))
-	if err != nil {
-		t.Fatalf("Format error: %v", err)
+// TestExplainPrefixAlwaysBreaks: the EXPLAIN line keeps a line of its own
+// even when the whole statement would fit inline, so what is being explained
+// still reads as a statement and not as an argument (fitsInline's rule-19
+// arm).
+func TestExplainPrefixAlwaysBreaks(t *testing.T) {
+	got := fmtOne(t, "explain select a from t;")
+	if strings.HasPrefix(strings.TrimLeft(got, " "), "explain select") {
+		t.Errorf("EXPLAIN collapsed onto one line with its payload:\n%s", got)
 	}
-	want := "explain (costs off, buffers, analyze)\n" +
-		"  select name, location, country\n" +
-		"    from circuits\n" +
-		"order by position <-> point(2.349014, 48.864716);\n"
-	if got != want {
-		t.Errorf("got:\n%s\nwant:\n%s", got, want)
+	if lines := strings.Split(strings.TrimRight(got, "\n"), "\n"); len(lines) < 2 {
+		t.Errorf("expected the prefix on its own line, got:\n%s", got)
 	}
 }
 
-// TestExplainIdempotent guards the property the pre-commit/CI use depends
-// on: formatting already-formatted EXPLAIN output changes nothing.
+// TestExplainNoTrailingWhitespace guards the empty-body case: "explain" with
+// no option list must not leave the clause-keyword/body separator behind.
+func TestExplainNoTrailingWhitespace(t *testing.T) {
+	for _, src := range []string{
+		"explain select a, b from t where c = 1;",
+		"explain (analyze) select a, b from t where c = 1;",
+		"explain analyze select a from t;",
+	} {
+		for _, line := range strings.Split(fmtOne(t, src), "\n") {
+			if line != strings.TrimRight(line, " \t") {
+				t.Errorf("trailing whitespace in %q output line: %q", src, line)
+			}
+		}
+	}
+}
+
+// TestExplainIdempotent guards the property the pre-filter use depends on:
+// formatting already-formatted EXPLAIN output changes nothing. It is the
+// river cases that make this worth testing -- the EXPLAIN line's own
+// indentation is input to the next parse.
 func TestExplainIdempotent(t *testing.T) {
 	srcs := []string{
 		"explain select a, b from t where c = 1;",
 		"explain (analyze, buffers) select a from t;",
 		"explain analyze select a from t;",
+		"explain (analyze, buffers) select a, b from t group by a order by b;",
+		"explain select title, name from album left join track using(album_id) where album_id = 1;",
+		"explain (analyze) insert into t (a) values (1);",
+		"explain (analyze) execute p(1);",
+		"explain (analyze) with x as (select 1 as n) select n from x;",
 	}
 	for _, src := range srcs {
-		once, err := Format(bytes.NewReader([]byte(src)))
-		if err != nil {
-			t.Fatalf("Format error: %v", err)
-		}
-		twice, err := Format(bytes.NewReader([]byte(once)))
-		if err != nil {
-			t.Fatalf("Format error on second pass: %v", err)
-		}
+		once := fmtOne(t, src)
+		twice := fmtOne(t, once)
 		if once != twice {
 			t.Errorf("not idempotent for %q:\nfirst:\n%s\nsecond:\n%s", src, once, twice)
 		}
@@ -106,15 +229,21 @@ func TestExplainIdempotent(t *testing.T) {
 // TestExplainPreservesComments checks that a comment header above an
 // EXPLAIN -- the shape every course example uses -- still survives.
 func TestExplainPreservesComments(t *testing.T) {
-	src := "-- why this plan matters\nexplain (analyze) select a from t;"
-	got, err := Format(bytes.NewReader([]byte(src)))
-	if err != nil {
-		t.Fatalf("Format error: %v", err)
-	}
+	got := fmtOne(t, "-- why this plan matters\nexplain (analyze) select a, b from t where c = 1;")
 	if !strings.HasPrefix(got, "-- why this plan matters\n") {
 		t.Errorf("leading comment lost:\n%s", got)
 	}
-	if !strings.Contains(got, "explain (analyze)\nselect a from t;") {
-		t.Errorf("explain not laid out on its own line:\n%s", got)
+	if !strings.Contains(got, "explain (analyze)\n select a, b\n") {
+		t.Errorf("explain not river-aligned after its comment:\n%s", got)
+	}
+}
+
+// TestExplainKeywordDoesNotBreakIdentifiers: adding "explain" to the keyword
+// table must not change how it lexes elsewhere in a statement -- a column
+// named "explain" is still just a column.
+func TestExplainKeywordAsColumnName(t *testing.T) {
+	got := fmtOne(t, "select explain from t;")
+	if !strings.Contains(got, "select explain") {
+		t.Errorf("column named explain mangled:\n%s", got)
 	}
 }

--- a/format/format.go
+++ b/format/format.go
@@ -151,10 +151,21 @@ func formatStatement(toks []Token) string {
 }
 
 // layoutExplain renders EXPLAIN per STYLE.md rule 19: the EXPLAIN prefix
-// (with its option list, if any) alone on the first line, then the
-// statement it wraps formatted exactly as if it had been written on its
-// own -- its own clause river, unindented. That is what the corpus does in
-// 185 of 192 cases.
+// (with its option list, if any) takes a line of its own, and is padded
+// into the same clause river as the statement it wraps -- "explain" is a
+// clause keyword like "select" or "order by", not a thing bolted on above
+// them:
+//
+//	explain (analyze, buffers)
+//	 select res.raceid, res.points
+//	   from f1db.results res
+//	  where res.points >= 10;
+//
+// That falls out of clauseWords listing "explain": splitClauses yields it
+// as an ordinary segment whose body is the option list, riverWidth sizes
+// the river with it included, and renderClause pads it. So a query whose
+// longest clause keyword is wider than "explain" indents the EXPLAIN line
+// instead, exactly as it would any other short clause keyword.
 //
 // Both spellings of the prefix are handled: the modern parenthesized option
 // list ("explain (analyze, buffers) select ...") and the legacy bare form
@@ -163,11 +174,37 @@ func formatStatement(toks []Token) string {
 // exactly those is precise rather than a guess about where the inner
 // statement starts.
 //
-// The wrapped statement is dispatched back through formatStatement, which
-// is what makes "explain (analyze) execute p(1)" and "explain select ..."
-// each come out formatted the way that statement would be on its own.
+// A payload that is not a clause-river query -- "explain execute p(1)", or
+// anything starting with WITH, whose CTE list has a layout of its own that
+// no single river spans -- can't participate in a river, so it falls back
+// to an unpadded prefix line plus that statement formatted as it would be
+// on its own.
 func layoutExplain(toks []Token) []string {
-	prefix := []Token{toks[0]}
+	prefix, rest := splitExplainPrefix(toks)
+
+	// "explain" with nothing after it is not a statement we can improve on.
+	if len(rest) == 0 {
+		return []string{plainJoin(prefix)}
+	}
+
+	if explainPayloadJoinsRiver(rest) {
+		return formatQuerySegment(toks, 0)
+	}
+
+	// plainJoin would render "explain(analyze)" -- spaceBetween treats "("
+	// after a name as a call, per STYLE.md rule 4. The option list is not a
+	// call, so the space goes in here.
+	head := prefix[0].Text
+	if len(prefix) > 1 {
+		head += " " + plainJoin(prefix[1:])
+	}
+	return append([]string{head}, strings.Split(formatStatement(rest), "\n")...)
+}
+
+// splitExplainPrefix splits "explain [ (opts) | analyze verbose ]" off the
+// front of toks, returning the prefix tokens and the statement they wrap.
+func splitExplainPrefix(toks []Token) (prefix, rest []Token) {
+	prefix = []Token{toks[0]}
 	i := 1
 
 	if i < len(toks) && toks[i].Text == "(" {
@@ -193,23 +230,22 @@ func layoutExplain(toks []Token) []string {
 			i++
 		}
 	}
+	return prefix, trimTokens(toks[i:])
+}
 
-	// "explain" with nothing after it is not a statement we can improve on.
-	rest := trimTokens(toks[i:])
-	if len(rest) == 0 {
-		return []string{plainJoin(prefix)}
+// explainPayloadJoinsRiver reports whether the statement an EXPLAIN wraps is
+// one whose clauses form a single river the EXPLAIN line can be padded into.
+// WITH is excluded deliberately: formatQuerySegment gives a CTE list its own
+// per-CTE layout, with no top-level river to join.
+func explainPayloadJoinsRiver(rest []Token) bool {
+	if len(rest) == 0 || rest[0].Kind != TokKeyword {
+		return false
 	}
-
-	// plainJoin would render "explain(analyze)" -- spaceBetween treats "("
-	// after a name as a call, per STYLE.md rule 4. The option list is not a
-	// call, so the space goes in here.
-	head := prefix[0].Text
-	if len(prefix) > 1 {
-		head += " " + plainJoin(prefix[1:])
+	switch rest[0].Lower {
+	case "select", "insert", "update", "delete", "values", "table":
+		return true
 	}
-
-	lines := []string{head}
-	return append(lines, strings.Split(formatStatement(rest), "\n")...)
+	return false
 }
 
 // layoutCreateTable renders "create table name ( col ..., ... );" per

--- a/format/format.go
+++ b/format/format.go
@@ -132,6 +132,8 @@ func formatStatement(toks []Token) string {
 		lines = layoutCreateTable(body)
 	case "select", "insert", "update", "delete", "with":
 		lines = formatQuerySegment(body, 0)
+	case "explain":
+		lines = layoutExplain(body)
 	default:
 		lines = []string{flatJoin(body)}
 	}
@@ -146,6 +148,68 @@ func formatStatement(toks []Token) string {
 		out += commentMarker + trailingCommentText(tc)
 	}
 	return out
+}
+
+// layoutExplain renders EXPLAIN per STYLE.md rule 19: the EXPLAIN prefix
+// (with its option list, if any) alone on the first line, then the
+// statement it wraps formatted exactly as if it had been written on its
+// own -- its own clause river, unindented. That is what the corpus does in
+// 185 of 192 cases.
+//
+// Both spellings of the prefix are handled: the modern parenthesized option
+// list ("explain (analyze, buffers) select ...") and the legacy bare form
+// the grammar still accepts ("explain analyze verbose select ..."). ANALYZE
+// and VERBOSE are the only two words the legacy form allows, so consuming
+// exactly those is precise rather than a guess about where the inner
+// statement starts.
+//
+// The wrapped statement is dispatched back through formatStatement, which
+// is what makes "explain (analyze) execute p(1)" and "explain select ..."
+// each come out formatted the way that statement would be on its own.
+func layoutExplain(toks []Token) []string {
+	prefix := []Token{toks[0]}
+	i := 1
+
+	if i < len(toks) && toks[i].Text == "(" {
+		depth := 0
+		for ; i < len(toks); i++ {
+			if toks[i].Text == "(" {
+				depth++
+			} else if toks[i].Text == ")" {
+				depth--
+				if depth == 0 {
+					prefix = append(prefix, toks[i])
+					i++
+					break
+				}
+			}
+			if depth > 0 {
+				prefix = append(prefix, toks[i])
+			}
+		}
+	} else {
+		for i < len(toks) && (toks[i].Lower == "analyze" || toks[i].Lower == "verbose") {
+			prefix = append(prefix, toks[i])
+			i++
+		}
+	}
+
+	// "explain" with nothing after it is not a statement we can improve on.
+	rest := trimTokens(toks[i:])
+	if len(rest) == 0 {
+		return []string{plainJoin(prefix)}
+	}
+
+	// plainJoin would render "explain(analyze)" -- spaceBetween treats "("
+	// after a name as a call, per STYLE.md rule 4. The option list is not a
+	// call, so the space goes in here.
+	head := prefix[0].Text
+	if len(prefix) > 1 {
+		head += " " + plainJoin(prefix[1:])
+	}
+
+	lines := []string{head}
+	return append(lines, strings.Split(formatStatement(rest), "\n")...)
 }
 
 // layoutCreateTable renders "create table name ( col ..., ... );" per

--- a/format/layout.go
+++ b/format/layout.go
@@ -10,22 +10,29 @@ const targetWidth = 78
 var clauseWords = []struct {
 	words []string
 	name  string
+	// leadingOnly restricts the match to position 0 of the statement.
+	// EXPLAIN is only ever a statement prefix in PostgreSQL, so matching
+	// it anywhere else would split "select explain from t" -- a query
+	// against a column that happens to be named "explain" -- into two
+	// clauses.
+	leadingOnly bool
 }{
-	{[]string{"insert", "into"}, "insert into"},
-	{[]string{"on", "conflict"}, "on conflict"},
-	{[]string{"group", "by"}, "group by"},
-	{[]string{"order", "by"}, "order by"},
-	{[]string{"select"}, "select"},
-	{[]string{"from"}, "from"},
-	{[]string{"where"}, "where"},
-	{[]string{"having"}, "having"},
-	{[]string{"update"}, "update"},
-	{[]string{"set"}, "set"},
-	{[]string{"delete"}, "delete"},
-	{[]string{"returning"}, "returning"},
-	{[]string{"values"}, "values"},
-	{[]string{"limit"}, "limit"},
-	{[]string{"offset"}, "offset"},
+	{[]string{"explain"}, "explain", true},
+	{[]string{"insert", "into"}, "insert into", false},
+	{[]string{"on", "conflict"}, "on conflict", false},
+	{[]string{"group", "by"}, "group by", false},
+	{[]string{"order", "by"}, "order by", false},
+	{[]string{"select"}, "select", false},
+	{[]string{"from"}, "from", false},
+	{[]string{"where"}, "where", false},
+	{[]string{"having"}, "having", false},
+	{[]string{"update"}, "update", false},
+	{[]string{"set"}, "set", false},
+	{[]string{"delete"}, "delete", false},
+	{[]string{"returning"}, "returning", false},
+	{[]string{"values"}, "values", false},
+	{[]string{"limit"}, "limit", false},
+	{[]string{"offset"}, "offset", false},
 }
 
 type clauseSeg struct {
@@ -199,6 +206,9 @@ func splitClauses(toks []Token) []clauseSeg {
 			continue
 		}
 		for _, cw := range clauseWords {
+			if cw.leadingOnly && i != 0 {
+				continue
+			}
 			if matchWords(toks, i, cw.words) {
 				bounds = append(bounds, bound{idx: i, name: cw.name, kwEnd: i + len(cw.words)})
 				break
@@ -963,6 +973,12 @@ func formatQuerySegment(toks []Token, baseIndent int) []string {
 func fitsInline(segs []clauseSeg, baseIndent, width int) bool {
 	total := 0
 	for _, s := range segs {
+		// STYLE.md rule 19: the EXPLAIN prefix keeps a line of its own even
+		// when everything would otherwise fit on one, so the statement being
+		// explained still reads as a statement rather than as an argument.
+		if s.name == "explain" {
+			return false
+		}
 		if s.name == "from" {
 			for _, t := range s.body {
 				if t.Kind == TokKeyword && t.Lower == "join" {
@@ -1026,6 +1042,9 @@ func renderClause(s clauseSeg, baseIndent, width int) []string {
 	}
 
 	first := strings.Repeat(" ", kwCol) + kwText + " " + bodyLines[0]
+	// A clause with an empty body -- "explain" with no option list is the
+	// only one in practice -- would otherwise leave a trailing space.
+	first = strings.TrimRight(first, " ")
 	out := append(lead, first)
 	out = append(out, bodyLines[1:]...)
 	return out

--- a/format/lexer.go
+++ b/format/lexer.go
@@ -67,6 +67,7 @@ var keywords = buildKeywordSet([]string{
 	"cast", "language", "function", "returns", "true", "false",
 	"lateral", "only", "of", "to", "for",
 	"conflict", "do", "nothing", "constraint", "foreign", "materialized",
+	"explain",
 })
 
 func buildKeywordSet(words []string) map[string]bool {

--- a/testdata/corpus/explain-analyze-buffers.sql
+++ b/testdata/corpus/explain-analyze-buffers.sql
@@ -1,0 +1,4 @@
+explain (analyze, buffers)
+select res.raceid, res.driverid, res.positionorder, res.points
+  from f1db.results res
+ where res.points in (25, 18, 15, 12, 10, 8, 6, 4, 2, 1);

--- a/testdata/corpus/explain-analyze-buffers.sql
+++ b/testdata/corpus/explain-analyze-buffers.sql
@@ -1,4 +1,4 @@
 explain (analyze, buffers)
-select res.raceid, res.driverid, res.positionorder, res.points
-  from f1db.results res
- where res.points in (25, 18, 15, 12, 10, 8, 6, 4, 2, 1);
+ select res.raceid, res.driverid, res.positionorder, res.points
+   from f1db.results res
+  where res.points in (25, 18, 15, 12, 10, 8, 6, 4, 2, 1);

--- a/testdata/corpus/explain-costs-off-knn.sql
+++ b/testdata/corpus/explain-costs-off-knn.sql
@@ -1,4 +1,4 @@
-explain (costs off, buffers, analyze)
+ explain (costs off, buffers, analyze)
   select name, location, country
     from circuits
 order by position <-> point(2.349014, 48.864716);

--- a/testdata/corpus/explain-costs-off-knn.sql
+++ b/testdata/corpus/explain-costs-off-knn.sql
@@ -1,0 +1,4 @@
+explain (costs off, buffers, analyze)
+  select name, location, country
+    from circuits
+order by position <-> point(2.349014, 48.864716);

--- a/testdata/corpus/hyperloglog-05_01_tweets.hll.sql
+++ b/testdata/corpus/hyperloglog-05_01_tweets.hll.sql
@@ -1,7 +1,7 @@
 begin;
 
 with new_visitors as (
-       delete 
+       delete
          from tweet.visitor
         where id = any(
         select id
@@ -23,7 +23,7 @@ insert into tweet.uniques
      select messageid, date, visitors
        from new_visitor_groups
 on conflict (messageid, date) do
-     update 
+     update
         set visitors = hll_union(uniques.visitors, excluded.visitors)
       where uniques.messageid = excluded.messageid
         and uniques.date = excluded.date


### PR DESCRIPTION
EXPLAIN silently cost you every clause break in the query underneath it.

## The bug

`explain` was not in the keyword table, so it lexed as a bare identifier, `statementKeyword` returned `""`, and `formatStatement`'s `default` arm ran `flatJoin` over the whole statement. Same query, with and without the prefix:

```
  select driverid, forename, surname        explain select driverid, forename, surname from
    from f1db.drivers                       f1db.drivers where nationality = 'British' order
   where nationality = 'British'            by surname limit 10;
order by surname
   limit 10;
```

Exit status 0 either way, so nothing surfaced it — the SQL just came back on one line. It also normalised `explain (analyze, buffers)` to `explain(analyze, buffers)`.

## The change

`explain` becomes an entry in `clauseWords`. That is the whole design: `splitClauses` yields it as an ordinary segment whose body is the option list, `riverWidth` sizes the river with it included, and `renderClause` pads it. EXPLAIN is a clause keyword like `select` or `order by`, and aligns like one.

```sql
explain (analyze, buffers)
 select res.raceid, res.driverid, res.points
   from f1db.results res
  where res.points >= 10;
```

`explain` is 7 characters, so it sets the river there. Where the wrapped statement has a wider keyword, that one sets the river and the EXPLAIN line indents under it:

```sql
 explain (costs off, buffers, analyze)
  select name, location, country
    from circuits
order by position <-> point(2.349014, 48.864716);
```

A JOIN phrase wide enough to set the river (rule 9) moves it too. The option list is body, not keyword, so its length never widens the river — only the word `explain` does.

Three supporting changes fell out of it:

- **`clauseWords` entries gain a `leadingOnly` flag**, set only for EXPLAIN. It is only ever a statement prefix, and without the flag `select explain from t` — a query against a column named `explain` — split into two clauses. Caught by its own test.
- **`fitsInline` refuses to collapse** a statement containing an EXPLAIN segment, so the prefix keeps its line even when everything would fit on one. What is being explained should read as a statement, not as an argument.
- **`renderClause` trims the keyword/body separator when the body is empty.** That is `explain` with no option list — but it turned out bare `delete` and `update` were already emitting trailing whitespace, which `testdata/corpus/hyperloglog-05_01_tweets.hll.sql` had recorded as expected output. That fixture is regenerated here.

`layoutExplain` is left handling only the payloads with no top-level river to join — `EXECUTE`, and anything starting with `WITH` (whose CTE list has a layout of its own, rule 13) — keeping an unpadded prefix line plus the statement formatted as it would be alone.

Both spellings of the prefix are accepted: the parenthesized option list, and the legacy bare form the grammar still allows (`explain analyze verbose select ...`), preserved as written rather than rewritten, per rule 1.

## Style rule

Documented as STYLE.md rule 19, and DESIGN.md notes that EXPLAIN needs no layout code of its own in the common case.

## Tests

`format/explain_test.go` covers the river specifically: EXPLAIN setting the river, `order by`/`group by` setting it instead, a JOIN phrase widening it, long option lists *not* widening it, the legacy bare form, INSERT/UPDATE/DELETE payloads, the EXECUTE and WITH fallbacks, the always-break rule, absence of trailing whitespace, `explain` as a column name, and idempotency across all of the above. Two corpus fixtures added. Full suite green, `gofmt` clean.

## Validation

Ran over the 154 EXPLAIN files in TheArtOfPostgreSQL: all format without error, all idempotent.

On that corpus the round-trip count moves **425 → 416**, which looks like a regression and is not — it is the metric measuring "already in house style", against a style that just changed:

- 2 files that EXPLAIN used to mangle now round-trip.
- The rest are files whose EXPLAIN examples were hand-written flush-left, which is precisely the alignment this PR changes; and 6 previously-unformatted one-liners like `EXPLAIN select surname, laps, row_number() over(...) ...;` that only "passed" before because both sides were flat.

Worth a look during review: `where x between 2010 and 2017` is split across two lines, with `and` treated as a boolean conjunction rather than as part of `BETWEEN`. That is pre-existing and unrelated to EXPLAIN, but it shows up in EXPLAIN examples now that they format at all — happy to fix it here or separately, whichever you prefer.