### PR TITLE
Fix silent content loss, and lay expressions out with a pretty printer

### DIFF
--- a/STYLE.md
+++ b/STYLE.md
@@ -272,7 +272,14 @@ fixture's current content.
     (`primary key(...)`, `unique(...)`, `check(...)`) from the column list
     with one blank line. Closing `)` on its own line at the opening `(`'s
     indent, then `;`. Collapse to one line only for genuinely trivial tables
-    that fit under the line-length target (rule 17).
+    that fit under the line-length target (rule 17). A table constraint too
+    wide for one line puts its `REFERENCES` (and any `ON DELETE` / `CHECK` /
+    `DEFERRABLE`) on the next line, right-aligned against the constraint's
+    own keyword so both values start in the same column:
+    ```sql
+      foreign key (isocode, regcode, discode)
+       references geoname.district(isocode, regcode, discode)
+    ```
 
 17. **Line length**: soft target ≈ 78–80 characters, not hard-enforced
     (measured: only 2.5% of 3887 corpus lines exceed 70 chars, only 16
@@ -356,6 +363,57 @@ fixture's current content.
     anything starting with `WITH` (whose CTE list has a layout of its own,
     rule 13). Those keep an unpadded `EXPLAIN` line followed by the
     statement formatted as it would be on its own.
+
+20. **Breaking an expression at a binary operator**: when a value
+    expression is too wide, break at its loosest-binding top-level
+    operator — `||` first, then the JSON/containment operators, then
+    `+`/`-`, then `*`/`/`/`%`. The operator hangs into the gutter *left* of
+    the operands and every operand starts in the same column, the way
+    `AND`/`OR` sit under `WHERE`:
+    ```sql
+    select a_long_column_name
+        || '--------------------------'
+        || b_long_column
+    ```
+    Comparison operators (`=`, `<>`, `<` …) are break points in a
+    condition — a `WHERE`, a `JOIN … ON` — but not in a value: an
+    `UPDATE`'s `set x = case … end` is an assignment, and breaking at its
+    `=` gives the column a line of its own. `AND`/`OR` are never expression
+    break points; they belong to the clause river (rules 10, 9).
+    `BETWEEN … AND` breaks before `BETWEEN`, its `AND` being part of the
+    operator. Adjacent string literals are an implicit concatenation and
+    break like an operator with no symbol.
+
+21. **Aggregate `FILTER` / `WITHIN GROUP`**: short stays inline. Too wide,
+    the suffix takes its own line, right-aligned against the aggregate so
+    both argument lists start in the same column — the measure runs
+    *through* the open paren, since `within group (` carries a space before
+    its paren and `count(` does not:
+    ```sql
+            count(*)
+           filter(where milliseconds is null) as dnfs,
+           percentile_cont(array[0.5, 0.99])
+             within group (order by cts - ats) as parr
+    ```
+    `OVER` is not treated this way: a window frame has its own internal
+    clauses and keeps the layout in rule 14.
+
+22. **Statement-level DDL beyond `CREATE TABLE`**: `ALTER TABLE`,
+    `GRANT`/`REVOKE`, `CREATE DATABASE`, `ALTER DEFAULT PRIVILEGES` and a
+    partition definition each keep their header on the first line and put
+    one continuation clause per line, indented 2 — not rivered, their
+    clause keywords being too unlike in length for that to read well:
+    ```sql
+    create table lab.invoice_2022        alter table chinook.invoice
+      partition of lab.invoice_by_year     add constraint invoice_currency_notnull
+      for values from (2022) to (2023);        check (currency is not null)
+                                               not valid;
+    ```
+    A statement that fits stays whole: a clause word opening the statement
+    is not a continuation. One `ALTER TABLE` subcommand too wide by itself
+    breaks its own inner clauses under it at indent 6. `PREPARE` puts its
+    header on a line and hands the statement it prepares to the query
+    layout.
 
 ## Summary of genuinely ambiguous areas
 

--- a/format/alter.go
+++ b/format/alter.go
@@ -1,0 +1,87 @@
+package format
+
+// alterSubcommands are the keywords that open a subcommand in the
+// comma-separated list an ALTER TABLE carries. Everything before the first
+// one is the header -- "alter table [if exists] [only] name".
+var alterSubcommands = map[string]bool{
+	"add": true, "drop": true, "alter": true, "rename": true,
+	"set": true, "reset": true, "owner": true, "enable": true,
+	"disable": true, "validate": true, "attach": true, "detach": true,
+	"inherit": true, "no": true, "cluster": true, "replica": true,
+	"of": true, "not": true, "force": true, "options": true,
+}
+
+// layoutAlter lays out ALTER TABLE, whose payload is a comma-separated
+// list of subcommands -- exactly the shape layoutCommaList handles, but
+// which fell through to the flat default and produced the corpus's single
+// worst line, a 236-column ALTER with three "alter ... type ... using"
+// clauses on it.
+//
+// The corpus's own hand formatting is a header line with the subcommands
+// indented under it, one per line:
+//
+//	alter table chinook.invoice
+//	  add constraint invoice_currency_notnull
+//	      check (currency is not null)
+//	      not valid;
+//
+// and a short one stays whole: "alter table t add column c int;".
+func layoutAlter(toks []Token) []string {
+	if len(toks) < 2 || toks[1].Lower != "table" {
+		return flatStatementLines(toks)
+	}
+	if !hasLineComment(toks) {
+		if flat := flatJoin(toks); cols(flat) <= targetWidth-1 {
+			return []string{flat}
+		}
+	}
+	head := alterHeaderEnd(toks)
+	if head <= 0 || head >= len(toks) {
+		return flatStatementLines(toks)
+	}
+	items := splitTopLevelComma(trimTokens(toks[head:]))
+	if len(items) == 0 {
+		return flatStatementLines(toks)
+	}
+	lines := []string{flatJoin(toks[:head])}
+	for i, it := range items {
+		it = trimTokens(it)
+		if len(it) == 0 {
+			continue
+		}
+		trailing := trailingCommentSuffix(it)
+		sub := renderRun(it, 2)
+		comma := ","
+		if i == len(items)-1 {
+			comma = ""
+		}
+		lines = append(lines, "  "+sub[0]+comma+trailing)
+		lines = append(lines, sub[1:]...)
+	}
+	return lines
+}
+
+// alterHeaderEnd returns the index of the first subcommand token, i.e. the
+// end of "alter table [if exists] [only] name".
+func alterHeaderEnd(toks []Token) int {
+	i := 2 // past "alter table"
+	for i < len(toks) && (toks[i].Lower == "if" || toks[i].Lower == "exists" ||
+		toks[i].Lower == "only") {
+		i++
+	}
+	// The (possibly schema-qualified) table name, and an optional "*".
+	if i >= len(toks) {
+		return -1
+	}
+	i++
+	for i+1 < len(toks) && toks[i].Text == "." {
+		i += 2
+	}
+	if i < len(toks) && toks[i].Text == "*" {
+		i++
+	}
+	if i >= len(toks) || toks[i].Kind != TokKeyword || !alterSubcommands[toks[i].Lower] {
+		return -1
+	}
+	return i
+}

--- a/format/alter.go
+++ b/format/alter.go
@@ -27,6 +27,11 @@ var alterSubcommands = map[string]bool{
 //
 // and a short one stays whole: "alter table t add column c int;".
 func layoutAlter(toks []Token) []string {
+	if len(toks) > 2 && toks[1].Lower == "default" && toks[2].Lower == "privileges" {
+		if l, ok := layoutIndentedClauses(toks, defaultPrivClauses, 2); ok {
+			return l
+		}
+	}
 	if len(toks) < 2 || toks[1].Lower != "table" {
 		return flatStatementLines(toks)
 	}
@@ -51,6 +56,14 @@ func layoutAlter(toks []Token) []string {
 		}
 		trailing := trailingCommentSuffix(it)
 		sub := renderRun(it, 2)
+		// One subcommand can be too wide on its own -- "add constraint c
+		// check (...) not valid" is three lines by hand. Its inner clauses
+		// hang under the subcommand rather than under the statement.
+		if len(sub) == 1 && 2+cols(sub[0]) > targetWidth {
+			if l, ok := layoutIndentedClauses(it, alterInnerClauses, 6); ok && len(l) > 1 {
+				sub = l
+			}
+		}
 		comma := ","
 		if i == len(items)-1 {
 			comma = ""

--- a/format/binary.go
+++ b/format/binary.go
@@ -1,0 +1,108 @@
+package format
+
+// Top-level binary operators as break points.
+//
+// splitTopLevelConcat handled "||" and nothing else, so an expression
+// whose outermost structure was any other operator arrived at
+// exprAtomDoc as one unbreakable Text:
+//
+//	count(*) filter(where action = 'rt') - count(*) filter(where action = 'de-rt') as rts
+//
+// The "-" is the only sensible break in that line and the layer could not
+// see it. Splitting there is the single largest remaining source of
+// over-margin select-list items in the corpus.
+
+// binaryLevels are the operators to break at, lowest binding power first,
+// so a chain breaks at its loosest joint: "a - b * c" breaks at "-", not
+// at "*".
+//
+// "and"/"or" are deliberately absent. They are clause structure, and the
+// river above this layer already breaks a WHERE at them; competing for
+// the same break point would produce two different alignments for the
+// same operator. "::" is absent because a cast binds tighter than
+// anything here and splitTrailingCast peels it instead.
+var binaryLevels = [][]string{
+	{"||"},
+	{"+", "-"},
+	{"*", "/", "%"},
+}
+
+// predicateLevels adds comparison to binaryLevels, for a run the caller
+// knows is a condition rather than a value: a WHERE or a JOIN ... ON.
+//
+// Comparison cannot go in binaryLevels itself, because an UPDATE's
+//
+//	set de_favs = case when ... end
+//
+// is a select-list-shaped item whose "=" is clause structure, not an
+// operator: breaking there gives "de_favs" a line of its own under a
+// hanging "=", which is not what an assignment means. The two shapes are
+// indistinguishable from the tokens alone, so the caller, which knows
+// which clause it is in, picks the set.
+var predicateLevels = append([][]string{
+	{"=", "<>", "!=", "<", ">", "<=", ">="},
+}, binaryLevels...)
+
+// endsOperand reports whether t can be the last token of an operand, which
+// is what distinguishes a binary operator from a unary sign: the "-" in
+// "a - b" follows an identifier, the one in "(-1)" follows "(".
+func endsOperand(t Token) bool {
+	switch t.Kind {
+	case TokIdent, TokNumber, TokString, TokDollarString, TokParam:
+		return true
+	}
+	switch t.Text {
+	case ")", "]", "*":
+		return true
+	}
+	// "end" closes a CASE, and a keyword like "null" or "true" is a value.
+	return t.Kind == TokKeyword && (t.Lower == "end" || t.Lower == "null" ||
+		t.Lower == "true" || t.Lower == "false")
+}
+
+// splitTopLevelBinary cuts toks at every occurrence of the loosest-binding
+// operator present at paren depth zero, returning the operands and the
+// operators between them. CASE spans are stepped over whole: an operator
+// inside a branch belongs to that branch, and splitting there would leave
+// the CASE without its END.
+func splitTopLevelBinary(toks []Token, levels [][]string) ([][]Token, []string) {
+	for _, level := range levels {
+		want := make(map[string]bool, len(level))
+		for _, op := range level {
+			want[op] = true
+		}
+		var parts [][]Token
+		var ops []string
+		depth, start := 0, 0
+		for i := 0; i < len(toks); i++ {
+			t := toks[i]
+			if t.Kind == TokKeyword && t.Lower == "case" {
+				if end := matchCaseEnd(toks, i); end > i {
+					i = end
+					continue
+				}
+			}
+			switch t.Text {
+			case "(":
+				depth++
+				continue
+			case ")":
+				depth--
+				continue
+			}
+			if depth != 0 || !want[t.Text] || i == start {
+				continue
+			}
+			if !endsOperand(toks[i-1]) {
+				continue
+			}
+			parts = append(parts, toks[start:i])
+			ops = append(ops, t.Text)
+			start = i + 1
+		}
+		if len(parts) > 0 && start < len(toks) {
+			return append(parts, toks[start:]), ops
+		}
+	}
+	return nil, nil
+}

--- a/format/binary.go
+++ b/format/binary.go
@@ -23,6 +23,10 @@ package format
 // anything here and splitTrailingCast peels it instead.
 var binaryLevels = [][]string{
 	{"||"},
+	// The JSON/containment operators bind like comparison but appear in
+	// value position, where a "->" chain applied to a wide call was the
+	// only joint in a 96-column select-list item.
+	{"->", "->>", "#>", "#>>", "@>", "<@", "?", "?|", "?&", "-|-"},
 	{"+", "-"},
 	{"*", "/", "%"},
 }

--- a/format/binary_test.go
+++ b/format/binary_test.go
@@ -1,0 +1,166 @@
+package format
+
+import (
+	"strings"
+	"testing"
+)
+
+// operandCol returns the column each operand of a hanging-operator line
+// starts at, for lines whose first non-space token is the operator.
+func operandCol(line, op string) (int, bool) {
+	t := strings.TrimLeft(line, " ")
+	if !strings.HasPrefix(t, op+" ") {
+		return 0, false
+	}
+	return len(line) - len(t) + len(op) + 1, true
+}
+
+// A broken chain puts the operator in the gutter to the left and lines
+// every operand up under the first one, the way the river sets "and"
+// under "where". Putting the operator at the operand column instead
+// pushes each continuation operand right by the operator's width.
+func TestBinaryChainHangsOperatorLeft(t *testing.T) {
+	src := "select a_long_column_name || '--------------------------' || b_long_column || '----' as x from t;\n"
+	got := mustFormat(t, src)
+	first := -1
+	for _, l := range strings.Split(got, "\n") {
+		if strings.HasPrefix(l, "select ") {
+			first = len("select ")
+			continue
+		}
+		col, ok := operandCol(l, "||")
+		if !ok {
+			continue
+		}
+		if col != first {
+			t.Errorf("operand at column %d, want %d:\n%s", col, first, got)
+		}
+		if opCol := col - 3; opCol >= first {
+			t.Errorf("operator at column %d is not left of the operands:\n%s", opCol, got)
+		}
+	}
+	if strings.Count(got, "|| ") != 3 {
+		t.Errorf("chain not broken at every ||:\n%s", got)
+	}
+}
+
+// The chain breaks at its loosest joint: "a - b * c" is a subtraction of
+// a product, so it breaks at "-".
+func TestBinarySplitTakesLowestPrecedence(t *testing.T) {
+	toks, err := Lex([]byte("aaa - bbb * ccc"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	toks, _ = attachComments(toks)
+	parts, ops := splitTopLevelBinary(trimTokens(toks[:len(toks)-1]), binaryLevels)
+	if len(parts) != 2 || len(ops) != 1 || ops[0] != "-" {
+		t.Fatalf("split at %v into %d parts, want one split at -", ops, len(parts))
+	}
+}
+
+// A sign is not an operator: the "-" in "(-1)" and in "x = -1" follows a
+// token that cannot end an operand.
+func TestBinarySplitIgnoresUnarySign(t *testing.T) {
+	for _, src := range []string{"a, -1", "a = -1"} {
+		toks, err := Lex([]byte(src))
+		if err != nil {
+			t.Fatal(err)
+		}
+		toks, _ = attachComments(toks)
+		if parts, _ := splitTopLevelBinary(trimTokens(toks[:len(toks)-1]), binaryLevels); parts != nil {
+			t.Errorf("%q split at a unary sign into %d parts", src, len(parts))
+		}
+	}
+}
+
+// A comparison is a break point in a condition but not in a value: an
+// UPDATE's "set de_favs = case ... end" is an assignment, and hanging the
+// "=" gives the column a line of its own, which is not what it means.
+func TestComparisonSplitsOnlyInPredicates(t *testing.T) {
+	toks, _ := Lex([]byte("de_favs = case when x then 1 else 2 end"))
+	toks, _ = attachComments(toks)
+	body := trimTokens(toks[:len(toks)-1])
+	if parts, _ := splitTopLevelBinary(body, binaryLevels); parts != nil {
+		t.Errorf("value expression split at =: %d parts", len(parts))
+	}
+	if parts, _ := splitTopLevelBinary(body, predicateLevels); len(parts) != 2 {
+		t.Errorf("predicate did not split at =: %d parts", len(parts))
+	}
+}
+
+// A WHERE whose single predicate is too wide breaks at its comparison,
+// with the operator in the gutter and both operands aligned.
+func TestWherePredicateBreaksAtComparison(t *testing.T) {
+	src := "select 1 from races, decades" +
+		" where extract('year' from date_trunc('decade', races.race_date)) = decades.decade_start;\n"
+	got := mustFormat(t, src)
+	var body, cont int
+	for _, l := range strings.Split(got, "\n") {
+		if i := strings.Index(l, "where "); i >= 0 {
+			body = i + len("where ")
+		}
+		if c, ok := operandCol(l, "="); ok {
+			cont = c
+		}
+	}
+	if cont == 0 {
+		t.Fatalf("predicate not broken at the comparison:\n%s", got)
+	}
+	if cont != body {
+		t.Errorf("right operand at column %d, left at %d -- not aligned:\n%s", cont, body, got)
+	}
+}
+
+// A trailing cast leaves the run ending in a type name rather than ")",
+// which hid the call it wraps from the paren layout.
+func TestTrailingCastIsPeeled(t *testing.T) {
+	toks, _ := Lex([]byte("extract('year' from d)::int"))
+	toks, _ = attachComments(toks)
+	expr, cast := splitTrailingCast(trimTokens(toks[:len(toks)-1]))
+	if cast != "::int" {
+		t.Fatalf("cast = %q, want ::int", cast)
+	}
+	if last := expr[len(expr)-1].Text; last != ")" {
+		t.Errorf("expression ends in %q, want )", last)
+	}
+}
+
+// ALTER TABLE is a comma list of subcommands, and produced the corpus's
+// worst line -- a 236-column ALTER with three "alter ... type ... using".
+func TestAlterTableBreaksIntoSubcommands(t *testing.T) {
+	src := "alter table factbook alter shares type bigint using replace(shares, ',', '')::bigint," +
+		" alter trades type bigint using replace(trades, ',', '')::bigint;\n"
+	got := mustFormat(t, src)
+	if !strings.HasPrefix(got, "alter table factbook\n") {
+		t.Errorf("header not on its own line:\n%s", got)
+	}
+	if strings.Count(got, "\n  alter ") != 2 {
+		t.Errorf("subcommands not one per line at indent 2:\n%s", got)
+	}
+	for _, l := range strings.Split(got, "\n") {
+		if cols(l) > targetWidth {
+			t.Errorf("line still over the margin (%d):\n%s", cols(l), got)
+		}
+	}
+	// A short one is left whole.
+	short := mustFormat(t, "alter table t add column c int;\n")
+	if strings.Count(short, "\n") > 1 {
+		t.Errorf("short ALTER was broken up:\n%s", short)
+	}
+}
+
+// cols counts display columns, not bytes: a box-drawing rule well inside
+// the margin was being wrapped as if it were far past it.
+func TestColsCountsColumnsNotBytes(t *testing.T) {
+	rule := strings.Repeat("─", 60)
+	if cols(rule) != 60 {
+		t.Errorf("cols = %d, want 60", cols(rule))
+	}
+	if len(rule) != 180 {
+		t.Fatalf("test premise wrong: %d bytes", len(rule))
+	}
+	got := mustFormat(t, "-- "+rule+"\nselect 1;\n")
+	if !strings.Contains(got, rule) {
+		t.Errorf("rule was re-wrapped:\n%s", got)
+	}
+}

--- a/format/binary_test.go
+++ b/format/binary_test.go
@@ -180,7 +180,6 @@ func TestSoleArgumentHangs(t *testing.T) {
 // strands "(" on a line above a stray ")".
 func TestSoleArgumentDoesNotHangClauseOrGroupParens(t *testing.T) {
 	cases := []struct{ name, src string }{
-		{"over", "select rank() over(partition by constructorid order by position nulls last) as r, x from t;\n"},
 		{"within group", "select percentile_cont(array[0.5, 0.99]) within group (order by count) as pct from counts;\n"},
 		{"grouping paren", "select '<a>' || (-(((pos)[1] - proj.y0) * proj.scale) + (case when rn % 2 = 0 then 9 else -4 end))::text from p;\n"},
 	}
@@ -193,6 +192,50 @@ func TestSoleArgumentDoesNotHangClauseOrGroupParens(t *testing.T) {
 				}
 			}
 		})
+	}
+}
+
+// An OVER that fits stays on one line: the sole-argument path must not
+// reach for it just because the select list around it had to break.
+// When it does not fit, splitTrailingOver hands it to layoutOver, whose
+// own style aligns the frame under the paren -- that is a different path
+// and is covered by TestWideOverIsDeferredToLayoutOver.
+func TestFittingOverStaysOnOneLine(t *testing.T) {
+	got := mustFormat(t, "select a_column, rank() over(partition by c order by p) as r from t;\n")
+	if !strings.Contains(got, "rank() over(partition by c order by p) as r") {
+		t.Errorf("a fitting OVER was broken up:\n%s", got)
+	}
+}
+
+// "avg(x) over(...)" does not start with OVER, so deferredConstruct never
+// fired, and the paren logic rightly refuses to hang a clause paren --
+// which left the whole thing one unbreakable atom at 100 columns.
+func TestWideOverIsDeferredToLayoutOver(t *testing.T) {
+	src := "select avg(res.points) over(order by r.round rows between 2 preceding and current row)::numeric as running from results res;\n"
+	got := mustFormat(t, src)
+	if !strings.Contains(got, "avg(res.points) over(\n") {
+		t.Errorf("wide OVER not deferred:\n%s", got)
+	}
+	if !strings.Contains(got, ")::numeric as running") {
+		t.Errorf("cast and alias lost their place:\n%s", got)
+	}
+	for _, l := range strings.Split(got, "\n") {
+		if cols(l) > targetWidth {
+			t.Errorf("line still over the margin (%d):\n%s", cols(l), got)
+		}
+	}
+}
+
+// A fill packs items onto as few lines as fit, but once an item has
+// broken across lines it ends on a line of its own; packing the next item
+// after it runs two arguments together so they read as one.
+func TestFillBreaksAfterABrokenItem(t *testing.T) {
+	src := "select format('%s / %s', row_number() over(partition by constructorid order by position nulls last), count(*) over(partition by constructorid)) as p from t;\n"
+	got := mustFormat(t, src)
+	for _, l := range strings.Split(got, "\n") {
+		if strings.Contains(l, ")") && strings.Contains(l, ", count(*)") {
+			t.Errorf("next argument packed onto a broken item's last line:\n%s", got)
+		}
 	}
 }
 

--- a/format/binary_test.go
+++ b/format/binary_test.go
@@ -250,3 +250,68 @@ func TestAggregateSuffixKeywordsAreLowercased(t *testing.T) {
 		}
 	}
 }
+
+// A single-condition ON was inlined after the join phrase with no width
+// check at all. Too wide, it goes under the join keyword, river-aligned
+// with it, which is how the corpus writes it.
+func TestWideJoinConditionGoesUnderTheJoin(t *testing.T) {
+	src := "select 1 from tweet.users join tweet.users f on f.uname = substring(users.bio from 'in love with #?(.*).');\n"
+	got := mustFormat(t, src)
+	var joinCol, onCol int
+	for _, l := range strings.Split(got, "\n") {
+		if i := strings.Index(l, "join "); i >= 0 && joinCol == 0 {
+			joinCol = i + len("join ")
+		}
+		if i := strings.Index(l, "on "); i >= 0 && strings.HasPrefix(strings.TrimLeft(l, " "), "on ") {
+			onCol = i + len("on ")
+		}
+	}
+	if onCol == 0 {
+		t.Fatalf("wide ON not moved onto its own line:\n%s", got)
+	}
+	if onCol != joinCol {
+		t.Errorf("ON body at column %d, join body at %d -- not river-aligned:\n%s", onCol, joinCol, got)
+	}
+	// A short one still stays inline.
+	short := mustFormat(t, "select 1 from a join b on a.id = b.id;\n")
+	if !strings.Contains(short, "join b on a.id = b.id") {
+		t.Errorf("short ON was moved off the join line:\n%s", short)
+	}
+}
+
+// A FROM item's alias can carry a column list. Without peeling it,
+// lastTopLevelOpen picked the alias's own paren, so a wide
+// generate_series was left whole and "as t(date)" was hung instead.
+func TestTableAliasColumnListIsPeeled(t *testing.T) {
+	src := "select * from generate_series(date '2000-01-01', date '2010-01-01', interval '1 year') as t(date);\n"
+	got := mustFormat(t, src)
+	if !strings.Contains(got, ") as t(date)") {
+		t.Errorf("alias column list was broken instead of the call:\n%s", got)
+	}
+	if !strings.Contains(got, "generate_series(\n") {
+		t.Errorf("call did not hang its arguments:\n%s", got)
+	}
+}
+
+// The relations before the first JOIN are a comma list and get the same
+// one-item-per-line treatment SELECT's list gets.
+func TestWideFromListBreaksPerItem(t *testing.T) {
+	got := mustFormat(t, "select * from magic.cards, lateral jsonb_array_elements_text(data -> 'colors') as t(color);\n")
+	if !strings.Contains(got, "from magic.cards,\n") {
+		t.Errorf("FROM list not broken per item:\n%s", got)
+	}
+}
+
+// A "->" chain applied to a wide call was the only joint in a 96-column
+// item, and adjacent string literals are an implicit concatenation whose
+// join has no operator to mark it.
+func TestJSONOperatorAndAdjacentStringsBreak(t *testing.T) {
+	j := mustFormat(t, "select jsonb_insert(data, '{subtypes, 0}', '\"Elemental Dragon\"', true) -> 'subtypes' as appended from cards;\n")
+	if !strings.Contains(j, "\n    -> 'subtypes' as appended") {
+		t.Errorf("JSON operator not a break point:\n%s", j)
+	}
+	s := mustFormat(t, "select '\\draw[arr,bend right=10] (%s,%s)' ' to node[font=\\tiny] (%s,%s);' as tikz from arcs;\n")
+	if !strings.Contains(s, "'\n") {
+		t.Errorf("adjacent literals not broken:\n%s", s)
+	}
+}

--- a/format/binary_test.go
+++ b/format/binary_test.go
@@ -164,3 +164,46 @@ func TestColsCountsColumnsNotBytes(t *testing.T) {
 		t.Errorf("rule was re-wrapped:\n%s", got)
 	}
 }
+
+// A call with a single wide argument has to be able to hang it, or it has
+// nowhere to break at all.
+func TestSoleArgumentHangs(t *testing.T) {
+	src := "select jsonb_strip_nulls(jsonb_build_object('cmc', data ->> 'cmc', 'power', data -> 'power', 'toughness', data -> 'toughness')) as stats from cards;\n"
+	got := mustFormat(t, src)
+	if !strings.Contains(got, "jsonb_strip_nulls(\n") {
+		t.Errorf("sole argument did not hang:\n%s", got)
+	}
+}
+
+// The three shapes that must NOT hang: a clause paren has a good one-line
+// form of its own, and a grouping paren has no callee, so hanging it
+// strands "(" on a line above a stray ")".
+func TestSoleArgumentDoesNotHangClauseOrGroupParens(t *testing.T) {
+	cases := []struct{ name, src string }{
+		{"over", "select rank() over(partition by constructorid order by position nulls last) as r, x from t;\n"},
+		{"within group", "select percentile_cont(array[0.5, 0.99]) within group (order by count) as pct from counts;\n"},
+		{"grouping paren", "select '<a>' || (-(((pos)[1] - proj.y0) * proj.scale) + (case when rn % 2 = 0 then 9 else -4 end))::text from p;\n"},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			got := mustFormat(t, c.src)
+			for _, l := range strings.Split(got, "\n") {
+				if strings.HasSuffix(strings.TrimRight(l, " "), "(") {
+					t.Errorf("paren left hanging on its own line:\n%s", got)
+				}
+			}
+		})
+	}
+}
+
+// "filter" and "within" are keywords, so rule 1 lowercases both words of
+// each construct rather than only the one that happened to be in the
+// table -- "WITHIN GROUP" used to come out as "WITHIN group".
+func TestAggregateSuffixKeywordsAreLowercased(t *testing.T) {
+	got := mustFormat(t, "select percentile_cont(0.5) WITHIN GROUP (ORDER BY x), count(*) FILTER (WHERE y > 0) from t;\n")
+	for _, want := range []string{"within group (order by x)", "filter(where y > 0)"} {
+		if !strings.Contains(got, want) {
+			t.Errorf("want %q in:\n%s", want, got)
+		}
+	}
+}

--- a/format/case_test.go
+++ b/format/case_test.go
@@ -1,0 +1,111 @@
+package format
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+)
+
+// caseFmt formats src and fails the test on error.
+func caseFmt(t *testing.T, src string) string {
+	t.Helper()
+	got, err := Format(bytes.NewReader([]byte(src)))
+	if err != nil {
+		t.Fatalf("Format(%q) error: %v", src, err)
+	}
+	return got
+}
+
+// TestSimpleCaseKeepsItsBody is a regression test for silent data loss: a
+// *simple* CASE (one with an operand between "case" and the first "when")
+// that was too long to render inline came out as "case end" -- operand,
+// every WHEN/THEN branch, and the ELSE all dropped, with no error and exit
+// status 0.
+//
+// layoutCase's when-loop only advances while it is looking at a "when", so
+// for "case <operand> when ..." it never started; i stayed at 1 and every
+// token up to "end" was skipped.
+func TestSimpleCaseKeepsItsBody(t *testing.T) {
+	// Long enough that layoutCase takes the multi-line path rather than
+	// returning the flat one-liner.
+	src := "select case name when 'AAAAAAAAAAAAAAAAAAAA' then 'first value here' else 'second value here' end as label, count(*) from t group by name;"
+	got := caseFmt(t, src)
+
+	if strings.Contains(got, "case end") || strings.Contains(got, "case\n") && !strings.Contains(got, "when") {
+		t.Fatalf("CASE body was dropped:\n%s", got)
+	}
+	for _, want := range []string{"name", "'AAAAAAAAAAAAAAAAAAAA'", "'first value here'", "'second value here'"} {
+		if !strings.Contains(got, want) {
+			t.Errorf("lost %q from the CASE expression:\n%s", want, got)
+		}
+	}
+}
+
+// TestSimpleCaseOperandOnCaseLine pins the layout, not just the survival of
+// the tokens: the operand belongs on the "case" line, with WHEN/THEN/ELSE
+// under it exactly as they are for a searched CASE.
+func TestSimpleCaseOperandOnCaseLine(t *testing.T) {
+	src := "select case grouping(drivers.driverid) when 1 then '<all drivers>' else drivers.surname end as driver, sum(points) as points from results group by rollup(drivers.driverid);"
+	got := caseFmt(t, src)
+	want := "case grouping (drivers.driverid)\n"
+	if !strings.Contains(got, want) {
+		t.Errorf("operand not on the case line (want %q):\n%s", want, got)
+	}
+	for _, frag := range []string{"when 1", "then '<all drivers>'", "else drivers.surname"} {
+		if !strings.Contains(got, frag) {
+			t.Errorf("missing %q:\n%s", frag, got)
+		}
+	}
+}
+
+// TestSearchedCaseUnchanged guards the form that already worked.
+func TestSearchedCaseUnchanged(t *testing.T) {
+	src := "select case when name = 'AAAAAAAAAAAAAAAAAAAA' then 'first value here' else 'second value here' end as label, count(*) from t group by name;"
+	got := caseFmt(t, src)
+	if !strings.Contains(got, "case\n") {
+		t.Errorf("searched CASE should keep a bare \"case\" line:\n%s", got)
+	}
+	for _, frag := range []string{"when name = 'AAAAAAAAAAAAAAAAAAAA'", "then 'first value here'", "else 'second value here'"} {
+		if !strings.Contains(got, frag) {
+			t.Errorf("missing %q:\n%s", frag, got)
+		}
+	}
+}
+
+// TestShortCaseStaysInline: the flat path is unaffected by the fix, per
+// STYLE.md rule 15.
+func TestShortCaseStaysInline(t *testing.T) {
+	got := caseFmt(t, "select case a when 1 then 'x' else 'y' end as label from t;")
+	if strings.Count(strings.TrimRight(got, "\n"), "\n") != 0 {
+		t.Errorf("short CASE should stay on one line:\n%s", got)
+	}
+}
+
+// TestSimpleCaseIdempotent: the multi-line output must survive a re-format,
+// which is what the fix's own layout is then parsed back as.
+func TestSimpleCaseIdempotent(t *testing.T) {
+	srcs := []string{
+		"select case name when 'AAAAAAAAAAAAAAAAAAAA' then 'first value here' else 'second value here' end as label, count(*) from t group by name;",
+		"select case grouping(d.id) when 1 then '<all drivers>' else d.surname end as driver from r;",
+		"select case when a = 1 then 'AAAAAAAAAAAAAAAAAAAAAAAAAAAA' else 'BBBBBBBBBBBBBBBBBBBBBBBBBB' end from t;",
+	}
+	for _, src := range srcs {
+		once := caseFmt(t, src)
+		twice := caseFmt(t, once)
+		if once != twice {
+			t.Errorf("not idempotent for %q:\nfirst:\n%s\nsecond:\n%s", src, once, twice)
+		}
+	}
+}
+
+// TestNestedSimpleCase: an operand containing parens must not confuse the
+// top-level "when" scan.
+func TestNestedSimpleCase(t *testing.T) {
+	src := "select case coalesce(a, (select max(b) from u)) when 1 then 'first value here' else 'second value here' end as label from t;"
+	got := caseFmt(t, src)
+	for _, frag := range []string{"coalesce", "select max(b)", "when 1", "else 'second value here'"} {
+		if !strings.Contains(got, frag) {
+			t.Errorf("missing %q:\n%s", frag, got)
+		}
+	}
+}

--- a/format/comment_loss_test.go
+++ b/format/comment_loss_test.go
@@ -1,0 +1,124 @@
+package format
+
+import (
+	"strings"
+	"testing"
+)
+
+// PostgreSQL's lexer puts the whole high-byte range in its identifier
+// classes (scan.l: ident_start [A-Za-z\200-\377_]), so an accented
+// identifier is one token. Scanning it byte by byte spelled it back out
+// with a space between every byte.
+func TestNonASCIIIdentifierSurvives(t *testing.T) {
+	for _, src := range []string{
+		"select prénom, âge from personne where prénom = 'Zoé';\n",
+		"select \"Ünïcode\".hôtel from \"Ünïcode\";\n",
+		"create table café (naïveté int);\n",
+	} {
+		got := mustFormat(t, src)
+		for _, want := range strings.Fields(strings.Map(func(r rune) rune {
+			if r == ',' || r == ';' || r == '(' || r == ')' {
+				return ' '
+			}
+			return r
+		}, src)) {
+			if !strings.Contains(got, want) {
+				t.Errorf("Format(%q) lost %q:\n%s", src, want, got)
+			}
+		}
+	}
+}
+
+// A "--" comment cannot share a line with the tokens after it: whatever
+// follows would be inside the comment. renderRun breaks the line for that
+// reason, but flatJoin used to join those lines back with a space.
+func TestLineCommentNeverSwallowsCode(t *testing.T) {
+	cases := []struct{ name, src string }{
+		{"select list", "select a, -- pick a\n       b\n  from t;\n"},
+		{"after comma", "select aaaa, -- why\n       bbbb\n  from t;\n"},
+		{"ddl", "create sequence s -- counter\n  start 10;\n"},
+		{"index paren", "create index on t (a) -- speed\n where b is not null;\n"},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			got := mustFormat(t, c.src)
+			for _, line := range strings.Split(got, "\n") {
+				i := strings.Index(line, "--")
+				if i < 0 {
+					continue
+				}
+				// Everything past the marker is comment text; no SQL may
+				// hide there. The tokens we care about are alphanumeric
+				// runs that appear in the source outside the comment.
+				if rest := line[i:]; strings.Contains(rest, ";") {
+					t.Errorf("statement terminator inside a comment: %q\n%s", line, got)
+				}
+			}
+			if !strings.Contains(got, "--") {
+				t.Errorf("comment dropped entirely:\n%s", got)
+			}
+		})
+	}
+}
+
+// A comment trailing on a separating comma belongs to no item, so the
+// item-boundary check never saw it and splitTopLevelComma dropped the
+// comma -- and the comment with it.
+func TestCommentOnSeparatorSurvives(t *testing.T) {
+	src := "select aaaa, -- first\n       bbbb, -- second\n       cccc\n  from t;\n"
+	got := mustFormat(t, src)
+	for _, want := range []string{"-- first", "-- second"} {
+		if !strings.Contains(got, want) {
+			t.Errorf("lost %q:\n%s", want, got)
+		}
+	}
+}
+
+// The comma separating two column definitions is part of the statement, so
+// it has to be emitted before any trailing comment. Appending it after put
+// the comma inside the comment, which is a syntax error.
+func TestCreateTableCommaPrecedesComment(t *testing.T) {
+	src := "create table t (\n  id bigserial primary key, -- the key\n  name text not null, -- who\n  ts timestamptz\n);\n"
+	got := mustFormat(t, src)
+	for _, line := range strings.Split(got, "\n") {
+		i := strings.Index(line, "--")
+		if i >= 0 && strings.Contains(line[i:], ",") {
+			t.Errorf("comma swallowed by comment: %q\n%s", line, got)
+		}
+	}
+	if !strings.Contains(got, "primary key,") || !strings.Contains(got, "not null,") {
+		t.Errorf("column comma missing:\n%s", got)
+	}
+}
+
+// Block comments nest in PostgreSQL. Reflowing one as prose rewrites the
+// inner "/*" and "*/", which moves where the comment ends and pulls the
+// SQL after it inside.
+func TestNestedBlockCommentKeptVerbatim(t *testing.T) {
+	src := "select 1;\n/*\n/*\n\n*/\n***/\nselect 2;\n"
+	got := mustFormat(t, src)
+	if !strings.Contains(got, "***/") {
+		t.Errorf("nested comment terminator lost:\n%s", got)
+	}
+	if !strings.Contains(got, "select 2") {
+		t.Errorf("SQL after the nested comment lost:\n%s", got)
+	}
+}
+
+// A CREATE VIEW's body is a query and goes back through the query layout,
+// which handles comments properly. Handing the whole statement to
+// renderRun because of one comment inside that body flattened a rivered
+// view into a single line.
+func TestDDLWithQueryBodyKeepsItsLayout(t *testing.T) {
+	src := "create or replace view v as\n" +
+		"select a,\n       b\n  from t\n where a is not null -- keep\n   and b > 0;\n"
+	got := mustFormat(t, src)
+	if !strings.Contains(got, "-- keep") {
+		t.Errorf("comment dropped:\n%s", got)
+	}
+	for _, line := range strings.Split(got, "\n") {
+		if len(line) > targetWidth {
+			t.Errorf("view flattened past the margin: %q\n%s", line, got)
+		}
+	}
+}

--- a/format/comments.go
+++ b/format/comments.go
@@ -204,22 +204,22 @@ func formatBlockComment(c Token, indent int) []string {
 func wrapWords(words []string, indent int, prefix string) []string {
 	var lines []string
 	var cur []string
-	curLen := indent + len(prefix)
+	curLen := indent + cols(prefix)
 	for _, w := range words {
-		add := len(w)
+		add := cols(w)
 		if len(cur) > 0 {
 			add++ // separating space
 		}
 		if curLen+add > commentWidth && len(cur) > 0 {
 			lines = append(lines, strings.Repeat(" ", indent)+prefix+strings.Join(cur, " "))
 			cur = nil
-			curLen = indent + len(prefix)
+			curLen = indent + cols(prefix)
 		}
 		if len(cur) > 0 {
 			curLen++
 		}
 		cur = append(cur, w)
-		curLen += len(w)
+		curLen += cols(w)
 	}
 	if len(cur) > 0 {
 		lines = append(lines, strings.Repeat(" ", indent)+prefix+strings.Join(cur, " "))
@@ -260,15 +260,15 @@ func alignTrailingComments(text string) string {
 		maxLen := 0
 		for j < len(lines) && strings.Contains(lines[j], commentMarker) {
 			content := strings.SplitN(lines[j], commentMarker, 2)[0]
-			if len(content) > maxLen {
-				maxLen = len(content)
+			if cols(content) > maxLen {
+				maxLen = cols(content)
 			}
 			j++
 		}
 		col := maxLen + 2
 		for k := i; k < j; k++ {
 			parts := strings.SplitN(lines[k], commentMarker, 2)
-			pad := col - len(parts[0])
+			pad := col - cols(parts[0])
 			if pad < 1 {
 				pad = 1
 			}

--- a/format/comments.go
+++ b/format/comments.go
@@ -143,6 +143,24 @@ func formatLineComment(c Token, indent int) []string {
 // formatter on its own output is a no-op.
 func formatBlockComment(c Token, indent int) []string {
 	inner := strings.TrimSuffix(strings.TrimPrefix(c.Text, "/*"), "*/")
+	// A comment whose body carries its own "/*" or "*/" is a nested
+	// comment (PostgreSQL nests them), and reflowing it as prose rewrites
+	// those markers -- stripping a leading "*", re-wrapping a line so a
+	// "*/" splits across the break -- which changes where the comment ends
+	// and pulls the SQL after it inside. Its exact bytes are the only
+	// rendering that is guaranteed to still mean the same thing.
+	if strings.Contains(inner, "/*") || strings.Contains(inner, "*/") {
+		pad := strings.Repeat(" ", indent)
+		var out []string
+		for i, l := range strings.Split(c.Text, "\n") {
+			if i == 0 {
+				out = append(out, pad+l)
+				continue
+			}
+			out = append(out, l)
+		}
+		return out
+	}
 	out := []string{strings.Repeat(" ", indent) + "/*"}
 
 	var para []string

--- a/format/comments.go
+++ b/format/comments.go
@@ -117,9 +117,19 @@ func formatLineComment(c Token, indent int) []string {
 	if isDashOnly(c.Text) {
 		return []string{strings.Repeat(" ", indent) + c.Text}
 	}
-	content := strings.TrimSpace(strings.TrimPrefix(c.Text, "--"))
+	body := strings.TrimPrefix(c.Text, "--")
+	content := strings.TrimSpace(body)
 	if content == "" {
 		return []string{strings.Repeat(" ", indent) + "--"}
+	}
+	// A comment whose text is itself indented is laid out on purpose --
+	// an EXPLAIN plan sketch, an ASCII diagram, a column of aligned
+	// values -- and reflowing it to the width destroys the only thing it
+	// was communicating. Reflow prose, which starts right after the
+	// "-- "; preserve anything indented further, the same way a dash-only
+	// divider is preserved above.
+	if strings.HasPrefix(body, "  ") {
+		return []string{strings.Repeat(" ", indent) + "--" + strings.TrimRight(body, " \t")}
 	}
 	return wrapWords(strings.Fields(content), indent, "-- ")
 }

--- a/format/dataloss_test.go
+++ b/format/dataloss_test.go
@@ -216,3 +216,28 @@ func TestAllFixesIdempotent(t *testing.T) {
 		}
 	}
 }
+
+// TestParenthesizedSetOperationArms: "(select ...) except (select ...)" has
+// every clause keyword at depth 1, so splitClauses found none and the whole
+// arm came back as one flat line -- 434 columns in the worst corpus case.
+func TestParenthesizedSetOperationArms(t *testing.T) {
+	src := "(select d.surname from results res join races r on r.raceid = res.raceid where r.year = 2016 and res.positionorder = 1) except (select d.surname from results res join races r on r.raceid = res.raceid where r.year = 2017 and res.positionorder = 1) order by surname;"
+	got := mustFormat(t, src)
+	if squash(got) != squash(src) {
+		t.Errorf("content changed:\n%s", got)
+	}
+	if n := strings.Count(got, "\n(select"); n < 1 {
+		t.Errorf("arms not formatted as queries:\n%s", got)
+	}
+	if !strings.Contains(got, "\nexcept\n") {
+		t.Errorf("set operator not on its own line:\n%s", got)
+	}
+	if !strings.HasSuffix(strings.TrimRight(got, "\n"), "order by surname;") {
+		t.Errorf("trailing ORDER BY lost or misplaced:\n%s", got)
+	}
+	for _, l := range strings.Split(got, "\n") {
+		if len(l) > 90 {
+			t.Errorf("line over 90 columns:\n%s", l)
+		}
+	}
+}

--- a/format/dataloss_test.go
+++ b/format/dataloss_test.go
@@ -1,0 +1,218 @@
+package format
+
+import (
+	"bytes"
+	"regexp"
+	"strings"
+	"testing"
+)
+
+func mustFormat(t *testing.T, src string) string {
+	t.Helper()
+	got, err := Format(bytes.NewReader([]byte(src)))
+	if err != nil {
+		t.Fatalf("Format(%q) error: %v", src, err)
+	}
+	return got
+}
+
+// squash reduces SQL to the part a reformat must never change: comments
+// out, all whitespace out, case folded. Two strings that differ after this
+// differ in content, not in layout.
+func squash(s string) string {
+	s = regexp.MustCompile(`(?s)/\*.*?\*/`).ReplaceAllString(s, " ")
+	s = regexp.MustCompile(`--[^\n]*`).ReplaceAllString(s, " ")
+	return strings.ToLower(strings.Join(strings.Fields(s), ""))
+}
+
+// TestNoContentLost is the regression net for a family of bugs that all had
+// the same shape: the formatter reached a construct it did not model, and
+// silently dropped the tokens it could not place. Exit status 0, valid-
+// looking output, missing SQL. Each case below lost something before the
+// fixes in this commit.
+func TestNoContentLost(t *testing.T) {
+	cases := []struct {
+		name string
+		src  string
+		lost string // a fragment that used to disappear
+	}{
+		{
+			"simple CASE that has to wrap",
+			"select case name when 'AAAAAAAAAAAAAAAAAAAA' then 'first value here' else 'second value here' end as label, count(*) from t group by name;",
+			"'first value here'",
+		},
+		{
+			"WITH ... AS MATERIALIZED",
+			"with x as materialized (select 1 as n) select n from x;",
+			"select 1 as n",
+		},
+		{
+			"WITH ... AS NOT MATERIALIZED",
+			"with x as not materialized (select 1 as n) select n from x;",
+			"not materialized",
+		},
+		{
+			"recursive CTE CYCLE clause",
+			"with recursive b(i, p) as (select 1, '{}'::int[] union all select i+1, p from b where i < 4) cycle i set is_cycle using path select * from b;",
+			"cycle i set is_cycle using path",
+		},
+		{
+			"CREATE TABLE ... PARTITION BY",
+			"create table t (a int, b int) partition by range (a);",
+			"partition by range",
+		},
+		{
+			"CREATE TABLE ... INHERITS",
+			"create table t (a int) inherits (parent);",
+			"inherits",
+		},
+		{
+			"CREATE TABLE ... PARTITION OF",
+			"create table t_2020 partition of t for values from (2020) to (2021);",
+			"to (2021)",
+		},
+		{
+			"CREATE TABLE ... AS SELECT",
+			"create table t as select a, b from other where c = 1;",
+			"where c = 1",
+		},
+		{
+			"EXCEPT ALL keeps its ALL",
+			"select a from t except all select a from u;",
+			"except all",
+		},
+		{
+			"INTERSECT ALL keeps its ALL",
+			"select a from t intersect all select a from u;",
+			"intersect all",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := mustFormat(t, tc.src)
+			if squash(got) != squash(tc.src) {
+				t.Errorf("content changed:\nin:  %s\nout: %s\n(squashed in:  %s)\n(squashed out: %s)",
+					tc.src, got, squash(tc.src), squash(got))
+			}
+			if !strings.Contains(strings.ToLower(strings.Join(strings.Fields(got), " ")), tc.lost) {
+				t.Errorf("lost %q from the output:\n%s", tc.lost, got)
+			}
+		})
+	}
+}
+
+// TestSetOperatorModifiers: ALL and DISTINCT belong to the set operator, not
+// to the query after it. Only UNION used to consume them, so "except all"
+// rendered as an "except" line followed by a stray "all select ..." -- and
+// dropping the ALL silently changes which rows the query returns.
+func TestSetOperatorModifiers(t *testing.T) {
+	for _, op := range []string{"union", "intersect", "except"} {
+		for _, mod := range []string{"", " all", " distinct"} {
+			src := "select a from t " + op + mod + " select a from u;"
+			got := mustFormat(t, src)
+			want := op + mod
+			if !strings.Contains(got, want+"\n") {
+				t.Errorf("%q: expected a %q line, got:\n%s", src, want, got)
+			}
+		}
+	}
+}
+
+// TestBetweenIsOnePredicate: the "and" in BETWEEN joins two bounds of a
+// single predicate and must not be treated as a boolean conjunction.
+func TestBetweenIsOnePredicate(t *testing.T) {
+	src := "select res.raceid, res.driverid, res.points, res.positionorder from f1db.results res where res.year between 2010 and 2017 and res.points > 0;"
+	got := mustFormat(t, src)
+	if !strings.Contains(got, "where res.year between 2010 and 2017\n") {
+		t.Errorf("BETWEEN split across lines:\n%s", got)
+	}
+	if !strings.Contains(got, "and res.points > 0") {
+		t.Errorf("the real conjunction was lost:\n%s", got)
+	}
+}
+
+// TestWindowClausesEachOnTheirOwnLine covers STYLE.md rule 14. layoutOver
+// searched for ORDER BY in the tokens *before* PARTITION BY -- empty for the
+// usual "over(partition by x order by y)" -- so it never split: the whole
+// window spec went out on one line and only the ")" moved down, leaving an
+// over-long line with an orphaned paren under it.
+func TestWindowClausesEachOnTheirOwnLine(t *testing.T) {
+	src := "select driverid, sum(points) over (partition by driverid order by raceid rows between unbounded preceding and current row) as running from results;"
+	got := mustFormat(t, src)
+	for _, want := range []string{
+		"over(\n",
+		"partition by driverid\n",
+		"order by raceid\n",
+		"rows between unbounded preceding and current row\n",
+	} {
+		if !strings.Contains(got, want) {
+			t.Errorf("missing %q:\n%s", want, got)
+		}
+	}
+	for _, l := range strings.Split(got, "\n") {
+		if len(l) > 90 {
+			t.Errorf("line over 90 columns:\n%s", l)
+		}
+	}
+}
+
+// TestWindowOrderByOnly / TestWindowPartitionByOnly: the split must work
+// with either clause missing.
+func TestWindowOrderByOnly(t *testing.T) {
+	got := mustFormat(t, "select x, array_agg(x) over (order by x rows between unbounded preceding and current row) as agg from t;")
+	if !strings.Contains(got, "order by x\n") || !strings.Contains(got, "rows between unbounded preceding and current row\n") {
+		t.Errorf("ORDER BY and frame not split:\n%s", got)
+	}
+}
+
+func TestWindowPartitionByOnly(t *testing.T) {
+	got := mustFormat(t, "select x, count(*) over (partition by aaaaaaaaaaaaaaaaaaaa, bbbbbbbbbbbbbbbbbbbb, cccccccccccccccccccc) as n from t;")
+	if !strings.Contains(got, "partition by") {
+		t.Errorf("PARTITION BY lost:\n%s", got)
+	}
+}
+
+// TestIndentedCommentsPreserved: a comment whose text is itself indented is
+// laid out on purpose -- an EXPLAIN plan sketch, an ASCII diagram -- and
+// reflowing it to the width destroys the only thing it communicated. Prose
+// comments still reflow.
+func TestIndentedCommentsPreserved(t *testing.T) {
+	src := "-- Limit\n--    -> Index Scan using idx on t\n--         Filter: (a = 1)\nselect a from t;\n"
+	got := mustFormat(t, src)
+	for _, want := range []string{"--    -> Index Scan using idx on t", "--         Filter: (a = 1)"} {
+		if !strings.Contains(got, want) {
+			t.Errorf("comment indentation lost (want %q):\n%s", want, got)
+		}
+	}
+}
+
+func TestProseCommentsStillReflow(t *testing.T) {
+	src := "-- a normal prose comment that is long enough that it really ought to be reflowed by the formatter to the target width\nselect a from t;\n"
+	got := mustFormat(t, src)
+	if strings.Count(got, "--") < 2 {
+		t.Errorf("prose comment was not reflowed:\n%s", got)
+	}
+}
+
+// TestAllFixesIdempotent: every construct above must survive a second pass
+// unchanged, since the pre-filter this feeds re-runs over its own output.
+func TestAllFixesIdempotent(t *testing.T) {
+	srcs := []string{
+		"select case name when 'AAAAAAAAAAAAAAAAAAAA' then 'first value here' else 'second value here' end as label from t;",
+		"with x as materialized (select 1 as n) select n from x;",
+		"with recursive b(i, p) as (select 1, '{}'::int[] union all select i+1, p from b where i < 4) cycle i set is_cycle using path select * from b;",
+		"create table t (a int, b int) partition by range (a);",
+		"create table t as select a, b from other where c = 1;",
+		"select a from t except all select a from u;",
+		"select res.raceid from f1db.results res where res.year between 2010 and 2017 and res.points > 0;",
+		"select driverid, sum(points) over (partition by driverid order by raceid rows between unbounded preceding and current row) as running from results;",
+		"-- Limit\n--    -> Index Scan using idx on t\nselect a from t;\n",
+	}
+	for _, src := range srcs {
+		once := mustFormat(t, src)
+		twice := mustFormat(t, once)
+		if once != twice {
+			t.Errorf("not idempotent for %q:\nfirst:\n%s\nsecond:\n%s", src, once, twice)
+		}
+	}
+}

--- a/format/ddl_test.go
+++ b/format/ddl_test.go
@@ -157,3 +157,43 @@ func TestTaggedDollarQuoteBody(t *testing.T) {
 		t.Errorf("tagged delimiter not preserved:\n%s", got)
 	}
 }
+
+// TestMultiAssignmentSetDoesNotCascade: a SET with several assignments is a
+// comma list. renderRun walked it inline instead, so the first assignment
+// that had to wrap -- a CASE, typically -- wrapped from wherever it
+// happened to start, and every assignment after it began deeper still. Four
+// CASE expressions turned into a 130-column staircase.
+func TestMultiAssignmentSetDoesNotCascade(t *testing.T) {
+	src := "update twcache.daily_counters set rts = case when NEW.action = 'rt' then rts + 1 else rts end, de_rts = case when NEW.action = 'de-rt' then de_rts + 1 else de_rts end, favs = case when NEW.action = 'fav' then favs + 1 else favs end where daily_counters.day = current_date;"
+	got := ddlFmt(t, src)
+
+	// Every assignment starts at the same column.
+	var cols []int
+	for _, l := range strings.Split(got, "\n") {
+		for _, name := range []string{"rts = case", "de_rts = case", "favs = case"} {
+			if idx := strings.Index(l, name); idx >= 0 && strings.HasPrefix(strings.TrimSpace(l), name) {
+				cols = append(cols, idx)
+			}
+		}
+	}
+	for i := 1; i < len(cols); i++ {
+		if cols[i] != cols[0] {
+			t.Errorf("assignments do not share a column (%v):\n%s", cols, got)
+			break
+		}
+	}
+	for _, l := range strings.Split(got, "\n") {
+		if len(l) > 90 {
+			t.Errorf("line over 90 columns:\n%s", l)
+		}
+	}
+}
+
+// TestSingleAssignmentSetUnchanged: the one-assignment form still renders
+// inline, and the row form still breaks at its operator.
+func TestSingleAssignmentSetUnchanged(t *testing.T) {
+	got := ddlFmt(t, "update t set a = 1 where id = 2;")
+	if !strings.Contains(got, "set a = 1") {
+		t.Errorf("single assignment changed shape:\n%s", got)
+	}
+}

--- a/format/ddl_test.go
+++ b/format/ddl_test.go
@@ -115,3 +115,55 @@ func TestDDLIdempotent(t *testing.T) {
 		}
 	}
 }
+
+// TestRowAssignmentBreaksAtTheOperator: "set (a, ...) = (x, ...)" and the
+// row comparison "(a, ...) <> (x, ...)" both run to a couple of hundred
+// columns with no useful break point inside either list. The break has to
+// be at the operator, which is a clause-level decision renderRun cannot
+// make from inside the expression -- 246 columns before this.
+func TestRowAssignmentBreaksAtTheOperator(t *testing.T) {
+	src := "update moma.artist set (name, bio, nationality, gender, begin, \"end\", wiki_qid, ulan) = (batch.name, batch.bio, batch.nationality, batch.gender, batch.begin, batch.\"end\", batch.wiki_qid, batch.ulan) from batch where batch.constituentid = artist.constituentid;"
+	got := ddlFmt(t, src)
+	if !strings.Contains(got, "\n  = (batch.name") && !strings.Contains(got, "= (batch.name") {
+		t.Errorf("no break at the operator:\n%s", got)
+	}
+	for _, l := range strings.Split(got, "\n") {
+		if len(l) > 90 {
+			t.Errorf("line over 90 columns:\n%s", l)
+		}
+	}
+}
+
+// TestFillKeepsListsCompact: a wrapped list is filled, not exploded one
+// item per line -- it should still read as a list.
+func TestFillKeepsListsCompact(t *testing.T) {
+	src := "update t set (alpha, bravo, charlie, delta, echo, foxtrot, golf, hotel) = (one, two, three, four, five, six, seven, eight) where id = 1;"
+	got := ddlFmt(t, src)
+	for _, l := range strings.Split(got, "\n") {
+		if strings.Count(l, ",") == 1 && strings.Contains(l, "one") {
+			t.Errorf("list exploded one item per line:\n%s", got)
+		}
+	}
+}
+
+// TestFunctionCallArgsNotWrapped: rule 4's no-space-before-"(" marks a
+// function call, and the corpus keeps long calls on one line -- breaking
+// their arguments reads worse than the overflow.
+func TestFunctionCallArgsNotWrapped(t *testing.T) {
+	got := ddlFmt(t, "select st_transscale(st_intersection(r.geom, win.env), -proj.x0, -proj.y0, proj.scale, proj.scale) as geom from r;")
+	if strings.Contains(got, "st_transscale(\n") {
+		t.Errorf("function call arguments were wrapped:\n%s", got)
+	}
+}
+
+// TestTaggedDollarQuoteBody: dollar-quote matching uses the lexer's own
+// rules, so a $tag$ body containing a "$" is split correctly.
+func TestTaggedDollarQuoteBody(t *testing.T) {
+	got := ddlFmt(t, "create function f(x int) returns int language sql as $body$ select x+1 from t where y = '$notatag$'; $body$;")
+	if !strings.Contains(got, "'$notatag$'") {
+		t.Errorf("body content lost:\n%s", got)
+	}
+	if !strings.Contains(got, "as $body$\n") {
+		t.Errorf("tagged delimiter not preserved:\n%s", got)
+	}
+}

--- a/format/ddl_test.go
+++ b/format/ddl_test.go
@@ -136,13 +136,34 @@ func TestFillKeepsListsCompact(t *testing.T) {
 	}
 }
 
-// TestFunctionCallArgsNotWrapped: rule 4's no-space-before-"(" marks a
-// function call, and the corpus keeps long calls on one line -- breaking
-// their arguments reads worse than the overflow.
-func TestFunctionCallArgsNotWrapped(t *testing.T) {
+// TestFunctionCallArgsFillWhenTooWide: a call that overflows the target has
+// its arguments filled -- packed onto as few lines as fit, not exploded one
+// per line. Three greedy attempts at this each improved some files and
+// regressed others; the Doc layer decides the whole group at once instead.
+func TestFunctionCallArgsFillWhenTooWide(t *testing.T) {
 	got := ddlFmt(t, "select st_transscale(st_intersection(r.geom, win.env), -proj.x0, -proj.y0, proj.scale, proj.scale) as geom from r;")
-	if strings.Contains(got, "st_transscale(\n") {
-		t.Errorf("function call arguments were wrapped:\n%s", got)
+	for _, l := range strings.Split(got, "\n") {
+		if len(l) > 80 {
+			t.Errorf("line over the target:\n%s", got)
+		}
+	}
+	// Filled, not one per line: at least one line carries several args.
+	packed := false
+	for _, l := range strings.Split(got, "\n") {
+		if strings.Count(l, ",") >= 2 {
+			packed = true
+		}
+	}
+	if !packed {
+		t.Errorf("arguments were exploded one per line rather than filled:\n%s", got)
+	}
+}
+
+// TestShortCallStaysInline: a call that fits is untouched.
+func TestShortCallStaysInline(t *testing.T) {
+	got := ddlFmt(t, "select coalesce(a, b, c) as x from t;")
+	if strings.Contains(got, "coalesce(\n") {
+		t.Errorf("short call was wrapped:\n%s", got)
 	}
 }
 

--- a/format/ddl_test.go
+++ b/format/ddl_test.go
@@ -244,3 +244,39 @@ func TestTrailingLanguageStillFound(t *testing.T) {
 		t.Errorf("trailing LANGUAGE not hoisted:\n%s", got)
 	}
 }
+
+// TestInsertColumnListFills: an INSERT column list is not a function call's
+// argument list, but it looks exactly like one -- it follows an identifier
+// directly -- so renderRun's paren handling declined to break it per rule 4
+// and a wide list ran off the page. Only the clause knows better.
+func TestInsertColumnListFills(t *testing.T) {
+	src := "insert into twcache.daily_counters (day, rts, de_rts, favs, de_favs, mentions, replies, quotes) values (1,2,3,4,5,6,7,8);"
+	got := ddlFmt(t, src)
+	if squash(got) != squash(src) {
+		t.Errorf("content changed:\n%s", got)
+	}
+	for _, l := range strings.Split(got, "\n") {
+		if len(l) > 90 {
+			t.Errorf("line over 90 columns:\n%s", l)
+		}
+	}
+	if !strings.Contains(got, "de_favs, mentions,\n") && !strings.Contains(got, "mentions,\n") {
+		t.Errorf("column list did not fill across lines:\n%s", got)
+	}
+}
+
+// TestShortInsertUnchanged: the break is width-driven.
+func TestShortInsertUnchanged(t *testing.T) {
+	got := ddlFmt(t, "insert into t (a, b) values (1, 2);")
+	if strings.Count(strings.TrimRight(got, "\n"), "\n") > 1 {
+		t.Errorf("short INSERT should not be broken up:\n%s", got)
+	}
+}
+
+// TestInsertWithoutColumnList: nothing to fill, and no crash looking.
+func TestInsertWithoutColumnList(t *testing.T) {
+	got := ddlFmt(t, "insert into t select a, b from u;")
+	if squash(got) != squash("insert into t select a, b from u;") {
+		t.Errorf("content changed:\n%s", got)
+	}
+}

--- a/format/ddl_test.go
+++ b/format/ddl_test.go
@@ -1,0 +1,117 @@
+package format
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+)
+
+func ddlFmt(t *testing.T, src string) string {
+	t.Helper()
+	got, err := Format(bytes.NewReader([]byte(src)))
+	if err != nil {
+		t.Fatalf("Format(%q): %v", src, err)
+	}
+	return got
+}
+
+// TestDDLHeadersAreLaidOut: everything except CREATE TABLE used to fall
+// through to flatJoin, putting a whole DDL header on one line -- 138
+// columns for a hand-written four-line CREATE FUNCTION.
+func TestDDLHeadersAreLaidOut(t *testing.T) {
+	cases := []struct {
+		name, src string
+		want      []string
+	}{
+		{
+			"create function",
+			"create or replace function twcache.tg_notify_counters() returns trigger language plpgsql as $$ begin end; $$;",
+			[]string{"create or replace function twcache.tg_notify_counters()\n", " returns trigger\n", "language plpgsql\n"},
+		},
+		{
+			"create index",
+			"create index if not exists geoname_class_p_isocode on geoname.geoname (isocode) where class = 'P';",
+			[]string{"create index if not exists geoname_class_p_isocode\n", "   on geoname.geoname(isocode)\n", "where class = 'P';"},
+		},
+		{
+			"create trigger",
+			"CREATE TRIGGER update_counters AFTER INSERT ON tweet.activity FOR EACH ROW EXECUTE PROCEDURE twcache.tg_update();",
+			[]string{"create trigger update_counters\n", "  after insert\n", "     on tweet.activity\n", "    for each row\n"},
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := ddlFmt(t, tc.src)
+			for _, w := range tc.want {
+				if !strings.Contains(got, w) {
+					t.Errorf("missing %q:\n%s", w, got)
+				}
+			}
+			for _, l := range strings.Split(got, "\n") {
+				if len(l) > 90 {
+					t.Errorf("line over 90 columns:\n%s", l)
+				}
+			}
+		})
+	}
+}
+
+// TestShortDDLStaysInline: the break is width-driven, per rule 17.
+func TestShortDDLStaysInline(t *testing.T) {
+	got := ddlFmt(t, "create index i on t (a);")
+	if strings.Count(strings.TrimRight(got, "\n"), "\n") != 0 {
+		t.Errorf("short DDL should stay on one line:\n%s", got)
+	}
+}
+
+// TestLanguageHoistedIntoHeader: PostgreSQL accepts a function's options in
+// any order, and "as $$ ... $$ language plpgsql" buries the language behind
+// the whole body.
+func TestLanguageHoistedIntoHeader(t *testing.T) {
+	got := ddlFmt(t, "create function f() returns trigger as $$ declare x int; begin return new; end; $$ language plpgsql;")
+	langAt := strings.Index(got, "language plpgsql")
+	asAt := strings.Index(got, "as $$")
+	if langAt == -1 || asAt == -1 {
+		t.Fatalf("clauses missing:\n%s", got)
+	}
+	if langAt > asAt {
+		t.Errorf("language still after the body:\n%s", got)
+	}
+}
+
+// TestLanguageSQLBodyIsFormatted: the body of a LANGUAGE SQL function is
+// SQL, so it gets the same layout as any other statement.
+func TestLanguageSQLBodyIsFormatted(t *testing.T) {
+	got := ddlFmt(t, "create function top_albums(x int) returns setof record language sql as $$ select a.title, count(*) as n from album a where a.artist_id=x group by a.title order by n desc limit 5; $$;")
+	for _, w := range []string{"  select a.title, count(*) as n\n", "    from album a\n", "group by a.title\n"} {
+		if !strings.Contains(got, w) {
+			t.Errorf("body not formatted (missing %q):\n%s", w, got)
+		}
+	}
+}
+
+// TestNonSQLBodiesUntouched: a plpgsql body is opaque to this formatter and
+// must be passed through exactly as written.
+func TestNonSQLBodiesUntouched(t *testing.T) {
+	body := "\ndeclare\n  channel text := TG_ARGV[0];\nbegin\n  PERFORM 1;\n  return NEW;\nend;\n"
+	got := ddlFmt(t, "create function f() returns trigger language plpgsql as $$"+body+"$$;")
+	if !strings.Contains(got, body) {
+		t.Errorf("plpgsql body was altered:\n%s", got)
+	}
+}
+
+func TestDDLIdempotent(t *testing.T) {
+	srcs := []string{
+		"create or replace function f() returns trigger language plpgsql as $$ begin end; $$;",
+		"create index if not exists i on t (a) where b = 'x';",
+		"CREATE TRIGGER tr AFTER INSERT ON t FOR EACH ROW EXECUTE PROCEDURE f();",
+		"create function g(x int) returns int language sql as $$ select x + 1; $$;",
+		"create function h() returns trigger as $$ begin end; $$ language plpgsql;",
+	}
+	for _, src := range srcs {
+		once := ddlFmt(t, src)
+		if twice := ddlFmt(t, once); once != twice {
+			t.Errorf("not idempotent for %q:\nfirst:\n%s\nsecond:\n%s", src, once, twice)
+		}
+	}
+}

--- a/format/ddl_test.go
+++ b/format/ddl_test.go
@@ -280,3 +280,69 @@ func TestInsertWithoutColumnList(t *testing.T) {
 		t.Errorf("content changed:\n%s", got)
 	}
 }
+
+// TestDDLClauseListFills: an index's column list and a statistics kind list
+// are call-shaped -- "using btree(a, b, ...)" -- so renderRun leaves them
+// alone per rule 4 and a wide one overflows. Only the clause knows it is a
+// list.
+func TestDDLClauseListFills(t *testing.T) {
+	src := "create index concurrently if not exists chinook_invoice_line_covering_idx on chinook.invoice_line using btree (invoice_id, track_id, unit_price, quantity, invoice_line_id, created_at, updated_at);"
+	got := ddlFmt(t, src)
+	if squash(got) != squash(src) {
+		t.Errorf("content changed:\n%s", got)
+	}
+	for _, l := range strings.Split(got, "\n") {
+		if len(l) > 85 {
+			t.Errorf("line over 85 columns:\n%s", l)
+		}
+	}
+	if !strings.Contains(got, "using btree(") {
+		t.Errorf("index method lost:\n%s", got)
+	}
+}
+
+// TestDDLBareCommaListFills covers the other shape: "on col, col, col" with
+// no parens at all.
+func TestDDLBareCommaListFills(t *testing.T) {
+	src := "create statistics if not exists geoname_multi_column_stats (dependencies, ndistinct, mcv) on isocode, class, feature, population, name, latitude, longitude from geoname.geoname;"
+	got := ddlFmt(t, src)
+	if squash(got) != squash(src) {
+		t.Errorf("content changed:\n%s", got)
+	}
+	for _, l := range strings.Split(got, "\n") {
+		if len(l) > 85 {
+			t.Errorf("line over 85 columns:\n%s", l)
+		}
+	}
+}
+
+// TestLateralSubqueryNotFlattened: layoutFrom rendered a JOIN's table
+// expression with flatJoin, which joins renderRun's output with spaces --
+// so a LATERAL subquery, which renderRun lays out across several lines, was
+// folded back onto the JOIN line and ran to hundreds of columns.
+func TestLateralSubqueryNotFlattened(t *testing.T) {
+	src := `select d.surname as driver, top3.race
+  from f1db.drivers d
+  join lateral (
+      select r.name as race, res.points
+        from f1db.results res
+        join f1db.races r on r.raceid = res.raceid
+       where res.driverid = d.driverid and r.year = 2017
+       order by res.points desc
+       limit 3
+  ) top3 on true
+ where d.surname in ('Hamilton', 'Vettel')
+ order by d.surname;`
+	got := ddlFmt(t, src)
+	if squash(got) != squash(src) {
+		t.Errorf("content changed:\n%s", got)
+	}
+	for _, l := range strings.Split(got, "\n") {
+		if len(l) > 90 {
+			t.Errorf("line over 90 columns:\n%s", l)
+		}
+	}
+	if !strings.Contains(got, "join lateral (\n") {
+		t.Errorf("lateral subquery was flattened onto the JOIN line:\n%s", got)
+	}
+}

--- a/format/ddl_test.go
+++ b/format/ddl_test.go
@@ -197,3 +197,50 @@ func TestSingleAssignmentSetUnchanged(t *testing.T) {
 		t.Errorf("single assignment changed shape:\n%s", got)
 	}
 }
+
+// TestCreateViewKeepsItsQuery: a view is its query. layoutDDL scanned the
+// payload for its own clause words, so a view's SELECT was chopped up at
+// its own FROM/AS/ON and most of it dropped -- 1344 characters of SQL in,
+// 355 out, on the corpus file that found this.
+func TestCreateViewKeepsItsQuery(t *testing.T) {
+	src := `create or replace view v as
+with recursive deps as (
+  select a.id as obj_id, b.name as obj_name from t a join u b on b.id = a.id where a.k in ('v', 'm')
+  union all
+  select p.id, p.name from deps p join t x on x.id = p.id where x.k in ('v', 'm')
+)
+select depth, obj_name as dependent from deps group by depth, obj_name;`
+	got := ddlFmt(t, src)
+	if squash(got) != squash(src) {
+		t.Errorf("content changed:\nin:  %s\nout: %s", squash(src), squash(got))
+	}
+	if !strings.Contains(got, "create or replace view v as\n") {
+		t.Errorf("view header not on its own line:\n%s", got)
+	}
+	if !strings.Contains(got, "\nwith recursive deps as (") {
+		t.Errorf("payload not formatted as a query:\n%s", got)
+	}
+}
+
+// TestCreateViewWithFromInPayload is the narrow case: FROM is a DDL clause
+// word too, and a view's payload is full of them.
+func TestCreateViewWithFromInPayload(t *testing.T) {
+	src := "create view v as select a, b from t where c = 1 order by a;"
+	got := ddlFmt(t, src)
+	if squash(got) != squash(src) {
+		t.Errorf("content changed:\n%s", got)
+	}
+}
+
+// TestTrailingLanguageStillFound: scanning has to resume after a
+// dollar-quoted body -- that is where a trailing LANGUAGE clause lives --
+// while still stopping at a view's query payload.
+func TestTrailingLanguageStillFound(t *testing.T) {
+	// Long enough to break across lines: a DDL statement that fits on one
+	// stays there per rule 17, and there is then nothing to reorder.
+	got := ddlFmt(t, "create or replace function chinook.album_duration(album_id bigint) returns interval as $$ select sum(milliseconds) * interval '1ms' from track where track.album_id = album_duration.album_id; $$ language sql;")
+	langAt, asAt := strings.Index(got, "language sql"), strings.Index(got, "as $$")
+	if langAt == -1 || asAt == -1 || langAt > asAt {
+		t.Errorf("trailing LANGUAGE not hoisted:\n%s", got)
+	}
+}

--- a/format/ddl_test.go
+++ b/format/ddl_test.go
@@ -90,16 +90,6 @@ func TestLanguageSQLBodyIsFormatted(t *testing.T) {
 	}
 }
 
-// TestNonSQLBodiesUntouched: a plpgsql body is opaque to this formatter and
-// must be passed through exactly as written.
-func TestNonSQLBodiesUntouched(t *testing.T) {
-	body := "\ndeclare\n  channel text := TG_ARGV[0];\nbegin\n  PERFORM 1;\n  return NEW;\nend;\n"
-	got := ddlFmt(t, "create function f() returns trigger language plpgsql as $$"+body+"$$;")
-	if !strings.Contains(got, body) {
-		t.Errorf("plpgsql body was altered:\n%s", got)
-	}
-}
-
 func TestDDLIdempotent(t *testing.T) {
 	srcs := []string{
 		"create or replace function f() returns trigger language plpgsql as $$ begin end; $$;",

--- a/format/ddlclause.go
+++ b/format/ddlclause.go
@@ -44,6 +44,15 @@ var (
 	defaultPrivClauses = []clauseStarter{
 		{"in", "schema"}, {"grant"}, {"revoke"}, {"on"}, {"to"}, {"from"},
 	}
+	// A table constraint that does not fit puts its REFERENCES (and any
+	// action clauses) on the next line, one step further in:
+	//
+	//	foreign key (isocode, regcode, discode)
+	//	  references geoname.district(isocode, regcode, discode),
+	constraintClauses = []clauseStarter{
+		{"references"}, {"on", "delete"}, {"on", "update"}, {"check"},
+		{"deferrable"}, {"not", "deferrable"}, {"initially"}, {"match"},
+	}
 	// Inside one ALTER TABLE subcommand: "add constraint c check (...) not
 	// valid" is three lines by hand, not one.
 	alterInnerClauses = []clauseStarter{

--- a/format/ddlclause.go
+++ b/format/ddlclause.go
@@ -1,0 +1,121 @@
+package format
+
+import "strings"
+
+// Statement-level DDL whose continuation clauses the corpus writes
+// indented under the header rather than rivered.
+//
+// layoutDDL's river suits CREATE FUNCTION and CREATE INDEX, where the
+// clause keywords are short and of similar length. These statements are
+// written differently by hand:
+//
+//	create table lab.invoice_2022
+//	  partition of lab.invoice_by_year
+//	  for values from (2022) to (2023);
+//
+//	create database chinook_prod
+//	  owner chinook_owner
+//	  encoding 'UTF8'
+//
+//	grant select (invoice_id, customer_id, invoice_date,
+//	              billing_address, billing_city, total)
+//	  on chinook.invoice to chinook_ro;
+//
+// so they get the same shape: header, then one clause per line at indent
+// 2. Without any of this they fell to flatJoin -- the GRANT above came
+// back as a single 205-column line, and the partitioned tables at 95-96
+// columns each.
+
+// clauseStarter is a sequence of words that opens a continuation clause.
+type clauseStarter []string
+
+var (
+	partitionClauses = []clauseStarter{
+		{"partition", "of"}, {"for", "values"}, {"default"}, {"tablespace"},
+	}
+	databaseClauses = []clauseStarter{
+		{"owner"}, {"template"}, {"encoding"}, {"strategy"}, {"locale"},
+		{"lc_collate"}, {"lc_ctype"}, {"tablespace"}, {"allow_connections"},
+		{"connection", "limit"}, {"is_template"}, {"oid"},
+	}
+	grantClauses = []clauseStarter{
+		{"on"}, {"to"}, {"from"}, {"with", "grant", "option"}, {"granted", "by"},
+	}
+	defaultPrivClauses = []clauseStarter{
+		{"in", "schema"}, {"grant"}, {"revoke"}, {"on"}, {"to"}, {"from"},
+	}
+	// Inside one ALTER TABLE subcommand: "add constraint c check (...) not
+	// valid" is three lines by hand, not one.
+	alterInnerClauses = []clauseStarter{
+		{"check"}, {"not", "valid"}, {"using"}, {"references"},
+		{"for", "values"}, {"default"},
+	}
+)
+
+// matchesAt reports whether cs's words sit at toks[i:].
+func (cs clauseStarter) matchesAt(toks []Token, i int) bool {
+	if i+len(cs) > len(toks) {
+		return false
+	}
+	for k, w := range cs {
+		if toks[i+k].Lower != w {
+			return false
+		}
+	}
+	return true
+}
+
+// clauseIndexes returns the token indexes at paren depth zero where one of
+// starts begins, skipping index 0 -- a clause word that opens the
+// statement is part of its header, not a continuation.
+func clauseIndexes(toks []Token, starts []clauseStarter) []int {
+	var out []int
+	depth := 0
+	for i := range toks {
+		switch toks[i].Text {
+		case "(":
+			depth++
+			continue
+		case ")":
+			depth--
+			continue
+		}
+		if depth != 0 || i == 0 {
+			continue
+		}
+		for _, cs := range starts {
+			if cs.matchesAt(toks, i) {
+				out = append(out, i)
+				break
+			}
+		}
+	}
+	return out
+}
+
+// layoutIndentedClauses renders toks as a header line followed by one
+// clause per line at the given indent, or as a single line when it fits.
+func layoutIndentedClauses(toks []Token, starts []clauseStarter, indent int) ([]string, bool) {
+	toks = trimTokens(toks)
+	if !hasLineComment(toks) {
+		if flat := flatJoin(toks); cols(flat) <= targetWidth-1 {
+			return []string{flat}, true
+		}
+	}
+	idx := clauseIndexes(toks, starts)
+	if len(idx) == 0 {
+		return nil, false
+	}
+	pad := strings.Repeat(" ", indent)
+	lines := renderRun(toks[:idx[0]], 0)
+	for n, at := range idx {
+		end := len(toks)
+		if n+1 < len(idx) {
+			end = idx[n+1]
+		}
+		sub := renderRun(trimTokens(toks[at:end]), indent)
+		lines = append(lines, pad+sub[0])
+		lines = append(lines, sub[1:]...)
+	}
+	return lines, true
+}

--- a/format/ddlclause.go
+++ b/format/ddlclause.go
@@ -102,6 +102,72 @@ func clauseIndexes(toks []Token, starts []clauseStarter) []int {
 	return out
 }
 
+// headerName is the run of leading keywords that names the construct --
+// "foreign key", "primary key", "unique", "constraint" -- i.e. what comes
+// before its first value.
+func headerName(toks []Token) string {
+	n := 0
+	for n < len(toks) && toks[n].Kind == TokKeyword {
+		n++
+	}
+	if n == 0 {
+		return ""
+	}
+	return plainJoin(toks[:n])
+}
+
+// layoutRiverClauses is layoutIndentedClauses with the clause keywords
+// right-aligned instead of indented, so that every clause's value starts
+// at the same column -- the river the rest of the tool uses:
+//
+//	foreign key (isocode, regcode, discode)
+//	 references geoname.district(isocode, regcode, discode)
+//
+// "references" is one column further left than "foreign key" precisely so
+// that "geoname" lands under the "(", rather than under "isocode".
+func layoutRiverClauses(toks []Token, starts []clauseStarter, indent int) ([]string, bool) {
+	toks = trimTokens(toks)
+	idx := clauseIndexes(toks, starts)
+	if len(idx) == 0 {
+		return nil, false
+	}
+	head := headerName(toks[:idx[0]])
+	if head == "" {
+		return nil, false
+	}
+	river := cols(head)
+	names := make([]string, len(idx))
+	for n, at := range idx {
+		end := len(toks)
+		if n+1 < len(idx) {
+			end = idx[n+1]
+		}
+		names[n] = headerName(toks[at:end])
+		if names[n] == "" {
+			return nil, false
+		}
+		if w := cols(names[n]); w > river {
+			river = w
+		}
+	}
+	pad := func(name string) string {
+		return strings.Repeat(" ", indent+river-cols(name)) + name
+	}
+	lines := []string{pad(head) + " " + flatJoin(toks[len(strings.Fields(head)):idx[0]])}
+	for n, at := range idx {
+		end := len(toks)
+		if n+1 < len(idx) {
+			end = idx[n+1]
+		}
+		body := trimTokens(toks[at+len(strings.Fields(names[n])) : end])
+		bodyCol := indent + river + 1
+		sub := renderRun(body, bodyCol)
+		lines = append(lines, pad(names[n])+" "+sub[0])
+		lines = append(lines, sub[1:]...)
+	}
+	return lines, true
+}
+
 // layoutIndentedClauses renders toks as a header line followed by one
 // clause per line at the given indent, or as a single line when it fits.
 func layoutIndentedClauses(toks []Token, starts []clauseStarter, indent int) ([]string, bool) {

--- a/format/ddlclause_test.go
+++ b/format/ddlclause_test.go
@@ -160,21 +160,17 @@ func TestAggregateSuffixIsRiverAligned(t *testing.T) {
 	checked := 0
 	for i, l := range lines {
 		body := strings.TrimLeft(l, " ")
-		var kw string
-		switch {
-		case strings.HasPrefix(body, "filter("):
-			kw = "filter"
-		case strings.HasPrefix(body, "within group "):
-			kw = "within group"
-		default:
+		if !strings.HasPrefix(body, "filter(") && !strings.HasPrefix(body, "within group ") {
 			continue
 		}
 		checked++
-		aggEnd := strings.Index(lines[i-1], "(")
-		kwEnd := len(l) - len(body) + len(kw)
-		if aggEnd != kwEnd {
-			t.Errorf("%q ends at %d, its aggregate name at %d -- not aligned:\n%s",
-				kw, kwEnd, aggEnd, got)
+		// The open parens are what must line up, not the names: "within
+		// group (" carries a space before its paren and "count(" does not.
+		aggParen := strings.Index(lines[i-1], "(")
+		kwParen := strings.Index(l, "(")
+		if aggParen != kwParen {
+			t.Errorf("suffix paren at %d, aggregate paren at %d -- not aligned:\n%s",
+				kwParen, aggParen, got)
 		}
 	}
 	if checked != 2 {

--- a/format/ddlclause_test.go
+++ b/format/ddlclause_test.go
@@ -75,3 +75,27 @@ func TestDDLVocabularyIsLowercased(t *testing.T) {
 		}
 	}
 }
+
+// A constraint's continuation keywords are right-aligned, not indented,
+// so every clause's value starts at the same column: "geoname" lands
+// under the "(" of the key it qualifies, not under "isocode".
+func TestConstraintClausesAreRiverAligned(t *testing.T) {
+	src := "create table geoname.city (id int, isocode text, regcode text, discode text," +
+		" foreign key (isocode, regcode, discode) references geoname.district(isocode, regcode, discode));\n"
+	got := mustFormat(t, src)
+	var keyCol, refCol int
+	for _, l := range strings.Split(got, "\n") {
+		if i := strings.Index(l, "foreign key ("); i >= 0 {
+			keyCol = i + len("foreign key ")
+		}
+		if i := strings.Index(l, "references "); i >= 0 {
+			refCol = i + len("references ")
+		}
+	}
+	if keyCol == 0 || refCol == 0 {
+		t.Fatalf("constraint not broken:\n%s", got)
+	}
+	if keyCol != refCol {
+		t.Errorf("values at columns %d and %d, want them aligned:\n%s", keyCol, refCol, got)
+	}
+}

--- a/format/ddlclause_test.go
+++ b/format/ddlclause_test.go
@@ -99,3 +99,86 @@ func TestConstraintClausesAreRiverAligned(t *testing.T) {
 		t.Errorf("values at columns %d and %d, want them aligned:\n%s", keyCol, refCol, got)
 	}
 }
+
+// PREPARE's payload is a statement, and went through flatJoin -- one
+// 144-column line carrying a complete SELECT.
+func TestPrepareHandsItsBodyToTheQueryLayout(t *testing.T) {
+	src := "prepare foo as select date, shares, trades, dollars from factbook" +
+		" where date >= $1::date and date < $1::date + interval '1 month' order by date;\n"
+	got := mustFormat(t, src)
+	if !strings.HasPrefix(got, "prepare foo as\n") {
+		t.Errorf("header not on its own line:\n%s", got)
+	}
+	// The body is a real query river: every clause keyword ends at one column.
+	end := -1
+	for _, l := range strings.Split(got, "\n") {
+		for _, kw := range []string{"select ", "from ", "where ", "and ", "order by "} {
+			if i := strings.Index(l, kw); i >= 0 && strings.TrimLeft(l, " ") == strings.TrimLeft(l[i:], " ") {
+				if e := i + len(kw) - 1; end == -1 {
+					end = e
+				} else if e != end {
+					t.Errorf("clause keyword ends at %d, want %d:\n%s", e, end, got)
+				}
+				break
+			}
+		}
+	}
+	for _, l := range strings.Split(got, "\n") {
+		if cols(l) > targetWidth {
+			t.Errorf("line over the margin (%d):\n%s", cols(l), got)
+		}
+	}
+}
+
+// A typed table still has a column list: "of" between the name and the
+// paren belongs to the name. "partition" deliberately does not, so a
+// partition definition still falls through to its own clause layout.
+func TestTypedTableKeepsItsColumnList(t *testing.T) {
+	got := mustFormat(t, "create table rate of rate_t(exclude using gist(currency with =, validity with &&));\n")
+	if !strings.Contains(got, "create table rate of rate_t\n") {
+		t.Errorf("typed table header not on its own line:\n%s", got)
+	}
+	if !strings.Contains(got, "  exclude using gist(") {
+		t.Errorf("EXCLUDE not laid out as a table constraint:\n%s", got)
+	}
+	part := mustFormat(t, "create table lab.invoice_2022 partition of lab.invoice_by_year for values from (2022) to (2023);\n")
+	if !strings.Contains(part, "  partition of lab.invoice_by_year") {
+		t.Errorf("partition definition lost its clause layout:\n%s", part)
+	}
+}
+
+// An aggregate's FILTER / WITHIN GROUP suffix starts at the same column as
+// the aggregate it qualifies, not under the "(" of the aggregate's own
+// arguments -- it continues one expression at one level rather than
+// nesting inside the call, which leaves its contents room to break.
+func TestAggregateSuffixStartsAtTheAggregateColumn(t *testing.T) {
+	src := "select season, count(*) filter(where milliseconds is null and position is null) as dnfs," +
+		" percentile_cont(array[0.5, 0.9, 0.95, 0.99]) within group (order by cts - ats) as parr from r;\n"
+	got := mustFormat(t, src)
+	lines := strings.Split(got, "\n")
+	for i, l := range lines {
+		t := strings.TrimLeft(l, " ")
+		if !strings.HasPrefix(t, "filter(") && !strings.HasPrefix(t, "within group ") {
+			continue
+		}
+		suffixCol := len(l) - len(t)
+		aggCol := len(lines[i-1]) - len(strings.TrimLeft(lines[i-1], " "))
+		if suffixCol != aggCol {
+			return // reported below
+		}
+	}
+	for i, l := range lines {
+		tl := strings.TrimLeft(l, " ")
+		if !strings.HasPrefix(tl, "filter(") && !strings.HasPrefix(tl, "within group ") {
+			continue
+		}
+		if got, want := len(l)-len(tl), len(lines[i-1])-len(strings.TrimLeft(lines[i-1], " ")); got != want {
+			t.Errorf("suffix at column %d, aggregate at %d:\n%s", got, want, strings.Join(lines, "\n"))
+		}
+	}
+	// OVER keeps its own layout: a frame's clauses each need a line.
+	over := mustFormat(t, "select avg(res.points) over(order by r.round rows between 2 preceding and current row)::numeric as x from t;\n")
+	if !strings.Contains(over, "over(\n") {
+		t.Errorf("OVER lost its frame layout:\n%s", over)
+	}
+}

--- a/format/ddlclause_test.go
+++ b/format/ddlclause_test.go
@@ -1,0 +1,77 @@
+package format
+
+import (
+	"strings"
+	"testing"
+)
+
+// Each of these fell to flatJoin: the GRANT came back as one 205-column
+// line, the partitioned tables at 95-96 each. The expected shape is the
+// corpus's own -- header, then one clause per line at indent 2.
+func TestIndentedDDLClauses(t *testing.T) {
+	cases := []struct {
+		name, src string
+		want      []string
+	}{
+		{"partition of",
+			"create table lab.invoice_2022 partition of lab.invoice_by_year for values from (2022) to (2023);\n",
+			[]string{"create table lab.invoice_2022", "  partition of lab.invoice_by_year", "  for values from (2022) to (2023);"}},
+		{"create database",
+			"create database chinook_prod owner chinook_owner encoding 'UTF8' lc_collate 'en_US.UTF-8' lc_ctype 'en_US.UTF-8' template template0;\n",
+			[]string{"create database chinook_prod", "  owner chinook_owner", "  encoding 'UTF8'", "  template template0;"}},
+		{"grant",
+			"grant select (invoice_id, customer_id, invoice_date, billing_address, billing_city, billing_state, billing_country, billing_postal_code, total) on chinook.invoice to chinook_ro;\n",
+			[]string{"grant select (invoice_id, customer_id, invoice_date, billing_address,", "  on chinook.invoice", "  to chinook_ro;"}},
+		{"alter default privileges",
+			"alter default privileges in schema chinook grant select, insert, update, delete on tables to chinook_rw;\n",
+			[]string{"alter default privileges", "  in schema chinook", "  grant select, insert, update, delete", "  on tables"}},
+		{"alter subcommand inner clauses",
+			"alter table chinook.invoice add constraint invoice_currency_notnull check (currency is not null) not valid;\n",
+			[]string{"alter table chinook.invoice", "  add constraint invoice_currency_notnull", "      check (currency is not null)", "      not valid;"}},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			got := mustFormat(t, c.src)
+			for _, w := range c.want {
+				if !strings.Contains(got, w) {
+					t.Errorf("want line %q in:\n%s", w, got)
+				}
+			}
+			for _, l := range strings.Split(got, "\n") {
+				if cols(l) > targetWidth {
+					t.Errorf("line over the margin (%d cols):\n%s", cols(l), got)
+				}
+			}
+		})
+	}
+}
+
+// A statement that fits is left whole; only the clause words that open a
+// continuation are break points, never one that opens the statement.
+func TestIndentedDDLKeepsShortStatementsWhole(t *testing.T) {
+	for _, src := range []string{
+		"grant usage on schema chinook to chinook_ro;\n",
+		"create database sandbox;\n",
+		"alter table t add column c int;\n",
+	} {
+		got := mustFormat(t, src)
+		if strings.Count(strings.TrimRight(got, "\n"), "\n") != 0 {
+			t.Errorf("short statement was broken up:\n%s", got)
+		}
+	}
+}
+
+// The ALTER/GRANT/CREATE DATABASE words are keywords now, so rule 1
+// lowercases the whole construct rather than whichever word was already
+// in the table: "ATTACH partition", "create DATABASE", "GRANT select".
+func TestDDLVocabularyIsLowercased(t *testing.T) {
+	got := mustFormat(t,
+		"ALTER TABLE t ATTACH PARTITION p FOR VALUES FROM (1) TO (2);\n"+
+			"CREATE DATABASE d OWNER o ENCODING 'UTF8';\n"+
+			"GRANT SELECT ON t TO r;\n")
+	for _, bad := range []string{"ATTACH", "DATABASE", "OWNER", "GRANT", "SELECT", "PARTITION"} {
+		if strings.Contains(got, bad) {
+			t.Errorf("%q left uppercased:\n%s", bad, got)
+		}
+	}
+}

--- a/format/ddlclause_test.go
+++ b/format/ddlclause_test.go
@@ -147,34 +147,38 @@ func TestTypedTableKeepsItsColumnList(t *testing.T) {
 	}
 }
 
-// An aggregate's FILTER / WITHIN GROUP suffix starts at the same column as
-// the aggregate it qualifies, not under the "(" of the aggregate's own
-// arguments -- it continues one expression at one level rather than
-// nesting inside the call, which leaves its contents room to break.
-func TestAggregateSuffixStartsAtTheAggregateColumn(t *testing.T) {
+// An aggregate and its FILTER / WITHIN GROUP suffix are right-aligned
+// with each other, so their argument lists start at the same column:
+// "count" is pushed one column right to end where "filter" ends, and
+// where the function name is the longer of the two the suffix keyword
+// moves instead.
+func TestAggregateSuffixIsRiverAligned(t *testing.T) {
 	src := "select season, count(*) filter(where milliseconds is null and position is null) as dnfs," +
 		" percentile_cont(array[0.5, 0.9, 0.95, 0.99]) within group (order by cts - ats) as parr from r;\n"
 	got := mustFormat(t, src)
 	lines := strings.Split(got, "\n")
+	checked := 0
 	for i, l := range lines {
-		t := strings.TrimLeft(l, " ")
-		if !strings.HasPrefix(t, "filter(") && !strings.HasPrefix(t, "within group ") {
+		body := strings.TrimLeft(l, " ")
+		var kw string
+		switch {
+		case strings.HasPrefix(body, "filter("):
+			kw = "filter"
+		case strings.HasPrefix(body, "within group "):
+			kw = "within group"
+		default:
 			continue
 		}
-		suffixCol := len(l) - len(t)
-		aggCol := len(lines[i-1]) - len(strings.TrimLeft(lines[i-1], " "))
-		if suffixCol != aggCol {
-			return // reported below
+		checked++
+		aggEnd := strings.Index(lines[i-1], "(")
+		kwEnd := len(l) - len(body) + len(kw)
+		if aggEnd != kwEnd {
+			t.Errorf("%q ends at %d, its aggregate name at %d -- not aligned:\n%s",
+				kw, kwEnd, aggEnd, got)
 		}
 	}
-	for i, l := range lines {
-		tl := strings.TrimLeft(l, " ")
-		if !strings.HasPrefix(tl, "filter(") && !strings.HasPrefix(tl, "within group ") {
-			continue
-		}
-		if got, want := len(l)-len(tl), len(lines[i-1])-len(strings.TrimLeft(lines[i-1], " ")); got != want {
-			t.Errorf("suffix at column %d, aggregate at %d:\n%s", got, want, strings.Join(lines, "\n"))
-		}
+	if checked != 2 {
+		t.Fatalf("expected both suffixes on their own line, saw %d:\n%s", checked, got)
 	}
 	// OVER keeps its own layout: a frame's clauses each need a line.
 	over := mustFormat(t, "select avg(res.points) over(order by r.round rows between 2 preceding and current row)::numeric as x from t;\n")

--- a/format/doc.go
+++ b/format/doc.go
@@ -142,9 +142,63 @@ func flatWidth(d Doc) int {
 // has already placed it -- and continuation lines are indented by col plus
 // whatever Nest adds.
 func renderDoc(d Doc, col int) []string {
+	return renderDocTail(d, col, 0)
+}
+
+// renderDocTail is renderDoc told what follows: tail is the number of
+// columns the caller will still write on d's last line.
+func renderDocTail(d Doc, col, tail int) []string {
 	r := &docRenderer{col: col, out: []string{""}}
-	r.render(d, col, false)
+	r.render(d, col, false, tail)
 	return r.out
+}
+
+// headWidth returns how much of d is guaranteed to land on the line it
+// starts on -- its width up to the first point where a break could be
+// taken -- and whether it stopped at such a point.
+//
+// This is what a group's fits check needs to know about what follows it.
+// Wadler's fits measures the flattened group *together with its
+// continuation*; measuring the group alone lets the text after it push the
+// line past the margin, which is how "format(...) as elem" overflowed
+// while the call itself was judged to fit. Stopping at the first break
+// opportunity keeps the measure a lower bound: we never invent pressure
+// that a later break would have relieved.
+func headWidth(d Doc) (int, bool) {
+	switch d.kind {
+	case docText:
+		return len(d.text), false
+	case docLine, docSoft, docHard:
+		return 0, true
+	case docDefer:
+		if d.flat == "" {
+			return 0, true
+		}
+		return len(d.flat), false
+	}
+	total := 0
+	for _, p := range d.parts {
+		w, stop := headWidth(p)
+		total += w
+		if stop {
+			return total, true
+		}
+	}
+	return total, false
+}
+
+// tailOf measures the siblings that follow on the same line, falling back
+// to the enclosing tail once none of them can break.
+func tailOf(rest []Doc, outer int) int {
+	total := 0
+	for _, p := range rest {
+		w, stop := headWidth(p)
+		total += w
+		if stop {
+			return total
+		}
+	}
+	return total + outer
 }
 
 type docRenderer struct {
@@ -163,8 +217,9 @@ func (r *docRenderer) newline(indent int) {
 }
 
 // render emits d. broken says whether the enclosing group chose to break;
-// indent is the column continuation lines start at.
-func (r *docRenderer) render(d Doc, indent int, broken bool) {
+// indent is the column continuation lines start at; tail is how many
+// columns the caller still writes on d's last line.
+func (r *docRenderer) render(d Doc, indent int, broken bool, tail int) {
 	switch d.kind {
 	case docText:
 		r.write(d.text)
@@ -181,15 +236,15 @@ func (r *docRenderer) render(d Doc, indent int, broken bool) {
 	case docHard:
 		r.newline(indent)
 	case docNest:
-		r.render(d.parts[0], indent+d.indent, broken)
+		r.render(d.parts[0], indent+d.indent, broken, tail)
 	case docConcat:
-		for _, p := range d.parts {
-			r.render(p, indent, broken)
+		for i, p := range d.parts {
+			r.render(p, indent, broken, tailOf(d.parts[i+1:], tail))
 		}
 	case docDefer:
 		// Flat if it fits where we are, otherwise let the clause layer lay
 		// it out at this column.
-		if d.flat != "" && r.col+len(d.flat) <= targetWidth {
+		if d.flat != "" && r.col+len(d.flat)+tail <= targetWidth {
 			r.write(d.flat)
 			return
 		}
@@ -211,29 +266,36 @@ func (r *docRenderer) render(d Doc, indent int, broken bool) {
 			part := d.parts[i]
 			if part.kind == docConcat && len(part.parts) == 2 &&
 				(part.parts[1].kind == docLine || part.parts[1].kind == docSoft) {
-				r.render(part.parts[0], indent, broken)
+				r.render(part.parts[0], indent, broken, 0)
 				w := 0
 				if i+1 < len(d.parts) {
 					w = flatWidth(d.parts[i+1])
+				}
+				// Only the last item carries the enclosing tail: what
+				// follows the whole list -- ") as elem" -- lands on its line.
+				nextTail := 0
+				if i+1 == len(d.parts)-1 {
+					nextTail = tail
 				}
 				sepW := 0
 				if part.parts[1].kind == docLine {
 					sepW = 1
 				}
-				if w >= 0 && r.col+sepW+w <= targetWidth {
-					r.render(part.parts[1], indent, false)
+				if w >= 0 && r.col+sepW+w+nextTail <= targetWidth {
+					r.render(part.parts[1], indent, false, 0)
 				} else {
 					r.newline(indent)
 				}
 				continue
 			}
-			r.render(part, indent, broken)
+			r.render(part, indent, broken, tailOf(d.parts[i+1:], tail))
 		}
 	case docGroup:
 		// The whole group's decision, made here and once: flat if what it
-		// would occupy fits in what is left of the line.
+		// would occupy, plus what follows it on the line, fits in what is
+		// left.
 		w := flatWidth(d.parts[0])
-		fits := w >= 0 && r.col+w <= targetWidth
-		r.render(d.parts[0], indent, !fits)
+		fits := w >= 0 && r.col+w+tail <= targetWidth
+		r.render(d.parts[0], indent, !fits, tail)
 	}
 }

--- a/format/doc.go
+++ b/format/doc.go
@@ -113,7 +113,7 @@ func hasHard(d Doc) bool {
 func flatWidth(d Doc) int {
 	switch d.kind {
 	case docText:
-		return len(d.text)
+		return cols(d.text)
 	case docLine:
 		return 1
 	case docSoft:
@@ -124,7 +124,7 @@ func flatWidth(d Doc) int {
 		if d.flat == "" {
 			return -1
 		}
-		return len(d.flat)
+		return cols(d.flat)
 	}
 	total := 0
 	for _, p := range d.parts {
@@ -167,14 +167,14 @@ func renderDocTail(d Doc, col, tail int) []string {
 func headWidth(d Doc) (int, bool) {
 	switch d.kind {
 	case docText:
-		return len(d.text), false
+		return cols(d.text), false
 	case docLine, docSoft, docHard:
 		return 0, true
 	case docDefer:
 		if d.flat == "" {
 			return 0, true
 		}
-		return len(d.flat), false
+		return cols(d.flat), false
 	}
 	total := 0
 	for _, p := range d.parts {
@@ -208,10 +208,13 @@ type docRenderer struct {
 
 func (r *docRenderer) write(s string) {
 	r.out[len(r.out)-1] += s
-	r.col += len(s)
+	r.col += cols(s)
 }
 
 func (r *docRenderer) newline(indent int) {
+	if indent < 0 {
+		indent = 0
+	}
 	r.out = append(r.out, strings.Repeat(" ", indent))
 	r.col = indent
 }
@@ -244,7 +247,7 @@ func (r *docRenderer) render(d Doc, indent int, broken bool, tail int) {
 	case docDefer:
 		// Flat if it fits where we are, otherwise let the clause layer lay
 		// it out at this column.
-		if d.flat != "" && r.col+len(d.flat)+tail <= targetWidth {
+		if d.flat != "" && r.col+cols(d.flat)+tail <= targetWidth {
 			r.write(d.flat)
 			return
 		}
@@ -256,7 +259,7 @@ func (r *docRenderer) render(d Doc, indent int, broken bool, tail int) {
 		r.write(sub[0])
 		for _, l := range sub[1:] {
 			r.out = append(r.out, l)
-			r.col = len(l)
+			r.col = cols(l)
 		}
 	case docFill:
 		// Each separator decides on its own: stay on this line while the

--- a/format/doc.go
+++ b/format/doc.go
@@ -1,0 +1,239 @@
+package format
+
+import "strings"
+
+// A Wadler/Lindig pretty-printing IR, used for expression layout.
+//
+// The greedy line-filler this replaces decided each break where it stood,
+// with no knowledge of what came after. That is fine for a clause river,
+// where the break points are fixed by the grammar, but wrong inside an
+// expression, where the decisions interact: whether to break a function
+// call's arguments depends on whether the enclosing comparison is going to
+// break at its operator, which depends on whether the call broke. Three
+// attempts to patch that greedily each improved some files and regressed
+// others.
+//
+// In this IR a Group is a unit that is laid out flat if it fits on the
+// remaining line and broken otherwise, and the decision is made for the
+// whole group at once, outermost first. "Break the outer group only if the
+// inner ones still do not fit" is then a property of the algorithm rather
+// than something hand-coded per construct.
+//
+// The vocabulary is the standard one:
+//
+//	Text  literal characters, never broken
+//	Line  a space when its group is flat, a newline + indent when broken
+//	Soft  nothing when flat, a newline + indent when broken
+//	Group a unit whose flat/broken choice is made together
+//	Nest  increases the indent applied by Line/Soft inside it
+//	Concat sequence
+type docKind int
+
+const (
+	docText docKind = iota
+	docLine
+	docSoft
+	docGroup
+	docNest
+	docConcat
+	// docHard is a break that is always taken, and which forces every
+	// enclosing group to break too -- what a comment attached mid-
+	// expression needs, since it cannot share a line with what follows.
+	docHard
+	// docFill packs its parts onto as few lines as fit, deciding each
+	// separator on its own rather than all-or-nothing like a Group. A
+	// function call's arguments want this: breaking a five-argument call
+	// onto five lines when two would do is not what the corpus does, and
+	// reads worse. A "||" chain wants Group instead, because its parts are
+	// whole clauses of a template and the author writes them one per line.
+	docFill
+	// docDefer holds a sub-expression the clause layer already knows how
+	// to lay out -- a CASE, an OVER(...), a subquery -- as a function of
+	// the column it ends up at. Without it the Doc layer had to decline
+	// any run containing one, which in practice meant declining the
+	// figure-generating calls that most needed it, since they pass a CASE
+	// as an argument.
+	docDefer
+)
+
+type Doc struct {
+	kind   docKind
+	text   string
+	indent int
+	parts  []Doc
+	// render is set for docDefer: it lays the sub-expression out at the
+	// column it is actually placed at. flat is its single-line form, used
+	// for width decisions, or "" when it has none.
+	render func(col int) []string
+	flat   string
+}
+
+// defer_ wraps an already-understood sub-expression. flat is its one-line
+// form ("" if it cannot be rendered on one line).
+func defer_(flat string, render func(col int) []string) Doc {
+	return Doc{kind: docDefer, flat: flat, render: render}
+}
+
+func text(s string) Doc     { return Doc{kind: docText, text: s} }
+func line() Doc             { return Doc{kind: docLine} }
+func soft() Doc             { return Doc{kind: docSoft} }
+func hard() Doc             { return Doc{kind: docHard} }
+func group(d Doc) Doc       { return Doc{kind: docGroup, parts: []Doc{d}} }
+func nest(i int, d Doc) Doc { return Doc{kind: docNest, indent: i, parts: []Doc{d}} }
+func concat(ds ...Doc) Doc  { return Doc{kind: docConcat, parts: ds} }
+
+// fill packs parts, separated by sep, onto as few lines as fit.
+func fill(sep Doc, parts ...Doc) Doc {
+	ds := make([]Doc, 0, len(parts)*2)
+	for i, p := range parts {
+		if i > 0 {
+			ds = append(ds, sep)
+		}
+		ds = append(ds, p)
+	}
+	return Doc{kind: docFill, parts: ds}
+}
+
+// hasHard reports whether d contains a hard break, which forces every
+// group containing it to break.
+func hasHard(d Doc) bool {
+	if d.kind == docHard {
+		return true
+	}
+	for _, p := range d.parts {
+		if hasHard(p) {
+			return true
+		}
+	}
+	return false
+}
+
+// flatWidth returns the width d would occupy laid out flat, or -1 when it
+// contains a hard break and therefore has no flat form.
+func flatWidth(d Doc) int {
+	switch d.kind {
+	case docText:
+		return len(d.text)
+	case docLine:
+		return 1
+	case docSoft:
+		return 0
+	case docHard:
+		return -1
+	case docDefer:
+		if d.flat == "" {
+			return -1
+		}
+		return len(d.flat)
+	}
+	total := 0
+	for _, p := range d.parts {
+		w := flatWidth(p)
+		if w < 0 {
+			return -1
+		}
+		total += w
+	}
+	return total
+}
+
+// renderDoc lays d out starting at column col, with lines wrapped to
+// targetWidth. The first line carries no indent of its own -- the caller
+// has already placed it -- and continuation lines are indented by col plus
+// whatever Nest adds.
+func renderDoc(d Doc, col int) []string {
+	r := &docRenderer{col: col, out: []string{""}}
+	r.render(d, col, false)
+	return r.out
+}
+
+type docRenderer struct {
+	col int
+	out []string
+}
+
+func (r *docRenderer) write(s string) {
+	r.out[len(r.out)-1] += s
+	r.col += len(s)
+}
+
+func (r *docRenderer) newline(indent int) {
+	r.out = append(r.out, strings.Repeat(" ", indent))
+	r.col = indent
+}
+
+// render emits d. broken says whether the enclosing group chose to break;
+// indent is the column continuation lines start at.
+func (r *docRenderer) render(d Doc, indent int, broken bool) {
+	switch d.kind {
+	case docText:
+		r.write(d.text)
+	case docLine:
+		if broken {
+			r.newline(indent)
+		} else {
+			r.write(" ")
+		}
+	case docSoft:
+		if broken {
+			r.newline(indent)
+		}
+	case docHard:
+		r.newline(indent)
+	case docNest:
+		r.render(d.parts[0], indent+d.indent, broken)
+	case docConcat:
+		for _, p := range d.parts {
+			r.render(p, indent, broken)
+		}
+	case docDefer:
+		// Flat if it fits where we are, otherwise let the clause layer lay
+		// it out at this column.
+		if d.flat != "" && r.col+len(d.flat) <= targetWidth {
+			r.write(d.flat)
+			return
+		}
+		sub := d.render(r.col)
+		if len(sub) == 0 {
+			r.write(d.flat)
+			return
+		}
+		r.write(sub[0])
+		for _, l := range sub[1:] {
+			r.out = append(r.out, l)
+			r.col = len(l)
+		}
+	case docFill:
+		// Each separator decides on its own: stay on this line while the
+		// next part still fits, break when it does not. That is what makes
+		// a filled list pack rather than explode one item per line.
+		for i := 0; i < len(d.parts); i++ {
+			part := d.parts[i]
+			if part.kind == docConcat && len(part.parts) == 2 &&
+				(part.parts[1].kind == docLine || part.parts[1].kind == docSoft) {
+				r.render(part.parts[0], indent, broken)
+				w := 0
+				if i+1 < len(d.parts) {
+					w = flatWidth(d.parts[i+1])
+				}
+				sepW := 0
+				if part.parts[1].kind == docLine {
+					sepW = 1
+				}
+				if w >= 0 && r.col+sepW+w <= targetWidth {
+					r.render(part.parts[1], indent, false)
+				} else {
+					r.newline(indent)
+				}
+				continue
+			}
+			r.render(part, indent, broken)
+		}
+	case docGroup:
+		// The whole group's decision, made here and once: flat if what it
+		// would occupy fits in what is left of the line.
+		w := flatWidth(d.parts[0])
+		fits := w >= 0 && r.col+w <= targetWidth
+		r.render(d.parts[0], indent, !fits)
+	}
+}

--- a/format/doc.go
+++ b/format/doc.go
@@ -265,11 +265,21 @@ func (r *docRenderer) render(d Doc, indent int, broken bool, tail int) {
 		// Each separator decides on its own: stay on this line while the
 		// next part still fits, break when it does not. That is what makes
 		// a filled list pack rather than explode one item per line.
+		prevBroke := false
 		for i := 0; i < len(d.parts); i++ {
 			part := d.parts[i]
 			if part.kind == docConcat && len(part.parts) == 2 &&
 				(part.parts[1].kind == docLine || part.parts[1].kind == docSoft) {
 				r.render(part.parts[0], indent, broken, 0)
+				// An item that took more than one line ends on a line of
+				// its own -- the closing paren of a deferred OVER, say --
+				// and packing the next item after it runs two list items
+				// together on that line, which reads as one. Once a part
+				// has broken, its separator breaks too.
+				if prevBroke {
+					r.newline(indent)
+					continue
+				}
 				w := 0
 				if i+1 < len(d.parts) {
 					w = flatWidth(d.parts[i+1])
@@ -291,7 +301,9 @@ func (r *docRenderer) render(d Doc, indent int, broken bool, tail int) {
 				}
 				continue
 			}
+			before := len(r.out)
 			r.render(part, indent, broken, tailOf(d.parts[i+1:], tail))
+			prevBroke = len(r.out) > before
 		}
 	case docGroup:
 		// The whole group's decision, made here and once: flat if what it

--- a/format/doc_test.go
+++ b/format/doc_test.go
@@ -1,0 +1,146 @@
+package format
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+)
+
+func docFmt(t *testing.T, src string) string {
+	t.Helper()
+	got, err := Format(bytes.NewReader([]byte(src)))
+	if err != nil {
+		t.Fatalf("Format: %v", err)
+	}
+	return got
+}
+
+func longestLine(s string) int {
+	m := 0
+	for _, l := range strings.Split(s, "\n") {
+		if len(l) > m {
+			m = len(l)
+		}
+	}
+	return m
+}
+
+// TestDocGroupIsAllOrNothing: a group either fits flat or breaks entirely.
+func TestDocGroupIsAllOrNothing(t *testing.T) {
+	d := group(concat(text("a"), line(), text("b"), line(), text("c")))
+	if got := renderDoc(d, 0); len(got) != 1 || got[0] != "a b c" {
+		t.Errorf("short group should stay flat, got %q", got)
+	}
+	wide := strings.Repeat("x", targetWidth)
+	d = group(concat(text(wide), line(), text("b")))
+	if got := renderDoc(d, 0); len(got) != 2 {
+		t.Errorf("over-wide group should break, got %q", got)
+	}
+}
+
+// TestDocFillPacks: a fill packs its parts, deciding each separator on its
+// own, rather than breaking all of them like a group would.
+func TestDocFillPacks(t *testing.T) {
+	parts := make([]Doc, 30)
+	for i := range parts {
+		parts[i] = text("item")
+	}
+	got := renderDoc(fill(concat(text(","), line()), parts...), 0)
+	if len(got) < 2 {
+		t.Fatalf("expected a break, got %q", got)
+	}
+	if len(got) >= len(parts) {
+		t.Errorf("fill exploded one item per line rather than packing: %q", got)
+	}
+	for _, l := range got {
+		if len(l) > targetWidth {
+			t.Errorf("fill produced an over-wide line: %q", l)
+		}
+	}
+}
+
+// TestDocNestIndentsContinuations checks the indent Nest contributes.
+func TestDocNestIndentsContinuations(t *testing.T) {
+	wide := strings.Repeat("x", targetWidth)
+	d := group(concat(text("f("), nest(2, concat(soft(), text(wide), text(","), line(), text("y"))), soft(), text(")")))
+	got := renderDoc(d, 0)
+	if len(got) < 3 {
+		t.Fatalf("expected a broken layout, got %q", got)
+	}
+	if !strings.HasPrefix(got[1], "  ") {
+		t.Errorf("nested line not indented: %q", got[1])
+	}
+}
+
+// TestCallArgsFillNotExplode is the behaviour the IR exists for: a call too
+// wide for its line gets its arguments packed, not one per line.
+func TestCallArgsFillNotExplode(t *testing.T) {
+	got := docFmt(t, "select st_transscale(st_intersection(r.geom, win.env), -proj.x0, -proj.y0, proj.scale, proj.scale) as geom from r;")
+	if longestLine(got) > targetWidth {
+		t.Errorf("still over the target:\n%s", got)
+	}
+	packed := false
+	for _, l := range strings.Split(got, "\n") {
+		if strings.Count(l, ",") >= 2 {
+			packed = true
+		}
+	}
+	if !packed {
+		t.Errorf("arguments exploded one per line:\n%s", got)
+	}
+}
+
+// TestConcatChainOnePerLine: a "||" chain is a Group, not a Fill -- its
+// parts are whole clauses of a template and the author writes them one per
+// line.
+func TestConcatChainOnePerLine(t *testing.T) {
+	src := "select '<path d=\"' || st_assvg(geom, 0, 1) || '\" fill=\"none\" stroke=\"#C0B8AE\" stroke-width=\"2\"/>' as elem from shapes;"
+	got := docFmt(t, src)
+	if strings.Count(got, "\n|| ") < 1 && strings.Count(got, "       || ") < 1 {
+		t.Errorf("chain not broken one part per line:\n%s", got)
+	}
+}
+
+// TestCaseInsideCallIsDeferred: a CASE passed as an argument is laid out by
+// the clause layer, via docDefer. Before that the Doc layer declined any
+// run containing a CASE -- which meant declining the figure-generating
+// calls that most needed it.
+func TestCaseInsideCallIsDeferred(t *testing.T) {
+	src := "select format('%s at (%s,%s)', case when rc.name = 'Czechia' then 'Czechia' when rc.name = 'North Macedonia' then 'N.Mac.' else rc.name end, round(nc.cx::numeric, 3), round(nc.cy::numeric, 3)) as elem from rc;"
+	got := docFmt(t, src)
+	if squash(got) != squash(src) {
+		t.Errorf("content changed:\n%s", got)
+	}
+	if longestLine(got) > 95 {
+		t.Errorf("line still far over the target (%d):\n%s", longestLine(got), got)
+	}
+}
+
+// TestConcatSplitSkipsCaseSpans is a data-loss regression: a "||" inside a
+// CASE branch is not a top-level operator, and splitting there cut the CASE
+// in half -- each half then looked like its own CASE and the "end" came out
+// twice.
+func TestConcatSplitSkipsCaseSpans(t *testing.T) {
+	src := "select case when length(t.name) < 55 then t.name else substring(t.name from 1 for 54) || '...' end as track, ar.name as artist from track t join artist ar on ar.id = t.artist_id;"
+	got := docFmt(t, src)
+	if squash(got) != squash(src) {
+		t.Errorf("content changed:\nin:  %s\nout: %s", squash(src), squash(got))
+	}
+	if strings.Count(strings.ToLower(got), "end") != 1 {
+		t.Errorf("the CASE's end was duplicated:\n%s", got)
+	}
+}
+
+func TestDocLayerIdempotent(t *testing.T) {
+	srcs := []string{
+		"select st_transscale(st_intersection(r.geom, win.env), -proj.x0, -proj.y0, proj.scale, proj.scale) as geom from r;",
+		"select '<path d=\"' || st_assvg(geom, 0, 1) || '\" fill=\"none\"/>' as elem from shapes;",
+		"select case when length(t.name) < 55 then t.name else substring(t.name from 1 for 54) || '...' end as track from track t;",
+	}
+	for _, src := range srcs {
+		once := docFmt(t, src)
+		if twice := docFmt(t, once); once != twice {
+			t.Errorf("not idempotent for %q:\nfirst:\n%s\nsecond:\n%s", src, once, twice)
+		}
+	}
+}

--- a/format/doc_test.go
+++ b/format/doc_test.go
@@ -96,8 +96,20 @@ func TestCallArgsFillNotExplode(t *testing.T) {
 func TestConcatChainOnePerLine(t *testing.T) {
 	src := "select '<path d=\"' || st_assvg(geom, 0, 1) || '\" fill=\"none\" stroke=\"#C0B8AE\" stroke-width=\"2\"/>' as elem from shapes;"
 	got := docFmt(t, src)
-	if strings.Count(got, "\n|| ") < 1 && strings.Count(got, "       || ") < 1 {
+	// The operator hangs left of the operand column and every operand
+	// lines up under the first one, as "and"/"or" do under "where".
+	if strings.Count(got, "\n    || ") < 2 {
 		t.Errorf("chain not broken one part per line:\n%s", got)
+	}
+	for _, l := range strings.Split(got, "\n") {
+		if op := strings.Index(l, "|| "); op >= 0 {
+			if !strings.HasPrefix(strings.TrimLeft(l, " "), "|| ") {
+				continue
+			}
+			if operandCol := op + 3; operandCol != 7 {
+				t.Errorf("operand at column %d, want 7 (aligned with the first):\n%s", operandCol, got)
+			}
+		}
 	}
 }
 

--- a/format/doc_test.go
+++ b/format/doc_test.go
@@ -144,3 +144,41 @@ func TestDocLayerIdempotent(t *testing.T) {
 		}
 	}
 }
+
+// A group must weigh what follows it on the line, not just itself. The
+// call below fits at column 0 on its own, but the alias that trails it
+// does not, and only a continuation-aware fits check can see that.
+func TestGroupCountsItsContinuation(t *testing.T) {
+	call := group(concat(
+		text("format("),
+		nest(2, concat(soft(), fill(concat(text(","), line()),
+			text("'%s %s'"), text("drivers.forename"), text("drivers.surname")))),
+		soft(),
+		text(")"),
+	))
+	if got := renderDoc(call, 0); len(got) != 1 {
+		t.Fatalf("call alone fits at col 0, want 1 line, got %d: %q", len(got), got)
+	}
+	d := concat(call, text(` as "Driver's Champion"`))
+	got := renderDoc(d, 9)
+	for _, l := range got {
+		if len(l) > targetWidth {
+			t.Errorf("line over margin: %d cols %q", len(l), l)
+		}
+	}
+	if len(got) < 2 {
+		t.Fatalf("want the call broken to make room for the alias, got %q", got)
+	}
+}
+
+// tailOf stops at the first break opportunity: content beyond a break is
+// not on this line and must not count against it.
+func TestTailStopsAtBreak(t *testing.T) {
+	rest := []Doc{text("ab"), line(), text("cdefgh")}
+	if got := tailOf(rest, 0); got != 2 {
+		t.Errorf("tailOf = %d, want 2 (stop at the line)", got)
+	}
+	if got := tailOf([]Doc{text("ab"), text("cd")}, 3); got != 7 {
+		t.Errorf("tailOf = %d, want 7 (no break, so the outer tail carries)", got)
+	}
+}

--- a/format/expr.go
+++ b/format/expr.go
@@ -114,6 +114,25 @@ func exprAtomDoc(toks []Token, levels [][]string) Doc {
 	// logic below is right to refuse to hang a clause paren, which left
 	// the whole thing as one unbreakable atom. Defer the OVER in place
 	// instead, so it can lay itself out at whatever column it lands at.
+	// An aggregate's FILTER / WITHIN GROUP suffix goes on its own line,
+	// starting at the same column as the aggregate it qualifies:
+	//
+	//	count(*)
+	//	filter(where milliseconds is null and position is null) as dnfs
+	//
+	// rather than aligned under the "(" of the aggregate's own arguments,
+	// which is where layoutOver puts a window frame. The suffix is a
+	// continuation of one expression at one level, not something nested
+	// inside the call, and starting it back at the expression's own column
+	// keeps its contents near the margin instead of compounding the
+	// indent -- so if the suffix has to break in turn, it still has room.
+	if head, suffix, ok := splitTrailingAggSuffix(toks); ok {
+		return group(concat(
+			exprAtomDoc(head, levels),
+			line(),
+			text(plainJoin(suffix)),
+		))
+	}
 	if head, over, ok := splitTrailingOver(toks); ok {
 		return concat(
 			text(plainJoin(head)+" "),
@@ -210,6 +229,34 @@ func clauseParen(toks []Token, i int) bool {
 		return i > 1 && toks[i-2].Kind == TokKeyword && toks[i-2].Lower == "within"
 	}
 	return false
+}
+
+// splitTrailingAggSuffix cuts a run that ends in an aggregate's FILTER or
+// WITHIN GROUP clause into the aggregate and the suffix.
+func splitTrailingAggSuffix(toks []Token) ([]Token, []Token, bool) {
+	n := len(toks)
+	if n < 4 || toks[n-1].Text != ")" {
+		return nil, nil, false
+	}
+	open := matchParenBack(toks, n-1)
+	if open < 1 || !clauseParen(toks, open) {
+		return nil, nil, false
+	}
+	// OVER is a clause paren too, but it keeps the deferral to layoutOver:
+	// a window frame's own clauses (PARTITION BY, ORDER BY, ROWS BETWEEN)
+	// each need a line, which is a layout, not a single suffix to move.
+	if toks[open-1].Lower == "over" {
+		return nil, nil, false
+	}
+	// "within group" is two words; "filter" is one.
+	start := open - 1
+	if toks[start].Lower == "group" {
+		start--
+	}
+	if start <= 0 {
+		return nil, nil, false
+	}
+	return trimTokens(toks[:start]), toks[start:], true
 }
 
 // splitTrailingOver cuts a run that ends in an OVER(...) clause into the

--- a/format/expr.go
+++ b/format/expr.go
@@ -122,6 +122,28 @@ func exprAtomDoc(toks []Token, levels [][]string) Doc {
 			}),
 		)
 	}
+	// "x between a and b" breaks before "between", which is the only
+	// joint in it -- the "and" belongs to the operator, so the predicate
+	// split steps over it and left the whole thing one atom.
+	if lo := topLevelBetween(toks); lo > 0 {
+		return group(concat(
+			exprAtomDoc(trimTokens(toks[:lo]), levels),
+			nest(2, concat(line(), text(plainJoin(toks[lo:])))),
+		))
+	}
+	// Adjacent string literals are an implicit concatenation -- the TikZ
+	// generators build a template that way -- and the join between them is
+	// a break point with no operator to mark it.
+	if parts := splitAdjacentStrings(toks); len(parts) > 1 {
+		ds := make([]Doc, 0, len(parts)*2)
+		for i, p := range parts {
+			if i > 0 {
+				ds = append(ds, line())
+			}
+			ds = append(ds, text(plainJoin(p)))
+		}
+		return group(concat(ds...))
+	}
 	// A trailing parenthesized group is the interesting case: a call's
 	// arguments, a row constructor, an IN list.
 	if toks[len(toks)-1].Text == ")" {
@@ -239,6 +261,69 @@ func deferredConstruct(toks []Token) (Doc, bool) {
 	return Doc{}, false
 }
 
+// topLevelBetween returns the index of a "between" keyword at paren depth
+// zero, or -1. Index 0 does not count: there is nothing to its left to
+// break away from.
+func topLevelBetween(toks []Token) int {
+	depth := 0
+	for i, t := range toks {
+		switch t.Text {
+		case "(":
+			depth++
+			continue
+		case ")":
+			depth--
+			continue
+		}
+		if depth == 0 && i > 0 && t.Kind == TokKeyword && t.Lower == "between" {
+			return i
+		}
+	}
+	return -1
+}
+
+// splitAdjacentStrings cuts a run at each point where one string literal
+// is directly followed by another, which SQL reads as concatenation.
+func splitAdjacentStrings(toks []Token) [][]Token {
+	var out [][]Token
+	depth, start := 0, 0
+	for i := 1; i < len(toks); i++ {
+		switch toks[i].Text {
+		case "(":
+			depth++
+			continue
+		case ")":
+			depth--
+			continue
+		}
+		if depth == 0 && toks[i].Kind == TokString && toks[i-1].Kind == TokString {
+			out = append(out, toks[start:i])
+			start = i
+		}
+	}
+	if len(out) == 0 {
+		return nil
+	}
+	return append(out, toks[start:])
+}
+
+// matchParenBack returns the index of the "(" matching the ")" at close.
+func matchParenBack(toks []Token, close int) int {
+	depth := 0
+	for i := close; i >= 0; i-- {
+		switch toks[i].Text {
+		case ")":
+			depth++
+		case "(":
+			depth--
+			if depth == 0 {
+				return i
+			}
+		}
+	}
+	return -1
+}
+
 // splitTrailingCast peels a trailing "::type" (including a schema
 // qualification and array brackets) off an expression, so what remains
 // ends in the ")" the paren layout keys on.
@@ -273,6 +358,18 @@ func splitTrailingCast(toks []Token) ([]Token, string) {
 // confused with an operator's right-hand side.
 func splitTrailingAlias(toks []Token) ([]Token, string) {
 	n := len(toks)
+	// A FROM item's alias can carry a column list -- "as t(color)",
+	// "as r(name text, type text)". Without peeling that too,
+	// lastTopLevelOpen picks the alias's own paren as the thing to break,
+	// so a wide generate_series(...) was left whole and its one-column
+	// alias was hung instead.
+	if n >= 4 && toks[n-1].Text == ")" {
+		if open := matchParenBack(toks, n-1); open > 1 &&
+			toks[open-1].Kind == TokIdent &&
+			toks[open-2].Kind == TokKeyword && toks[open-2].Lower == "as" {
+			return toks[:open-2], plainJoin(toks[open-2:])
+		}
+	}
 	if n >= 3 && toks[n-2].Kind == TokKeyword && toks[n-2].Lower == "as" &&
 		toks[n-3].Text == ")" {
 		return toks[:n-2], "as " + toks[n-1].Text

--- a/format/expr.go
+++ b/format/expr.go
@@ -1,0 +1,216 @@
+package format
+
+import "strings"
+
+// Expression layout, built on the Doc IR in doc.go.
+//
+// This covers the part of the language where break decisions interact:
+// parenthesized groups, function-call argument lists, "||" concatenation
+// chains and comparison operators. The clause layer above it -- the
+// select/from/where river -- keeps its own layout, because its break
+// points are fixed by the grammar rather than chosen.
+//
+// exprDoc is deliberately conservative about what it claims: it reports
+// false for any run containing a construct the clause layer handles better
+// (CASE, OVER, a subquery, an attached comment), and renderRun keeps its
+// existing path for those. The point is to fix the expression cases, not
+// to relitigate the ones that already work.
+
+// exprDoc builds a Doc for a token run, or reports false when the run
+// contains something this layer does not model.
+func exprDoc(toks []Token) (Doc, bool) {
+	toks = trimTokens(toks)
+	if len(toks) == 0 {
+		return Doc{}, false
+	}
+	for _, t := range toks {
+		if isNonLayout(t) || len(t.Comments) > 0 || t.TrailingComment != nil {
+			return Doc{}, false
+		}
+		// A subquery brings the whole clause layer with it, including its
+		// own river; that stays where it is.
+		if t.Kind == TokKeyword && (t.Lower == "select" || t.Lower == "with") {
+			return Doc{}, false
+		}
+	}
+	return exprConcatDoc(toks), true
+}
+
+// exprConcatDoc handles the outermost structure: a "||" chain, if there is
+// one, else a comparison, else a plain run.
+func exprConcatDoc(toks []Token) Doc {
+	if parts := splitTopLevelConcat(toks); len(parts) > 1 {
+		ds := make([]Doc, 0, len(parts)*2)
+		for i, p := range parts {
+			if i > 0 {
+				ds = append(ds, line(), text("|| "))
+			}
+			ds = append(ds, exprCompareDoc(trimTokens(p)))
+		}
+		return group(concat(ds...))
+	}
+	return exprCompareDoc(toks)
+}
+
+// exprCompareDoc breaks at a top-level comparison operator between two
+// parenthesized row constructors -- "(a, b) <> (x, y)" -- which is a break
+// point no amount of breaking inside either list can substitute for.
+func exprCompareDoc(toks []Token) Doc {
+	if i := topLevelRowOp(toks); i > 0 {
+		lhs, rhs := trimTokens(toks[:i]), trimTokens(toks[i+1:])
+		if isParenGroup(lhs) && isParenGroup(rhs) {
+			return group(concat(
+				exprAtomDoc(lhs),
+				line(),
+				text(toks[i].Lower+" "),
+				exprAtomDoc(rhs),
+			))
+		}
+	}
+	return exprAtomDoc(toks)
+}
+
+// exprAtomDoc renders a run that has no top-level operator structure left:
+// a parenthesized group (possibly a call's argument list), or plain text.
+func exprAtomDoc(toks []Token) Doc {
+	toks = trimTokens(toks)
+	if len(toks) == 0 {
+		return text("")
+	}
+	// A CASE or a windowed aggregate is laid out by the clause layer, which
+	// already does it well; the Doc layer only needs to know how wide it is
+	// flat and how to ask for it at a given column.
+	if d, ok := deferredConstruct(toks); ok {
+		return d
+	}
+	// A select-list item usually carries an alias -- "format(...) as elem"
+	// -- and the expression to lay out is what precedes it. Without peeling
+	// it off the run does not end in ")", and the whole item fell through
+	// to a single unbreakable Text.
+	if expr, alias := splitTrailingAlias(toks); alias != "" {
+		return concat(exprAtomDoc(expr), text(" "+alias))
+	}
+	// A trailing parenthesized group is the interesting case: a call's
+	// arguments, a row constructor, an IN list.
+	if toks[len(toks)-1].Text == ")" {
+		if open := lastTopLevelOpen(toks); open >= 0 {
+			head := plainJoin(toks[:open])
+			inner := trimTokens(toks[open+1 : len(toks)-1])
+			if len(inner) > 0 {
+				items := splitTopLevelComma(inner)
+				if len(items) > 1 {
+					// Arguments fill rather than going one per line: a
+					// five-argument call broken onto five lines is not
+					// what the corpus does and reads worse than two.
+					ds := make([]Doc, 0, len(items))
+					for _, it := range items {
+						ds = append(ds, exprConcatDoc(trimTokens(it)))
+					}
+					args := fill(concat(text(","), line()), ds...)
+					_ = args
+					// The arguments hang from the opening paren: soft()
+					// after "(" so a broken group starts them on their own
+					// line, nest() so they line up under it.
+					return group(concat(
+						text(head+"("),
+						nest(2, concat(soft(), args)),
+						soft(),
+						text(")"),
+					))
+				}
+			}
+		}
+	}
+	return text(plainJoin(toks))
+}
+
+// deferredConstruct wraps a run that is exactly one CASE ... END, or one
+// OVER(...) clause, as a docDefer.
+func deferredConstruct(toks []Token) (Doc, bool) {
+	if len(toks) == 0 || toks[0].Kind != TokKeyword {
+		return Doc{}, false
+	}
+	switch toks[0].Lower {
+	case "case":
+		if end := matchCaseEnd(toks, 0); end == len(toks)-1 {
+			run := toks
+			return defer_(plainJoin(run), func(col int) []string {
+				return layoutCase(run, col)
+			}), true
+		}
+	case "over":
+		if len(toks) > 1 && toks[1].Text == "(" && matchParen(toks, 1) == len(toks)-1 {
+			run := toks
+			return defer_(plainJoin(run), func(col int) []string {
+				return layoutOver(run, col)
+			}), true
+		}
+	}
+	return Doc{}, false
+}
+
+// splitTrailingAlias peels a trailing column alias off an expression,
+// returning the expression and the alias text ("as elem", "elem"), or an
+// empty alias when there is none. Only an alias directly after a closing
+// paren is recognised: that is the case this exists for, and it cannot be
+// confused with an operator's right-hand side.
+func splitTrailingAlias(toks []Token) ([]Token, string) {
+	n := len(toks)
+	if n >= 3 && toks[n-2].Kind == TokKeyword && toks[n-2].Lower == "as" &&
+		toks[n-3].Text == ")" {
+		return toks[:n-2], "as " + toks[n-1].Text
+	}
+	if n >= 2 && toks[n-1].Kind == TokIdent && toks[n-2].Text == ")" {
+		return toks[:n-1], toks[n-1].Text
+	}
+	return toks, ""
+}
+
+// lastTopLevelOpen returns the index of the "(" matching the final ")", or
+// -1 if the run is not one that ends in a balanced group.
+func lastTopLevelOpen(toks []Token) int {
+	depth := 0
+	for i := len(toks) - 1; i >= 0; i-- {
+		switch toks[i].Text {
+		case ")":
+			depth++
+		case "(":
+			depth--
+			if depth == 0 {
+				return i
+			}
+		}
+	}
+	return -1
+}
+
+// exprLines renders a token run through the Doc layer, reporting false when
+// the run is one this layer declines, or when the result is no better than
+// the flat form the caller already has.
+func exprLines(toks []Token, col int) ([]string, bool) {
+	d, ok := exprDoc(toks)
+	if !ok {
+		return nil, false
+	}
+	if w := flatWidth(d); w >= 0 && col+w <= targetWidth {
+		return nil, false // fits flat; nothing to decide
+	}
+	lines := renderDoc(d, col)
+	if len(lines) < 2 {
+		return nil, false
+	}
+	// Only worth it if it actually shortened the longest line.
+	flat := plainJoin(trimTokens(toks))
+	longest := 0
+	for _, l := range lines {
+		if n := len(l); n > longest {
+			longest = n
+		}
+	}
+	if longest >= col+len(flat) {
+		return nil, false
+	}
+	return lines, true
+}
+
+var _ = strings.TrimSpace

--- a/format/expr.go
+++ b/format/expr.go
@@ -116,7 +116,20 @@ func exprAtomDoc(toks []Token, levels [][]string) Doc {
 			inner := trimTokens(toks[open+1 : len(toks)-1])
 			if len(inner) > 0 {
 				items := splitTopLevelComma(inner)
-				if len(items) > 1 {
+				// A lone argument may hang from its paren too, so a
+				// single wide call has somewhere to break -- but not when
+				// the paren opens a clause rather than an argument list.
+				// OVER(...), FILTER(...) and WITHIN GROUP(...) each read
+				// as one unit with a good one-line form, and hanging them
+				// turned a fitting window frame into three lines: shorter
+				// and worse.
+				// It must also actually be a call: "(a + b)::text" is a
+				// grouping paren with no callee in front of it, and
+				// hanging its one item strands the "(" on a line of its
+				// own above a stray ")".
+				soleOK := len(items) == 1 && isCallParen(toks, open) &&
+					!clauseParen(toks, open)
+				if len(items) > 1 || soleOK {
 					// Arguments fill rather than going one per line: a
 					// five-argument call broken onto five lines is not
 					// what the corpus does and reads worse than two.
@@ -140,6 +153,27 @@ func exprAtomDoc(toks []Token, levels [][]string) Doc {
 		}
 	}
 	return text(plainJoin(toks))
+}
+
+// isCallParen reports whether the "(" at i follows a name, i.e. opens a
+// call's argument list rather than grouping an expression.
+func isCallParen(toks []Token, i int) bool {
+	return i > 0 && (toks[i-1].Kind == TokIdent || toks[i-1].Kind == TokKeyword)
+}
+
+// clauseParen reports whether the "(" at i opens a clause -- OVER,
+// FILTER, WITHIN GROUP -- rather than a call's argument list.
+func clauseParen(toks []Token, i int) bool {
+	if i == 0 || toks[i-1].Kind != TokKeyword {
+		return false
+	}
+	switch toks[i-1].Lower {
+	case "over", "filter":
+		return true
+	case "group":
+		return i > 1 && toks[i-2].Kind == TokKeyword && toks[i-2].Lower == "within"
+	}
+	return false
 }
 
 // deferredConstruct wraps a run that is exactly one CASE ... END, or one

--- a/format/expr.go
+++ b/format/expr.go
@@ -127,11 +127,9 @@ func exprAtomDoc(toks []Token, levels [][]string) Doc {
 	// keeps its contents near the margin instead of compounding the
 	// indent -- so if the suffix has to break in turn, it still has room.
 	if head, suffix, ok := splitTrailingAggSuffix(toks); ok {
-		return group(concat(
-			exprAtomDoc(head, levels),
-			line(),
-			text(plainJoin(suffix)),
-		))
+		return defer_(plainJoin(toks), func(col int) []string {
+			return aggSuffixLines(head, suffix, col)
+		})
 	}
 	if head, over, ok := splitTrailingOver(toks); ok {
 		return concat(
@@ -229,6 +227,41 @@ func clauseParen(toks []Token, i int) bool {
 		return i > 1 && toks[i-2].Kind == TokKeyword && toks[i-2].Lower == "within"
 	}
 	return false
+}
+
+// aggSuffixLines lays an aggregate out above its FILTER / WITHIN GROUP
+// suffix, with the two names right-aligned so their argument lists start
+// at the same column -- the river the rest of the tool uses, applied to a
+// two-line construct:
+//
+//	 count(*)                                percentile_cont(array[0.5, 0.99])
+//	filter(where x is null) as dnfs             within group (order by d)
+//
+// "count" is pushed one column right to end where "filter" ends; where
+// the function name is the longer of the two it stays put and the suffix
+// keyword moves instead.
+func aggSuffixLines(head, suffix []Token, col int) []string {
+	name := plainJoin(head[:openParenAt(head)])
+	kw := plainJoin(suffix[:openParenAt(suffix)])
+	river := cols(name)
+	if w := cols(kw); w > river {
+		river = w
+	}
+	return []string{
+		strings.Repeat(" ", river-cols(name)) + plainJoin(head),
+		strings.Repeat(" ", col+river-cols(kw)) + plainJoin(suffix),
+	}
+}
+
+// openParenAt returns the index of the first top-level "(" in toks, or
+// len(toks) when there is none.
+func openParenAt(toks []Token) int {
+	for i, t := range toks {
+		if t.Text == "(" {
+			return i
+		}
+	}
+	return len(toks)
 }
 
 // splitTrailingAggSuffix cuts a run that ends in an aggregate's FILTER or

--- a/format/expr.go
+++ b/format/expr.go
@@ -234,15 +234,21 @@ func clauseParen(toks []Token, i int) bool {
 // at the same column -- the river the rest of the tool uses, applied to a
 // two-line construct:
 //
-//	 count(*)                                percentile_cont(array[0.5, 0.99])
-//	filter(where x is null) as dnfs             within group (order by d)
+//	 count(*)                              percentile_cont(array[0.5, 0.99])
+//	filter(where x is null) as dnfs           within group (order by d)
 //
 // "count" is pushed one column right to end where "filter" ends; where
 // the function name is the longer of the two it stays put and the suffix
 // keyword moves instead.
+//
+// The measure runs through the open paren, not just to the end of the
+// name, because "within group (" carries a space before its paren and
+// "percentile_cont(" does not: aligning the names alone would leave the
+// two argument lists one column apart, which is the thing the alignment
+// exists to line up.
 func aggSuffixLines(head, suffix []Token, col int) []string {
-	name := plainJoin(head[:openParenAt(head)])
-	kw := plainJoin(suffix[:openParenAt(suffix)])
+	name := plainJoin(head[:min(openParenAt(head)+1, len(head))])
+	kw := plainJoin(suffix[:min(openParenAt(suffix)+1, len(suffix))])
 	river := cols(name)
 	if w := cols(kw); w > river {
 		river = w

--- a/format/expr.go
+++ b/format/expr.go
@@ -108,6 +108,20 @@ func exprAtomDoc(toks []Token, levels [][]string) Doc {
 	if expr, cast := splitTrailingCast(toks); cast != "" {
 		return concat(exprAtomDoc(expr, levels), text(cast))
 	}
+	// "avg(x) over(...)" and "avg(x) over(...)::numeric" once the cast is
+	// peeled: the OVER clause has a layout of its own, but the run does
+	// not start with it, so deferredConstruct never fired -- and the paren
+	// logic below is right to refuse to hang a clause paren, which left
+	// the whole thing as one unbreakable atom. Defer the OVER in place
+	// instead, so it can lay itself out at whatever column it lands at.
+	if head, over, ok := splitTrailingOver(toks); ok {
+		return concat(
+			text(plainJoin(head)+" "),
+			defer_(plainJoin(over), func(col int) []string {
+				return layoutOver(over, col)
+			}),
+		)
+	}
 	// A trailing parenthesized group is the interesting case: a call's
 	// arguments, a row constructor, an IN list.
 	if toks[len(toks)-1].Text == ")" {
@@ -174,6 +188,30 @@ func clauseParen(toks []Token, i int) bool {
 		return i > 1 && toks[i-2].Kind == TokKeyword && toks[i-2].Lower == "within"
 	}
 	return false
+}
+
+// splitTrailingOver cuts a run that ends in an OVER(...) clause into the
+// windowed expression and the clause itself. The run must not be the OVER
+// alone -- deferredConstruct already handles that.
+func splitTrailingOver(toks []Token) ([]Token, []Token, bool) {
+	depth := 0
+	for i := range toks {
+		switch toks[i].Text {
+		case "(":
+			depth++
+			continue
+		case ")":
+			depth--
+			continue
+		}
+		if depth != 0 || i == 0 || toks[i].Kind != TokKeyword || toks[i].Lower != "over" {
+			continue
+		}
+		if i+1 < len(toks) && toks[i+1].Text == "(" && matchParen(toks, i+1) == len(toks)-1 {
+			return toks[:i], toks[i:], true
+		}
+	}
+	return nil, nil, false
 }
 
 // deferredConstruct wraps a run that is exactly one CASE ... END, or one

--- a/format/expr.go
+++ b/format/expr.go
@@ -19,6 +19,12 @@ import "strings"
 // exprDoc builds a Doc for a token run, or reports false when the run
 // contains something this layer does not model.
 func exprDoc(toks []Token) (Doc, bool) {
+	return exprDocLevels(toks, binaryLevels)
+}
+
+// exprDocLevels is exprDoc with an explicit operator set; see
+// predicateLevels for why the caller chooses it.
+func exprDocLevels(toks []Token, levels [][]string) (Doc, bool) {
 	toks = trimTokens(toks)
 	if len(toks) == 0 {
 		return Doc{}, false
@@ -33,46 +39,53 @@ func exprDoc(toks []Token) (Doc, bool) {
 			return Doc{}, false
 		}
 	}
-	return exprConcatDoc(toks), true
+	return exprConcatDoc(toks, levels), true
 }
 
 // exprConcatDoc handles the outermost structure: a "||" chain, if there is
 // one, else a comparison, else a plain run.
-func exprConcatDoc(toks []Token) Doc {
-	if parts := splitTopLevelConcat(toks); len(parts) > 1 {
+func exprConcatDoc(toks []Token, levels [][]string) Doc {
+	if parts, ops := splitTopLevelBinary(toks, levels); len(parts) > 1 {
 		ds := make([]Doc, 0, len(parts)*2)
-		for i, p := range parts {
-			if i > 0 {
-				ds = append(ds, line(), text("|| "))
-			}
-			ds = append(ds, exprCompareDoc(trimTokens(p)))
+		ds = append(ds, exprCompareDoc(trimTokens(parts[0]), levels))
+		for i, p := range parts[1:] {
+			// The operator hangs into the gutter left of the operands and
+			// every operand starts at the same column, the way the clause
+			// river sets "and"/"or" under "where". Putting the operator at
+			// the operand column instead pushes each continuation operand
+			// right by the operator's width, so a chain no longer lines up
+			// with the operand it started from.
+			op := ops[i]
+			ds = append(ds,
+				nest(-(cols(op)+1), concat(line(), text(op+" "))),
+				exprCompareDoc(trimTokens(p), levels))
 		}
 		return group(concat(ds...))
 	}
-	return exprCompareDoc(toks)
+	return exprCompareDoc(toks, levels)
 }
 
 // exprCompareDoc breaks at a top-level comparison operator between two
 // parenthesized row constructors -- "(a, b) <> (x, y)" -- which is a break
 // point no amount of breaking inside either list can substitute for.
-func exprCompareDoc(toks []Token) Doc {
+func exprCompareDoc(toks []Token, levels [][]string) Doc {
 	if i := topLevelRowOp(toks); i > 0 {
 		lhs, rhs := trimTokens(toks[:i]), trimTokens(toks[i+1:])
 		if isParenGroup(lhs) && isParenGroup(rhs) {
 			return group(concat(
-				exprAtomDoc(lhs),
+				exprAtomDoc(lhs, levels),
 				line(),
 				text(toks[i].Lower+" "),
-				exprAtomDoc(rhs),
+				exprAtomDoc(rhs, levels),
 			))
 		}
 	}
-	return exprAtomDoc(toks)
+	return exprAtomDoc(toks, levels)
 }
 
 // exprAtomDoc renders a run that has no top-level operator structure left:
 // a parenthesized group (possibly a call's argument list), or plain text.
-func exprAtomDoc(toks []Token) Doc {
+func exprAtomDoc(toks []Token, levels [][]string) Doc {
 	toks = trimTokens(toks)
 	if len(toks) == 0 {
 		return text("")
@@ -88,7 +101,12 @@ func exprAtomDoc(toks []Token) Doc {
 	// it off the run does not end in ")", and the whole item fell through
 	// to a single unbreakable Text.
 	if expr, alias := splitTrailingAlias(toks); alias != "" {
-		return concat(exprAtomDoc(expr), text(" "+alias))
+		return concat(exprAtomDoc(expr, levels), text(" "+alias))
+	}
+	// Same problem as the alias: "extract(...)::int" ends in a type name,
+	// not in ")", so the paren logic below never saw the call it wraps.
+	if expr, cast := splitTrailingCast(toks); cast != "" {
+		return concat(exprAtomDoc(expr, levels), text(cast))
 	}
 	// A trailing parenthesized group is the interesting case: a call's
 	// arguments, a row constructor, an IN list.
@@ -104,7 +122,7 @@ func exprAtomDoc(toks []Token) Doc {
 					// what the corpus does and reads worse than two.
 					ds := make([]Doc, 0, len(items))
 					for _, it := range items {
-						ds = append(ds, exprConcatDoc(trimTokens(it)))
+						ds = append(ds, exprConcatDoc(trimTokens(it), levels))
 					}
 					args := fill(concat(text(","), line()), ds...)
 					_ = args
@@ -149,6 +167,33 @@ func deferredConstruct(toks []Token) (Doc, bool) {
 	return Doc{}, false
 }
 
+// splitTrailingCast peels a trailing "::type" (including a schema
+// qualification and array brackets) off an expression, so what remains
+// ends in the ")" the paren layout keys on.
+func splitTrailingCast(toks []Token) ([]Token, string) {
+	n := len(toks)
+	// Walk back over "[]" pairs and a dotted type name to the "::".
+	i := n
+	for i > 0 && toks[i-1].Text == "]" {
+		if i < 2 || toks[i-2].Text != "[" {
+			return toks, ""
+		}
+		i -= 2
+	}
+	for i > 0 && (toks[i-1].Kind == TokIdent || toks[i-1].Kind == TokKeyword) {
+		i--
+		if i > 0 && toks[i-1].Text == "." {
+			i--
+			continue
+		}
+		break
+	}
+	if i < 2 || toks[i-1].Text != "::" || i-1 == 0 {
+		return toks, ""
+	}
+	return toks[:i-1], plainJoin(toks[i-1:])
+}
+
 // splitTrailingAlias peels a trailing column alias off an expression,
 // returning the expression and the alias text ("as elem", "elem"), or an
 // empty alias when there is none. Only an alias directly after a closing
@@ -188,7 +233,17 @@ func lastTopLevelOpen(toks []Token) int {
 // the run is one this layer declines, or when the result is no better than
 // the flat form the caller already has.
 func exprLines(toks []Token, col int) ([]string, bool) {
-	d, ok := exprDoc(toks)
+	return exprLinesLevels(toks, col, binaryLevels)
+}
+
+// predicateLines lays out a condition -- a WHERE body, a JOIN ... ON --
+// which may also break at a comparison operator.
+func predicateLines(toks []Token, col int) ([]string, bool) {
+	return exprLinesLevels(toks, col, predicateLevels)
+}
+
+func exprLinesLevels(toks []Token, col int, levels [][]string) ([]string, bool) {
+	d, ok := exprDocLevels(toks, levels)
 	if !ok {
 		return nil, false
 	}
@@ -203,11 +258,11 @@ func exprLines(toks []Token, col int) ([]string, bool) {
 	flat := plainJoin(trimTokens(toks))
 	longest := 0
 	for _, l := range lines {
-		if n := len(l); n > longest {
+		if n := cols(l); n > longest {
 			longest = n
 		}
 	}
-	if longest >= col+len(flat) {
+	if longest >= col+cols(flat) {
 		return nil, false
 	}
 	return lines, true

--- a/format/format.go
+++ b/format/format.go
@@ -236,6 +236,17 @@ func layoutDDL(toks []Token) []string {
 	if len(bounds) == 0 {
 		return []string{flatJoin(toks)}
 	}
+	// A view is its query: "create view v as" on one line, then the query
+	// laid out as it would be on its own. Running it through the clause
+	// river below would put "as" on a line of its own and leave the query
+	// flat beside it.
+	if last := bounds[len(bounds)-1]; last.name == "as" && len(bounds) == 1 {
+		body := trimTokens(toks[last.idx+1:])
+		if isQueryStart(body) {
+			head := flatJoin(toks[:last.idx]) + " as"
+			return append([]string{head}, strings.Split(formatStatement(body), "\n")...)
+		}
+	}
 	head := flatJoin(toks[:bounds[0].idx])
 	if len(head)+1+len(flatJoin(toks[bounds[0].idx:])) <= targetWidth {
 		return []string{flatJoin(toks)}
@@ -392,6 +403,19 @@ func hoistLanguage(clauses []ddlClause) []ddlClause {
 	return out
 }
 
+// isQueryStart reports whether toks begins a query -- the payload of a
+// CREATE VIEW or a CREATE TABLE ... AS.
+func isQueryStart(toks []Token) bool {
+	if len(toks) == 0 || toks[0].Kind != TokKeyword {
+		return false
+	}
+	switch toks[0].Lower {
+	case "select", "with", "values", "table":
+		return true
+	}
+	return false
+}
+
 // matchDDLWords is matchWords without the TokKeyword requirement. Several
 // DDL clause introducers -- BEFORE, AFTER, EXECUTE, RETURNS, INCLUDE,
 // TABLESPACE -- are not in the lexer's keyword table and lex as plain
@@ -433,6 +457,19 @@ func ddlClauseBounds(toks []Token) []ddlBound {
 		for _, cw := range ddlClauseWords {
 			if matchDDLWords(toks, i, cw.words) {
 				out = append(out, ddlBound{idx: i, name: cw.name, words: cw.words})
+				if cw.name == "as" {
+					// AS introduces the payload. A dollar-quoted function
+					// body is a single token, so scanning can resume after
+					// it -- that is where a trailing LANGUAGE clause lives.
+					// A view's payload is a query, which has FROM/AS/ON of
+					// its own: continuing to scan chopped the SELECT up at
+					// its own clause keywords and dropped most of it.
+					if i+1 < len(toks) && toks[i+1].Kind == TokDollarString {
+						i++
+						break
+					}
+					return out
+				}
 				i += len(cw.words) - 1
 				break
 			}

--- a/format/format.go
+++ b/format/format.go
@@ -161,6 +161,8 @@ func formatStatement(toks []Token) string {
 		lines = formatQuerySegment(body, 0)
 	case "explain":
 		lines = layoutExplain(body)
+	case "merge":
+		lines = layoutMerge(body)
 	case "":
 		// A statement that opens with "(" -- the parenthesized arms of a
 		// set operation -- is still a query, and formatQuerySegment knows

--- a/format/format.go
+++ b/format/format.go
@@ -134,6 +134,16 @@ func formatStatement(toks []Token) string {
 		lines = formatQuerySegment(body, 0)
 	case "explain":
 		lines = layoutExplain(body)
+	case "":
+		// A statement that opens with "(" -- the parenthesized arms of a
+		// set operation -- is still a query, and formatQuerySegment knows
+		// how to unwrap it. Anything else with no leading keyword falls
+		// through to the flat default below.
+		if len(body) > 0 && body[0].Text == "(" {
+			lines = formatQuerySegment(body, 0)
+		} else {
+			lines = []string{flatJoin(body)}
+		}
 	default:
 		lines = []string{flatJoin(body)}
 	}

--- a/format/format.go
+++ b/format/format.go
@@ -254,15 +254,47 @@ func explainPayloadJoinsRiver(rest []Token) bool {
 // left-padded to a common width so data types start in the same column,
 // table-level constraints separated by a blank line, closing ")" at the
 // opening "("'s indent.
-func layoutCreateTable(toks []Token) []string {
-	open := -1
+// createTableColumnList returns the index of the "(" opening a CREATE
+// TABLE's column list, or -1 when the statement has none. The column list
+// is the first "(" that follows the table name directly; anything with a
+// keyword in between ("partition of t for values from (", "as select ... (")
+// is some other construct's paren, and treating it as the column list
+// mangled the statement and dropped everything after it.
+func createTableColumnList(toks []Token) int {
 	for i, t := range toks {
-		if t.Text == "(" {
-			open = i
-			break
+		if t.Text != "(" {
+			continue
+		}
+		for j := 2; j < i; j++ {
+			if toks[j].Kind == TokKeyword && toks[j].Lower != "if" &&
+				toks[j].Lower != "not" && toks[j].Lower != "exists" {
+				return -1
+			}
+		}
+		return i
+	}
+	return -1
+}
+
+// createTableAsBody returns the index of the statement a CREATE TABLE ... AS
+// wraps, or -1 if this is not a CTAS. The wrapped statement is then
+// formatted as it would be on its own.
+func createTableAsBody(toks []Token) int {
+	for i, t := range toks {
+		if t.Kind == TokKeyword && t.Lower == "as" && i+1 < len(toks) {
+			return i + 1
 		}
 	}
+	return -1
+}
+
+func layoutCreateTable(toks []Token) []string {
+	open := createTableColumnList(toks)
 	if open == -1 {
+		if body := createTableAsBody(toks); body != -1 {
+			head := flatJoin(toks[:body])
+			return append([]string{head}, strings.Split(formatStatement(toks[body:]), "\n")...)
+		}
 		return []string{flatJoin(toks)}
 	}
 	header := flatJoin(toks[:open])
@@ -312,6 +344,13 @@ func layoutCreateTable(toks []Token) []string {
 		lines = append(lines, rest[1:]...)
 		prevWasColumn = true
 	}
-	lines = append(lines, ")")
+	// Whatever follows the column list belongs to the statement and must
+	// not be dropped: PARTITION BY, INHERITS, TABLESPACE, WITH (...), the
+	// lot. Losing it silently turned a partitioned table into a plain one.
+	closing := ")"
+	if tail := trimTokens(toks[close+1:]); len(tail) > 0 {
+		closing += " " + flatJoin(tail)
+	}
+	lines = append(lines, closing)
 	return lines
 }

--- a/format/format.go
+++ b/format/format.go
@@ -84,8 +84,32 @@ func statementKeyword(toks []Token) string {
 		return ""
 	}
 	first := toks[0].Lower
-	if first == "create" && len(toks) > 1 && toks[1].Kind == TokKeyword && toks[1].Lower == "table" {
-		return "create table"
+	if first == "create" || first == "drop" || first == "alter" {
+		// Skip the optional "or replace" / "unique" / "materialized" /
+		// "if not exists" noise between the verb and the object kind.
+		for i := 1; i < len(toks) && i < 6; i++ {
+			if toks[i].Kind != TokKeyword && toks[i].Kind != TokIdent {
+				break
+			}
+			switch toks[i].Lower {
+			case "or", "replace", "unique", "if", "not", "exists", "recursive",
+				"temp", "temporary", "unlogged", "concurrently":
+				continue
+			case "table", "index", "function", "view", "trigger", "statistics",
+				"sequence", "procedure", "materialized":
+				kind := toks[i].Lower
+				if kind == "materialized" {
+					// "create materialized view" lays out as a view.
+					kind = "view"
+				}
+				if first == "create" {
+					return "create " + kind
+				}
+				return first
+			default:
+				return first
+			}
+		}
 	}
 	return first
 }
@@ -130,6 +154,9 @@ func formatStatement(toks []Token) string {
 		lines = []string{flatJoin(body)}
 	case "create table":
 		lines = layoutCreateTable(body)
+	case "create index", "create function", "create view", "create trigger",
+		"create statistics", "create sequence", "create procedure":
+		lines = layoutDDL(body)
 	case "select", "insert", "update", "delete", "with":
 		lines = formatQuerySegment(body, 0)
 	case "explain":
@@ -156,6 +183,177 @@ func formatStatement(toks []Token) string {
 		}
 	} else if tc := toks[len(toks)-1].TrailingComment; tc != nil {
 		out += commentMarker + trailingCommentText(tc)
+	}
+	return out
+}
+
+// ddlClauseWords are the keywords that introduce a continuation clause in
+// the DDL statements layoutDDL handles. Order matters only for the two-word
+// entries, which must precede any single-word entry sharing their first
+// word.
+var ddlClauseWords = []struct {
+	words []string
+	name  string
+}{
+	{[]string{"security", "definer"}, "security definer"},
+	{[]string{"security", "invoker"}, "security invoker"},
+	{[]string{"returns"}, "returns"},
+	{[]string{"language"}, "language"},
+	{[]string{"using"}, "using"},
+	{[]string{"include"}, "include"},
+	{[]string{"tablespace"}, "tablespace"},
+	{[]string{"where"}, "where"},
+	{[]string{"from"}, "from"},
+	{[]string{"on"}, "on"},
+	{[]string{"as"}, "as"},
+	{[]string{"immutable"}, "immutable"},
+	{[]string{"stable"}, "stable"},
+	{[]string{"volatile"}, "volatile"},
+	{[]string{"strict"}, "strict"},
+	{[]string{"parallel"}, "parallel"},
+	{[]string{"cost"}, "cost"},
+	{[]string{"execute"}, "execute"},
+	{[]string{"for"}, "for"},
+	{[]string{"before"}, "before"},
+	{[]string{"after"}, "after"},
+}
+
+// layoutDDL renders CREATE FUNCTION / INDEX / VIEW / TRIGGER / STATISTICS
+// and friends. Everything except CREATE TABLE used to fall through
+// formatStatement's default arm to flatJoin, which put the whole header on
+// one line -- a hand-written four-line CREATE FUNCTION header came back at
+// 138 columns, and 47 CREATE INDEX statements lost their line breaks.
+//
+// The shape is the one the rest of the tool uses: the object being created
+// stays on the first line, and each continuation clause goes on its own
+// line, right-padded so the clause keywords end at a common column -- a
+// river, computed over the continuation clauses only. The "create ..."
+// line is deliberately not part of that river: it carries the object name
+// and argument list and is routinely 40+ characters, which would push every
+// other line off the page.
+func layoutDDL(toks []Token) []string {
+	bounds := ddlClauseBounds(toks)
+	if len(bounds) == 0 {
+		return []string{flatJoin(toks)}
+	}
+	head := flatJoin(toks[:bounds[0].idx])
+	if len(head)+1+len(flatJoin(toks[bounds[0].idx:])) <= targetWidth {
+		return []string{flatJoin(toks)}
+	}
+
+	width := 0
+	for _, b := range bounds {
+		if len(b.name) > width {
+			width = len(b.name)
+		}
+	}
+
+	// Resolve each clause's body span first: hoistLanguage reorders the
+	// clauses, and a clause's span is defined by where the *next* one
+	// starts in the source, not in the output.
+	clauses := make([]ddlClause, 0, len(bounds))
+	for bi, b := range bounds {
+		end := len(toks)
+		if bi+1 < len(bounds) {
+			end = bounds[bi+1].idx
+		}
+		clauses = append(clauses, ddlClause{b.name, flatJoin(toks[b.idx+len(b.words) : end])})
+	}
+	clauses = hoistLanguage(clauses)
+
+	lines := []string{head}
+	for _, c := range clauses {
+		line := strings.Repeat(" ", width-len(c.name)) + c.name
+		if c.body != "" {
+			line += " " + c.body
+		}
+		lines = append(lines, line)
+	}
+	return lines
+}
+
+// ddlClause is one rendered continuation clause: its keyword and the text
+// that follows it.
+type ddlClause struct{ name, body string }
+
+// hoistLanguage moves a LANGUAGE clause that trails the body back into the
+// header, ahead of AS. PostgreSQL accepts a function's option list in any
+// order, so "as $$ ... $$ language plpgsql" is legal and common -- but it
+// buries the single most useful fact about a function, what language it is
+// written in, behind however many hundred lines its body runs to. Reading
+// the declaration should not require scrolling past the implementation.
+// Reordering options changes nothing about what the statement does.
+func hoistLanguage(clauses []ddlClause) []ddlClause {
+	asAt, langAt := -1, -1
+	for i, c := range clauses {
+		switch c.name {
+		case "as":
+			if asAt == -1 {
+				asAt = i
+			}
+		case "language":
+			langAt = i
+		}
+	}
+	if asAt == -1 || langAt == -1 || langAt < asAt {
+		return clauses
+	}
+	out := make([]ddlClause, 0, len(clauses))
+	out = append(out, clauses[:asAt]...)
+	out = append(out, clauses[langAt])
+	for i := asAt; i < len(clauses); i++ {
+		if i != langAt {
+			out = append(out, clauses[i])
+		}
+	}
+	return out
+}
+
+// matchDDLWords is matchWords without the TokKeyword requirement. Several
+// DDL clause introducers -- BEFORE, AFTER, EXECUTE, RETURNS, INCLUDE,
+// TABLESPACE -- are not in the lexer's keyword table and lex as plain
+// identifiers, but in this position they are unambiguously clause
+// keywords.
+func matchDDLWords(toks []Token, i int, words []string) bool {
+	for j, w := range words {
+		if i+j >= len(toks) || toks[i+j].Lower != w {
+			return false
+		}
+	}
+	return true
+}
+
+type ddlBound struct {
+	idx   int
+	name  string
+	words []string
+}
+
+// ddlClauseBounds finds each top-level DDL continuation clause. A clause
+// keyword inside parentheses (a column list, an argument list, an index
+// expression) belongs to that construct, not to the statement.
+func ddlClauseBounds(toks []Token) []ddlBound {
+	var out []ddlBound
+	depth := 0
+	for i := 0; i < len(toks); i++ {
+		switch toks[i].Text {
+		case "(":
+			depth++
+			continue
+		case ")":
+			depth--
+			continue
+		}
+		if depth != 0 {
+			continue
+		}
+		for _, cw := range ddlClauseWords {
+			if matchDDLWords(toks, i, cw.words) {
+				out = append(out, ddlBound{idx: i, name: cw.name, words: cw.words})
+				i += len(cw.words) - 1
+				break
+			}
+		}
 	}
 	return out
 }

--- a/format/format.go
+++ b/format/format.go
@@ -298,7 +298,7 @@ func formatSQLBody(clauses []ddlClause) []ddlClause {
 		if c.name != "as" {
 			continue
 		}
-		tag, inner, ok := splitDollarQuote(c.body)
+		tag, inner, ok := SplitDollarQuoted(strings.TrimSpace(c.body))
 		if !ok {
 			continue
 		}
@@ -309,25 +309,6 @@ func formatSQLBody(clauses []ddlClause) []ddlClause {
 		out[i].body = tag + "\n" + strings.TrimRight(formatted, "\n") + "\n" + tag
 	}
 	return out
-}
-
-// splitDollarQuote splits "$tag$body$tag$" into its tag and body. It
-// reports false for anything that is not a single, complete dollar-quoted
-// string -- a body with trailing options after it, say.
-func splitDollarQuote(s string) (tag, inner string, ok bool) {
-	s = strings.TrimSpace(s)
-	if !strings.HasPrefix(s, "$") {
-		return "", "", false
-	}
-	end := strings.Index(s[1:], "$")
-	if end < 0 {
-		return "", "", false
-	}
-	tag = s[:end+2]
-	if !strings.HasSuffix(s, tag) || len(s) < 2*len(tag) {
-		return "", "", false
-	}
-	return tag, s[len(tag) : len(s)-len(tag)], true
 }
 
 // ddlClause is one rendered continuation clause: its keyword and the text

--- a/format/format.go
+++ b/format/format.go
@@ -791,7 +791,21 @@ func layoutCreateTable(toks []Token) []string {
 			if prevWasColumn {
 				lines = append(lines, "")
 			}
-			lines = append(lines, "  "+flatJoin(it)+comma+trailing)
+			// A wide constraint breaks the way the corpus writes it, with
+			// REFERENCES a step further in than the key it qualifies.
+			// flatJoin alone left "foreign key (a, b, c) references
+			// t(a, b, c)" on one 97-column line.
+			flat := flatJoin(it)
+			if cols(flat)+2+cols(comma) > targetWidth {
+				if l, ok := layoutIndentedClauses(it, constraintClauses, 4); ok && len(l) > 1 {
+					l[len(l)-1] += comma + trailing
+					lines = append(lines, "  "+l[0])
+					lines = append(lines, l[1:]...)
+					prevWasColumn = false
+					continue
+				}
+			}
+			lines = append(lines, "  "+flat+comma+trailing)
 			prevWasColumn = false
 			continue
 		}

--- a/format/format.go
+++ b/format/format.go
@@ -797,10 +797,9 @@ func layoutCreateTable(toks []Token) []string {
 			// t(a, b, c)" on one 97-column line.
 			flat := flatJoin(it)
 			if cols(flat)+2+cols(comma) > targetWidth {
-				if l, ok := layoutIndentedClauses(it, constraintClauses, 4); ok && len(l) > 1 {
+				if l, ok := layoutRiverClauses(it, constraintClauses, 2); ok && len(l) > 1 {
 					l[len(l)-1] += comma + trailing
-					lines = append(lines, "  "+l[0])
-					lines = append(lines, l[1:]...)
+					lines = append(lines, l...)
 					prevWasColumn = false
 					continue
 				}

--- a/format/format.go
+++ b/format/format.go
@@ -315,10 +315,15 @@ func formatSQLBody(clauses []ddlClause) []ddlClause {
 			// come back wider and more ragged than the author's own
 			// version. The author's version is then the better answer, and
 			// leaving it is always correct.
-			// Indentation legitimately lengthens lines, so the test is
-			// not "longer than before" but "pushed past the target width
-			// when it was not there already".
-			if maxLineLen(pl) > targetWidth && maxLineLen(pl) > maxLineLen(inner) {
+			// The guard is here to catch pathological output -- a
+			// construct the SQL layout cascades into a staircase running
+			// well past the page -- not to enforce rule 17, which is a
+			// soft target. Indentation legitimately lengthens lines, and a
+			// body that lands a column or two over the target is still far
+			// better than an unformatted one, so the comparison is against
+			// the author's own longest line plus a tolerance for the
+			// indentation this adds.
+			if maxLineLen(pl) > maxLineLen(inner)+plBodyTolerance {
 				continue
 			}
 			formatted = pl
@@ -333,6 +338,11 @@ func formatSQLBody(clauses []ddlClause) []ddlClause {
 	}
 	return out
 }
+
+// plBodyTolerance is how much longer than the author's own longest line a
+// formatted PL/pgSQL body may be before it is rejected as worse than what
+// it replaces -- roughly the indentation a couple of nested blocks add.
+const plBodyTolerance = 8
 
 // maxLineLen returns the length of the longest line in s.
 func maxLineLen(s string) int {

--- a/format/format.go
+++ b/format/format.go
@@ -263,23 +263,46 @@ func layoutDDL(toks []Token) []string {
 	// clauses, and a clause's span is defined by where the *next* one
 	// starts in the source, not in the output.
 	clauses := make([]ddlClause, 0, len(bounds))
+	clauseToks := make([][]Token, 0, len(bounds))
 	for bi, b := range bounds {
 		end := len(toks)
 		if bi+1 < len(bounds) {
 			end = bounds[bi+1].idx
 		}
 		clauses = append(clauses, ddlClause{b.name, flatJoin(toks[b.idx+len(b.words) : end])})
+		clauseToks = append(clauseToks, toks[b.idx+len(b.words):end])
 	}
 	clauses = hoistLanguage(clauses)
 	clauses = formatSQLBody(clauses)
 
-	lines := []string{head}
-	for _, c := range clauses {
-		line := strings.Repeat(" ", width-len(c.name)) + c.name
-		if c.body != "" {
-			line += " " + c.body
+	// The head can overflow on its own -- "create statistics name (kind,
+	// kind, ...)" carries a list too -- and gets the same treatment.
+	headLines := []string{head}
+	if len(head) > targetWidth {
+		if filled, ok := ddlFillBody(toks[:bounds[0].idx], 0); ok {
+			headLines = filled
 		}
-		lines = append(lines, line)
+	}
+	lines := headLines
+	for ci, c := range clauses {
+		prefix := strings.Repeat(" ", width-len(c.name)) + c.name
+		if c.body == "" {
+			lines = append(lines, prefix)
+			continue
+		}
+		if len(prefix)+1+len(c.body) > targetWidth && ci < len(clauseToks) {
+			// An index's column list or a statistics kind list is
+			// call-shaped -- "using btree(a, b, ...)" -- so renderRun's
+			// paren handling leaves it alone per rule 4, and a wide one
+			// overflows. Only the clause knows it is a list, so fill it
+			// here, the same way the INSERT column list is filled.
+			if filled, ok := ddlFillBody(clauseToks[ci], len(prefix)+1); ok {
+				lines = append(lines, prefix+" "+filled[0])
+				lines = append(lines, filled[1:]...)
+				continue
+			}
+		}
+		lines = append(lines, prefix+" "+c.body)
 	}
 	return lines
 }
@@ -369,6 +392,46 @@ func maxLineLen(s string) int {
 // ddlClause is one rendered continuation clause: its keyword and the text
 // that follows it.
 type ddlClause struct{ name, body string }
+
+// ddlFillBody fills a DDL clause body that does not fit: either a trailing
+// parenthesized list ("using btree(a, b, ...)", "on t (a, b, ...)") or a
+// bare comma list ("on isocode, class, feature"). Reports false when there
+// is no list to fill, or when filling would not help.
+func ddlFillBody(toks []Token, col int) ([]string, bool) {
+	toks = trimTokens(toks)
+	if len(toks) == 0 {
+		return nil, false
+	}
+	if toks[len(toks)-1].Text == ")" {
+		open := -1
+		depth := 0
+		for i := len(toks) - 1; i >= 0; i-- {
+			switch toks[i].Text {
+			case ")":
+				depth++
+			case "(":
+				depth--
+				if depth == 0 {
+					open = i
+				}
+			}
+			if open >= 0 {
+				break
+			}
+		}
+		if open >= 0 {
+			head := plainJoin(toks[:open])
+			filled, ok := fillCommaList(toks[open+1:len(toks)-1], col+len(head)+1)
+			if !ok {
+				return nil, false
+			}
+			filled[0] = head + "(" + filled[0]
+			filled[len(filled)-1] += ")"
+			return filled, true
+		}
+	}
+	return fillCommaList(toks, col)
+}
 
 // hoistLanguage moves a LANGUAGE clause that trails the body back into the
 // header, ahead of AS. PostgreSQL accepts a function's option list in any

--- a/format/format.go
+++ b/format/format.go
@@ -172,6 +172,8 @@ func formatStatement(toks []Token) string {
 		lines = formatQuerySegment(body, 0)
 	case "alter":
 		lines = layoutAlter(body)
+	case "prepare":
+		lines = layoutPrepare(body)
 	case "grant", "revoke":
 		if l, ok := layoutIndentedClauses(body, grantClauses, 2); ok {
 			lines = l
@@ -212,6 +214,41 @@ func formatStatement(toks []Token) string {
 		out += commentMarker + trailingCommentText(tc)
 	}
 	return out
+}
+
+// layoutPrepare puts a PREPARE's header on its own line and hands the
+// statement it prepares to the query layout, which is how the corpus
+// writes it:
+//
+//	prepare foo as
+//	 select date, shares, trades, dollars
+//	   from factbook
+//	  where date >= $1::date
+//
+// Without this the whole thing went through flatJoin -- one 144-column
+// line carrying a complete SELECT.
+func layoutPrepare(toks []Token) []string {
+	depth := 0
+	for i, t := range toks {
+		switch t.Text {
+		case "(":
+			depth++
+			continue
+		case ")":
+			depth--
+			continue
+		}
+		if depth != 0 || t.Kind != TokKeyword || t.Lower != "as" {
+			continue
+		}
+		rest := trimTokens(toks[i+1:])
+		if !isQueryStart(rest) {
+			break
+		}
+		head := flatJoin(toks[:i+1])
+		return append([]string{head}, formatQuerySegment(rest, 1)...)
+	}
+	return flatStatementLines(toks)
 }
 
 // flatStatementLines renders a statement the layout has no clause
@@ -713,8 +750,13 @@ func createTableColumnList(toks []Token) int {
 			continue
 		}
 		for j := 2; j < i; j++ {
+			// "of" belongs to the table's name -- "create table rate of
+			// rate_t (...)" is a typed table and still has a column list.
+			// "partition" deliberately stays disallowed, so a partition
+			// definition falls through to its own clause layout.
 			if toks[j].Kind == TokKeyword && toks[j].Lower != "if" &&
-				toks[j].Lower != "not" && toks[j].Lower != "exists" {
+				toks[j].Lower != "not" && toks[j].Lower != "exists" &&
+				toks[j].Lower != "of" {
 				return -1
 			}
 		}
@@ -751,7 +793,8 @@ func layoutCreateTable(toks []Token) []string {
 	close := matchParen(toks, open)
 	items := splitTopLevelComma(trimTokens(toks[open+1 : close]))
 
-	constraintKws := map[string]bool{"primary": true, "unique": true, "check": true, "constraint": true, "foreign": true}
+	constraintKws := map[string]bool{"primary": true, "unique": true, "check": true,
+		"constraint": true, "foreign": true, "exclude": true}
 	isConstraint := func(it []Token) bool {
 		it = trimTokens(it)
 		return len(it) > 0 && it[0].Kind == TokKeyword && constraintKws[it[0].Lower]

--- a/format/format.go
+++ b/format/format.go
@@ -151,12 +151,23 @@ func formatStatement(toks []Token) string {
 	var lines []string
 	switch kw {
 	case "begin", "commit", "rollback":
-		lines = []string{flatJoin(body)}
+		lines = flatStatementLines(body)
 	case "create table":
 		lines = layoutCreateTable(body)
 	case "create index", "create function", "create view", "create trigger",
 		"create statistics", "create sequence", "create procedure":
-		lines = layoutDDL(body)
+		// layoutDDL assembles its clause words with flatJoin and has no
+		// place to put a "--" comment, so it dropped them; renderRun
+		// always breaks the line after one. That trade is only worth
+		// making for DDL whose payload is not itself a query -- a CREATE
+		// VIEW's body goes back through the query layout, which handles
+		// comments properly, and handing the whole statement to renderRun
+		// instead flattens a carefully rivered view into one long line.
+		if hasLineComment(body) && !ddlBodyIsQuery(body) {
+			lines = renderRun(body, 0)
+		} else {
+			lines = layoutDDL(body)
+		}
 	case "select", "insert", "update", "delete", "with":
 		lines = formatQuerySegment(body, 0)
 	case "explain":
@@ -171,10 +182,10 @@ func formatStatement(toks []Token) string {
 		if len(body) > 0 && body[0].Text == "(" {
 			lines = formatQuerySegment(body, 0)
 		} else {
-			lines = []string{flatJoin(body)}
+			lines = flatStatementLines(body)
 		}
 	default:
-		lines = []string{flatJoin(body)}
+		lines = flatStatementLines(body)
 	}
 
 	out := strings.Join(lines, "\n")
@@ -187,6 +198,17 @@ func formatStatement(toks []Token) string {
 		out += commentMarker + trailingCommentText(tc)
 	}
 	return out
+}
+
+// flatStatementLines renders a statement the layout has no clause
+// structure for. That is normally one flat line, but a "--" comment in the
+// middle of the run cannot share a line with the tokens after it, so the
+// run keeps the line breaks renderRun put in for it.
+func flatStatementLines(body []Token) []string {
+	if hasLineComment(body) {
+		return renderRun(body, 0)
+	}
+	return []string{flatJoin(body)}
 }
 
 // ddlClauseWords are the keywords that introduce a continuation clause in
@@ -470,6 +492,24 @@ func hoistLanguage(clauses []ddlClause) []ddlClause {
 
 // isQueryStart reports whether toks begins a query -- the payload of a
 // CREATE VIEW or a CREATE TABLE ... AS.
+// ddlBodyIsQuery reports whether a DDL statement carries a query as its
+// payload -- "create view v as select ...", "create table t as with ...".
+func ddlBodyIsQuery(toks []Token) bool {
+	depth := 0
+	for i, t := range toks {
+		switch t.Text {
+		case "(":
+			depth++
+		case ")":
+			depth--
+		}
+		if depth == 0 && t.Kind == TokKeyword && t.Lower == "as" && isQueryStart(toks[i+1:]) {
+			return true
+		}
+	}
+	return false
+}
+
 func isQueryStart(toks []Token) bool {
 	if len(toks) == 0 || toks[0].Kind != TokKeyword {
 		return false
@@ -685,10 +725,10 @@ func layoutCreateTable(toks []Token) []string {
 	open := createTableColumnList(toks)
 	if open == -1 {
 		if body := createTableAsBody(toks); body != -1 {
-			head := flatJoin(toks[:body])
-			return append([]string{head}, strings.Split(formatStatement(toks[body:]), "\n")...)
+			head := flatStatementLines(toks[:body])
+			return append(head, strings.Split(formatStatement(toks[body:]), "\n")...)
 		}
-		return []string{flatJoin(toks)}
+		return flatStatementLines(toks)
 	}
 	header := flatJoin(toks[:open])
 	close := matchParen(toks, open)
@@ -722,18 +762,26 @@ func layoutCreateTable(toks []Token) []string {
 		if idx == len(items)-1 {
 			comma = ""
 		}
+		// Peeled before flatJoin/renderRun, both of which consume the
+		// metadata: the comma separating two columns is part of the
+		// statement and has to be emitted before the comment, not after
+		// it. Appending it to renderRun's output put the comma inside the
+		// comment -- "bigserial primary key -- the key," -- which is a
+		// syntax error, and left renderRun's post-comment line break
+		// behind as a stray blank line.
+		trailing := trailingCommentSuffix(it)
 		if isConstraint(it) {
 			if prevWasColumn {
 				lines = append(lines, "")
 			}
-			lines = append(lines, "  "+flatJoin(it)+comma)
+			lines = append(lines, "  "+flatJoin(it)+comma+trailing)
 			prevWasColumn = false
 			continue
 		}
 		name := it[0].Text
 		rest := renderRun(trimTokens(it[1:]), 2+maxName+1)
 		pad := strings.Repeat(" ", maxName-len(name))
-		lines = append(lines, "  "+name+pad+" "+rest[0]+comma)
+		lines = append(lines, "  "+name+pad+" "+rest[0]+comma+trailing)
 		lines = append(lines, rest[1:]...)
 		prevWasColumn = true
 	}

--- a/format/format.go
+++ b/format/format.go
@@ -278,10 +278,11 @@ func layoutDDL(toks []Token) []string {
 // leave it as whatever the author typed while every other statement in the
 // file gets laid out.
 //
-// Only "language sql" is touched. Every other language -- plpgsql, plpython,
-// plperl -- is passed through verbatim, which is both the existing behaviour
-// and the only safe one: the lexer treats a dollar-quoted body as a single
-// opaque token, so a body it does not understand is preserved exactly.
+// LANGUAGE SQL bodies go through Format; LANGUAGE PLPGSQL bodies go
+// through FormatPlpgsql. Every other language -- plpython, plperl, plv8 --
+// is passed through verbatim, which is the only safe answer: the lexer
+// treats a dollar-quoted body as a single opaque token, so a body this
+// package does not understand is preserved exactly as written.
 func formatSQLBody(clauses []ddlClause) []ddlClause {
 	lang := ""
 	for _, c := range clauses {
@@ -289,7 +290,7 @@ func formatSQLBody(clauses []ddlClause) []ddlClause {
 			lang = strings.ToLower(strings.TrimSpace(c.body))
 		}
 	}
-	if lang != "sql" {
+	if lang != "sql" && lang != "plpgsql" {
 		return clauses
 	}
 	out := make([]ddlClause, len(clauses))
@@ -302,13 +303,46 @@ func formatSQLBody(clauses []ddlClause) []ddlClause {
 		if !ok {
 			continue
 		}
-		formatted, err := Format(strings.NewReader(inner))
-		if err != nil {
-			continue // unparseable body: leave it exactly as written
+		var formatted string
+		if lang == "plpgsql" {
+			pl, pok := FormatPlpgsql(inner, 0)
+			if !pok {
+				continue // not a skeleton we recognise: leave it alone
+			}
+			// Only rewrite when it is an improvement. A PL/pgSQL body is
+			// mostly embedded SQL, and a construct the SQL layout handles
+			// poorly -- a SET with several CASE expressions, say -- can
+			// come back wider and more ragged than the author's own
+			// version. The author's version is then the better answer, and
+			// leaving it is always correct.
+			// Indentation legitimately lengthens lines, so the test is
+			// not "longer than before" but "pushed past the target width
+			// when it was not there already".
+			if maxLineLen(pl) > targetWidth && maxLineLen(pl) > maxLineLen(inner) {
+				continue
+			}
+			formatted = pl
+		} else {
+			f, err := Format(strings.NewReader(inner))
+			if err != nil {
+				continue // unparseable body: leave it exactly as written
+			}
+			formatted = f
 		}
 		out[i].body = tag + "\n" + strings.TrimRight(formatted, "\n") + "\n" + tag
 	}
 	return out
+}
+
+// maxLineLen returns the length of the longest line in s.
+func maxLineLen(s string) int {
+	m := 0
+	for _, l := range strings.Split(s, "\n") {
+		if len(l) > m {
+			m = len(l)
+		}
+	}
+	return m
 }
 
 // ddlClause is one rendered continuation clause: its keyword and the text

--- a/format/format.go
+++ b/format/format.go
@@ -170,6 +170,8 @@ func formatStatement(toks []Token) string {
 		}
 	case "select", "insert", "update", "delete", "with":
 		lines = formatQuerySegment(body, 0)
+	case "alter":
+		lines = layoutAlter(body)
 	case "explain":
 		lines = layoutExplain(body)
 	case "merge":
@@ -272,7 +274,7 @@ func layoutDDL(toks []Token) []string {
 		}
 	}
 	head := flatJoin(toks[:bounds[0].idx])
-	if len(head)+1+len(flatJoin(toks[bounds[0].idx:])) <= targetWidth {
+	if cols(head)+1+cols(flatJoin(toks[bounds[0].idx:])) <= targetWidth {
 		return []string{flatJoin(toks)}
 	}
 
@@ -302,7 +304,7 @@ func layoutDDL(toks []Token) []string {
 	// The head can overflow on its own -- "create statistics name (kind,
 	// kind, ...)" carries a list too -- and gets the same treatment.
 	headLines := []string{head}
-	if len(head) > targetWidth {
+	if cols(head) > targetWidth {
 		if filled, ok := ddlFillBody(toks[:bounds[0].idx], 0); ok {
 			headLines = filled
 		}
@@ -314,7 +316,7 @@ func layoutDDL(toks []Token) []string {
 			lines = append(lines, prefix)
 			continue
 		}
-		if len(prefix)+1+len(c.body) > targetWidth && ci < len(clauseToks) {
+		if cols(prefix)+1+cols(c.body) > targetWidth && ci < len(clauseToks) {
 			// An index's column list or a statistics kind list is
 			// call-shaped -- "using btree(a, b, ...)" -- so renderRun's
 			// paren handling leaves it alone per rule 4, and a wide one
@@ -746,8 +748,8 @@ func layoutCreateTable(toks []Token) []string {
 		if len(it) == 0 || isConstraint(it) {
 			continue
 		}
-		if len(it[0].Text) > maxName {
-			maxName = len(it[0].Text)
+		if cols(it[0].Text) > maxName {
+			maxName = cols(it[0].Text)
 		}
 	}
 
@@ -780,7 +782,7 @@ func layoutCreateTable(toks []Token) []string {
 		}
 		name := it[0].Text
 		rest := renderRun(trimTokens(it[1:]), 2+maxName+1)
-		pad := strings.Repeat(" ", maxName-len(name))
+		pad := strings.Repeat(" ", maxName-cols(name))
 		lines = append(lines, "  "+name+pad+" "+rest[0]+comma+trailing)
 		lines = append(lines, rest[1:]...)
 		prevWasColumn = true

--- a/format/format.go
+++ b/format/format.go
@@ -96,7 +96,7 @@ func statementKeyword(toks []Token) string {
 				"temp", "temporary", "unlogged", "concurrently":
 				continue
 			case "table", "index", "function", "view", "trigger", "statistics",
-				"sequence", "procedure", "materialized":
+				"sequence", "procedure", "materialized", "database":
 				kind := toks[i].Lower
 				if kind == "materialized" {
 					// "create materialized view" lays out as a view.
@@ -172,6 +172,18 @@ func formatStatement(toks []Token) string {
 		lines = formatQuerySegment(body, 0)
 	case "alter":
 		lines = layoutAlter(body)
+	case "grant", "revoke":
+		if l, ok := layoutIndentedClauses(body, grantClauses, 2); ok {
+			lines = l
+		} else {
+			lines = flatStatementLines(body)
+		}
+	case "create database":
+		if l, ok := layoutIndentedClauses(body, databaseClauses, 2); ok {
+			lines = l
+		} else {
+			lines = flatStatementLines(body)
+		}
 	case "explain":
 		lines = layoutExplain(body)
 	case "merge":
@@ -726,6 +738,9 @@ func createTableAsBody(toks []Token) int {
 func layoutCreateTable(toks []Token) []string {
 	open := createTableColumnList(toks)
 	if open == -1 {
+		if l, ok := layoutIndentedClauses(toks, partitionClauses, 2); ok {
+			return l
+		}
 		if body := createTableAsBody(toks); body != -1 {
 			head := flatStatementLines(toks[:body])
 			return append(head, strings.Split(formatStatement(toks[body:]), "\n")...)

--- a/format/format.go
+++ b/format/format.go
@@ -260,6 +260,7 @@ func layoutDDL(toks []Token) []string {
 		clauses = append(clauses, ddlClause{b.name, flatJoin(toks[b.idx+len(b.words) : end])})
 	}
 	clauses = hoistLanguage(clauses)
+	clauses = formatSQLBody(clauses)
 
 	lines := []string{head}
 	for _, c := range clauses {
@@ -270,6 +271,63 @@ func layoutDDL(toks []Token) []string {
 		lines = append(lines, line)
 	}
 	return lines
+}
+
+// formatSQLBody reformats a LANGUAGE SQL function body. The body of such a
+// function is SQL, and this package formats SQL, so there is no reason to
+// leave it as whatever the author typed while every other statement in the
+// file gets laid out.
+//
+// Only "language sql" is touched. Every other language -- plpgsql, plpython,
+// plperl -- is passed through verbatim, which is both the existing behaviour
+// and the only safe one: the lexer treats a dollar-quoted body as a single
+// opaque token, so a body it does not understand is preserved exactly.
+func formatSQLBody(clauses []ddlClause) []ddlClause {
+	lang := ""
+	for _, c := range clauses {
+		if c.name == "language" {
+			lang = strings.ToLower(strings.TrimSpace(c.body))
+		}
+	}
+	if lang != "sql" {
+		return clauses
+	}
+	out := make([]ddlClause, len(clauses))
+	copy(out, clauses)
+	for i, c := range out {
+		if c.name != "as" {
+			continue
+		}
+		tag, inner, ok := splitDollarQuote(c.body)
+		if !ok {
+			continue
+		}
+		formatted, err := Format(strings.NewReader(inner))
+		if err != nil {
+			continue // unparseable body: leave it exactly as written
+		}
+		out[i].body = tag + "\n" + strings.TrimRight(formatted, "\n") + "\n" + tag
+	}
+	return out
+}
+
+// splitDollarQuote splits "$tag$body$tag$" into its tag and body. It
+// reports false for anything that is not a single, complete dollar-quoted
+// string -- a body with trailing options after it, say.
+func splitDollarQuote(s string) (tag, inner string, ok bool) {
+	s = strings.TrimSpace(s)
+	if !strings.HasPrefix(s, "$") {
+		return "", "", false
+	}
+	end := strings.Index(s[1:], "$")
+	if end < 0 {
+		return "", "", false
+	}
+	tag = s[:end+2]
+	if !strings.HasSuffix(s, tag) || len(s) < 2*len(tag) {
+		return "", "", false
+	}
+	return tag, s[len(tag) : len(s)-len(tag)], true
 }
 
 // ddlClause is one rendered continuation clause: its keyword and the text

--- a/format/layout.go
+++ b/format/layout.go
@@ -179,6 +179,16 @@ func splitTopLevelComma(toks []Token) [][]Token {
 		} else if t.Text == ")" {
 			depth--
 		} else if depth == 0 && t.Text == "," {
+			// The comma is dropped here -- it is a separator, not part of
+			// either item -- so a comment trailing on it would vanish with
+			// it. Carry it back onto the item it follows, which is where
+			// the author put it and where the layout can still render it.
+			if tc := toks[i].TrailingComment; tc != nil && i > start {
+				if last := &toks[i-1]; last.TrailingComment == nil {
+					last.TrailingComment = tc
+					toks[i].TrailingComment = nil
+				}
+			}
 			segs = append(segs, toks[start:i])
 			start = i + 1
 		}
@@ -716,6 +726,21 @@ func renderRun(toks []Token, col int) []string {
 
 	var prev, prevPrev *Token
 	i := 0
+	// A "--" comment on the last token of a span the loop skips over -- a
+	// CASE, an OVER(...), a parenthesized group -- is never seen by the
+	// per-token safety net below, which only runs on the plain path. Left
+	// alone it is dropped outright, which is data loss; written without a
+	// break it would swallow whatever follows it on the line.
+	flushTrailing := func(j int) {
+		if toks[j].TrailingComment == nil {
+			return
+		}
+		write(commentMarker + trailingCommentText(toks[j].TrailingComment))
+		toks[j].TrailingComment = nil
+		lines = append(lines, "")
+		curCol = 0
+	}
+
 	for i < len(toks) {
 		t := toks[i]
 		if isNonLayout(t) {
@@ -760,6 +785,7 @@ func renderRun(toks []Token, col int) []string {
 			}
 			merge(layoutCase(toks[i:end+1], curCol))
 			prevPrev, prev = prev, &toks[end]
+			flushTrailing(end)
 			i = end + 1
 			continue
 		}
@@ -777,6 +803,7 @@ func renderRun(toks []Token, col int) []string {
 				merge(layoutOver(overToks, curCol))
 			}
 			prevPrev, prev = prev, &toks[close]
+			flushTrailing(close)
 			i = close + 1
 			continue
 		}
@@ -833,6 +860,7 @@ func renderRun(toks []Token, col int) []string {
 						merge(filled)
 						write(")")
 						prevPrev, prev = prev, &toks[close]
+						flushTrailing(close)
 						i = close + 1
 						continue
 					}
@@ -852,6 +880,7 @@ func renderRun(toks []Token, col int) []string {
 				}
 			}
 			prevPrev, prev = prev, &toks[close]
+			flushTrailing(close)
 			i = close + 1
 			continue
 		}
@@ -1128,7 +1157,7 @@ func layoutCommaList(toks []Token, startCol int) []string {
 	// flatJoin's underlying renderRun call consumes/clears any comment
 	// metadata on these tokens as a side effect, which the multi-line path
 	// below still needs intact if this fast path doesn't end up taking it.
-	if len(items) > 0 && !anyItemComments(items) {
+	if len(items) > 0 && !anyItemComments(items) && !hasLineComment(toks) {
 		if flat := flatJoin(trimTokens(toks)); startCol+len(flat) <= targetWidth {
 			return []string{flat}
 		}
@@ -1216,6 +1245,31 @@ func anyTokenComments(toks []Token) bool {
 // carries a leading or trailing comment -- used to force the multi-line
 // layout even when the flattened form would otherwise fit inline, since the
 // single-line fast path has nowhere to put a comment.
+// hasLineComment reports whether any token in the run carries a "--"
+// comment, in a leading or a trailing position.
+//
+// Such a run has no valid one-line rendering: everything placed after the
+// comment on that line ends up inside it. renderRun already breaks the
+// line for exactly this reason, but flatJoin joins its lines back with a
+// space, which undoes the protection -- so a flat path has to be refused
+// before it is taken rather than repaired after. anyItemComments is not
+// enough on its own: it looks only at each item's first and last token, so
+// a comment on a separating comma, which belongs to no item at all, was
+// invisible to it.
+func hasLineComment(toks []Token) bool {
+	for i := range toks {
+		if tc := toks[i].TrailingComment; tc != nil && tc.Kind == TokLineComment {
+			return true
+		}
+		for _, c := range toks[i].Comments {
+			if c.Kind == TokLineComment {
+				return true
+			}
+		}
+	}
+	return false
+}
+
 func anyItemComments(items [][]Token) bool {
 	for _, it := range items {
 		it = trimTokens(it)

--- a/format/layout.go
+++ b/format/layout.go
@@ -19,6 +19,12 @@ var clauseWords = []struct {
 }{
 	{[]string{"explain"}, "explain", true},
 	{[]string{"insert", "into"}, "insert into", false},
+	// MERGE's INSERT action has no INTO: "when not matched then insert
+	// (cols) values (...)". Without this the bare "insert" was not a clause
+	// bound, and splitClauses drops whatever precedes the first bound --
+	// so the column list vanished. Must stay after "insert into", which
+	// shares its first word.
+	{[]string{"insert"}, "insert", false},
 	{[]string{"on", "conflict"}, "on conflict", false},
 	{[]string{"group", "by"}, "group by", false},
 	{[]string{"order", "by"}, "order by", false},
@@ -433,6 +439,26 @@ func isUnaryContext(prevPrev *Token) bool {
 // It reports ok=false when filling cannot help: if col is already so deep
 // that even a single item overflows, breaking the list only adds ragged
 // lines to an over-long one, and the caller should leave it alone.
+// layoutValuesRow fills a single, over-wide VALUES row across lines.
+// Reports false for anything else -- several rows, or a row that fits.
+func layoutValuesRow(body []Token, bodyCol int) ([]string, bool) {
+	body = trimTokens(body)
+	items := splitTopLevelComma(body)
+	if len(items) != 1 || !isParenGroup(body) {
+		return nil, false
+	}
+	if bodyCol+len(plainJoin(body)) <= targetWidth {
+		return nil, false
+	}
+	filled, ok := fillCommaList(body[1:len(body)-1], bodyCol+1)
+	if !ok {
+		return nil, false
+	}
+	filled[0] = "(" + filled[0]
+	filled[len(filled)-1] += ")"
+	return filled, true
+}
+
 // layoutInsertTarget renders "insert into t (col, col, ...)". The column
 // list is not a function call's argument list, but it looks exactly like
 // one -- it follows an identifier directly -- so renderRun's paren handling
@@ -1419,7 +1445,17 @@ func renderClause(s clauseSeg, baseIndent, width int) []string {
 
 	var bodyLines []string
 	switch s.name {
-	case "select", "group by", "order by", "returning", "values":
+	case "values":
+		// A single VALUES row wide enough to overflow is one item as far
+		// as layoutCommaList is concerned -- the whole "(a, b, c)" group --
+		// so it had nothing to break and left the row long. Fill inside the
+		// parens instead. Several rows still go one per line.
+		if l, ok := layoutValuesRow(body, bodyCol); ok {
+			bodyLines = l
+		} else {
+			bodyLines = layoutCommaList(body, bodyCol)
+		}
+	case "select", "group by", "order by", "returning":
 		bodyLines = layoutCommaList(body, bodyCol)
 	case "where":
 		bodyLines = layoutPredicateList(body, baseIndent+width)

--- a/format/layout.go
+++ b/format/layout.go
@@ -136,25 +136,26 @@ func splitUnionSegments(toks []Token) (segs [][]Token, ops []string) {
 			continue
 		}
 		switch t.Lower {
-		case "union":
+		case "union", "intersect", "except":
+			// All three take an optional ALL or DISTINCT modifier, and it
+			// belongs to the operator, not to the query that follows it.
+			// Only UNION used to consume it: "except all select ..." left
+			// "all" as the first token of the next segment, which rendered
+			// as a stray "all select ..." line -- and, in a segment the
+			// layout then recursed into, could be dropped outright. Losing
+			// it silently turns EXCEPT ALL into EXCEPT, which is a
+			// different result set, not a formatting difference.
 			end := i + 1
-			op := "union"
-			if end < len(toks) && toks[end].Kind == TokKeyword && toks[end].Lower == "all" {
-				op = "union all"
+			op := t.Lower
+			if end < len(toks) && toks[end].Kind == TokKeyword &&
+				(toks[end].Lower == "all" || toks[end].Lower == "distinct") {
+				op += " " + toks[end].Lower
 				end++
 			}
 			segs = append(segs, toks[start:i])
 			ops = append(ops, op)
 			start = end
 			i = end - 1
-		case "intersect":
-			segs = append(segs, toks[start:i])
-			ops = append(ops, "intersect")
-			start = i + 1
-		case "except":
-			segs = append(segs, toks[start:i])
-			ops = append(ops, "except")
-			start = i + 1
 		}
 	}
 	segs = append(segs, toks[start:])
@@ -727,36 +728,94 @@ func splitTopLevelTwoWord(toks []Token, w1, w2 string) [][]Token {
 	return [][]Token{toks}
 }
 
+// layoutOver renders a long OVER(...) with PARTITION BY, ORDER BY, and any
+// frame clause each on its own line under the opening paren's column, per
+// STYLE.md rule 14.
+//
+// splitTopLevelTwoWord returns [before, after]. The ORDER BY search used to
+// run over segs[0] -- the tokens *before* PARTITION BY, which for the usual
+// "over(partition by x order by y)" is empty -- so it never matched: the
+// whole body went out on the "partition by" line and only the ")" moved
+// down, giving a 90+ column line with an orphaned paren under it.
+// Everything after PARTITION BY has to be searched instead.
 func layoutOver(toks []Token, overCol int) []string {
 	openCol := overCol + len("over(")
 	// toks: over ( ... )
 	inner := toks[2 : len(toks)-1]
-	segs := splitTopLevelTwoWord(inner, "partition", "by")
-	var lines []string
-	first := true
+
+	// "over(" keeps a line of its own, with every window clause under the
+	// opening paren's column -- the shape the corpus already uses.
+	lines := []string{"over("}
 	emit := func(prefix string, body []Token) {
-		bodyLines := renderRun(body, openCol+len(prefix))
-		text := strings.Repeat(" ", openCol) + prefix + strings.TrimSpace(bodyLines[0])
-		if first {
-			lines = append(lines, "over("+strings.TrimPrefix(text, strings.Repeat(" ", openCol)))
-			first = false
-		} else {
-			lines = append(lines, text)
+		body = trimTokens(body)
+		if len(body) == 0 {
+			return
 		}
+		bodyLines := renderRun(body, openCol+len(prefix))
+		lines = append(lines, strings.Repeat(" ", openCol)+prefix+strings.TrimSpace(bodyLines[0]))
 		lines = append(lines, bodyLines[1:]...)
 	}
-	if len(segs) == 2 {
-		emit("partition by ", segs[1])
+
+	rest := inner
+	if segs := splitTopLevelTwoWord(inner, "partition", "by"); len(segs) == 2 {
+		// segs[1] is everything after "partition by": the partition
+		// expression list, then any ORDER BY and frame clause.
+		partition, tail := segs[1], []Token(nil)
+		if o := splitTopLevelTwoWord(segs[1], "order", "by"); len(o) == 2 {
+			partition, tail = o[0], o[1]
+			emit("partition by ", partition)
+			emit("order by ", frameSplit(&tail))
+			rest = tail
+		} else {
+			partition, rest = splitFrame(segs[1])
+			emit("partition by ", partition)
+		}
+	} else if o := splitTopLevelTwoWord(inner, "order", "by"); len(o) == 2 {
+		tail := o[1]
+		emit("order by ", frameSplit(&tail))
+		rest = tail
 	} else {
-		lines = append(lines, "over(")
-		first = false
+		body, frame := splitFrame(inner)
+		emit("", body)
+		rest = frame
 	}
-	orderSegs := splitTopLevelTwoWord(segs[0], "order", "by")
-	if len(orderSegs) == 2 {
-		emit("order by ", orderSegs[1])
-	}
+	// Whatever is left is the frame clause ("rows between ...",
+	// "range ...", "groups ...", with an optional "exclude ...").
+	emit("", rest)
+
 	lines = append(lines, strings.Repeat(" ", overCol)+")")
 	return lines
+}
+
+// frameStarters are the keywords that begin a window frame clause, which
+// rule 14 puts on a line of its own after PARTITION BY / ORDER BY.
+var frameStarters = map[string]bool{"rows": true, "range": true, "groups": true}
+
+// splitFrame splits a window-clause token run at the start of its frame
+// clause, returning the part before it and the frame itself (nil when there
+// is no frame).
+func splitFrame(toks []Token) (body, frame []Token) {
+	depth := 0
+	for i, t := range toks {
+		switch {
+		case t.Text == "(":
+			depth++
+		case t.Text == ")":
+			depth--
+		case depth == 0 && t.Kind == TokKeyword && frameStarters[t.Lower]:
+			return toks[:i], toks[i:]
+		}
+	}
+	return toks, nil
+}
+
+// frameSplit peels the frame clause off *tail, leaving *tail holding just
+// the frame and returning the part before it -- a small helper so the
+// ORDER BY body and the frame can be emitted as two separate lines.
+func frameSplit(tail *[]Token) []Token {
+	body, frame := splitFrame(*tail)
+	*tail = frame
+	return body
 }
 
 // layoutCommaList renders a comma-separated list. If the flat form fits
@@ -938,6 +997,13 @@ func splitAndOr(toks []Token) ([][]Token, []string) {
 		} else if t.Text == ")" {
 			depth--
 		} else if depth == 0 && t.Kind == TokKeyword && (t.Lower == "and" || t.Lower == "or") {
+			// The "and" in "between X and Y" joins the two bounds of one
+			// predicate; it is not a boolean conjunction, and splitting on
+			// it turned "where y between 2010 and 2017" into two lines that
+			// read as two separate conditions.
+			if t.Lower == "and" && betweenAndAt(toks, start, i) {
+				continue
+			}
 			preds = append(preds, toks[start:i])
 			ops = append(ops, t.Lower)
 			start = i + 1
@@ -945,6 +1011,30 @@ func splitAndOr(toks []Token) ([][]Token, []string) {
 	}
 	preds = append(preds, toks[start:])
 	return preds, ops
+}
+
+// betweenAndAt reports whether the "and" at index i is the one belonging to
+// a BETWEEN in the same predicate -- i.e. whether an unconsumed "between"
+// appears between the start of the current predicate and that "and". A
+// second BETWEEN inside the same predicate would each claim their own
+// "and", so they are counted rather than merely detected.
+func betweenAndAt(toks []Token, start, i int) bool {
+	depth, pending := 0, 0
+	for j := start; j < i; j++ {
+		t := toks[j]
+		switch {
+		case t.Text == "(":
+			depth++
+		case t.Text == ")":
+			depth--
+		case depth != 0:
+		case t.Kind == TokKeyword && t.Lower == "between":
+			pending++
+		case t.Kind == TokKeyword && t.Lower == "and" && pending > 0:
+			pending--
+		}
+	}
+	return pending > 0
 }
 
 // formatQuerySegment formats a SELECT/INSERT/UPDATE/DELETE (optionally
@@ -1188,14 +1278,25 @@ func parseCTEs(toks []Token) ([][]Token, []Token) {
 				i = close + 1
 			}
 		}
-		// optional "as"
+		// optional "as", then the optional materialization hint
+		// ("as materialized (" / "as not materialized ("). Without
+		// consuming the hint the "(" test below failed, the CTE body was
+		// never taken, and everything from "materialized" onwards fell out
+		// into the tail -- which is how a MATERIALIZED CTE lost its body.
 		if i < len(toks) && toks[i].Kind == TokKeyword && toks[i].Lower == "as" {
 			i++
+			i = skipMaterialized(toks, i)
 		}
 		if i < len(toks) && toks[i].Text == "(" {
 			close := matchParen(toks, i)
 			i = close + 1
 		}
+		// A recursive CTE may be followed by SEARCH and/or CYCLE clauses,
+		// which belong to it rather than to the statement after it. Left in
+		// the tail they were parsed as part of the main query, where CYCLE's
+		// own "set" reads as an UPDATE clause keyword and the clause got
+		// mangled.
+		i = skipSearchCycle(toks, i)
 		ctes = append(ctes, toks[start:i])
 		if i < len(toks) && toks[i].Text == "," {
 			i++
@@ -1204,6 +1305,52 @@ func parseCTEs(toks []Token) ([][]Token, []Token) {
 		break
 	}
 	return ctes, toks[i:]
+}
+
+// skipMaterialized advances past an optional "materialized" /
+// "not materialized" hint following a CTE's "as".
+func skipMaterialized(toks []Token, i int) int {
+	if i < len(toks) && toks[i].Kind == TokKeyword && toks[i].Lower == "not" {
+		if i+1 < len(toks) && toks[i+1].Lower == "materialized" {
+			return i + 2
+		}
+		return i
+	}
+	if i < len(toks) && toks[i].Lower == "materialized" {
+		return i + 1
+	}
+	return i
+}
+
+// skipSearchCycle advances past the SEARCH and CYCLE clauses a recursive
+// CTE may carry, so they stay attached to the CTE they qualify:
+//
+//	search depth first by id set ordercol
+//	cycle id set is_cycle using path
+//
+// Both run to the next "," or to the statement's main SELECT.
+func skipSearchCycle(toks []Token, i int) int {
+	// "search"/"cycle" are not in the keyword table -- they lex as plain
+	// identifiers -- so match on the text, not on Kind.
+	for i < len(toks) && (toks[i].Lower == "search" || toks[i].Lower == "cycle") {
+		i++
+		depth := 0
+		for i < len(toks) {
+			t := toks[i]
+			if t.Text == "(" {
+				depth++
+			} else if t.Text == ")" {
+				depth--
+			} else if depth == 0 && t.Kind == TokKeyword &&
+				(t.Lower == "select" || t.Lower == "search" || t.Lower == "cycle") {
+				break
+			} else if depth == 0 && t.Text == "," {
+				break
+			}
+			i++
+		}
+	}
+	return i
 }
 
 // renderCTE renders one "name [(cols)] as ( body )" CTE entry. withPrefix,
@@ -1223,8 +1370,13 @@ func renderCTE(cte []Token, baseIndent int, more bool, withPrefix string) []stri
 			i = colClose + 1
 		}
 	}
+	asText := " as ("
 	if i < len(cte) && cte[i].Kind == TokKeyword && cte[i].Lower == "as" {
 		i++
+		if j := skipMaterialized(cte, i); j > i {
+			asText = " as " + plainJoin(cte[i:j]) + " ("
+			i = j
+		}
 	}
 	open := -1
 	if i < len(cte) && cte[i].Text == "(" {
@@ -1238,11 +1390,14 @@ func renderCTE(cte []Token, baseIndent int, more bool, withPrefix string) []stri
 	bodyIndent := baseIndent + 2
 	bodyLines := formatQuerySegment(inner, bodyIndent)
 	lines := lead
-	lines = append(lines, strings.Repeat(" ", baseIndent)+name+" as (")
+	lines = append(lines, strings.Repeat(" ", baseIndent)+name+asText)
 	for _, l := range bodyLines {
 		lines = append(lines, strings.Repeat(" ", bodyIndent)+l)
 	}
 	closing := strings.Repeat(" ", baseIndent) + ")"
+	if tail := trimTokens(cte[close+1:]); len(tail) > 0 {
+		closing += " " + plainJoin(tail)
+	}
 	if more {
 		closing += ","
 	}

--- a/format/layout.go
+++ b/format/layout.go
@@ -246,6 +246,19 @@ func isJoinModifier(lower string) bool {
 	return false
 }
 
+// joinTableLines renders a JOIN's table expression, keeping it multi-line
+// when it is one. flatJoin was used here, and flatJoin joins renderRun's
+// output with spaces -- so a LATERAL subquery, which renderRun lays out
+// across several lines, was folded back onto the JOIN line and ran to
+// hundreds of columns. Always returns at least one line.
+func joinTableLines(toks []Token, col int) []string {
+	lines := renderRun(trimTokens(toks), col)
+	if len(lines) == 0 {
+		return []string{""}
+	}
+	return lines
+}
+
 // splitJoinSegments splits a FROM clause's tokens into the leading table
 // expression and each subsequent JOIN segment (starting at its modifier, if
 // any, else at "join" itself).
@@ -1510,21 +1523,40 @@ func layoutFrom(toks []Token, baseIndent, width int) []string {
 			phrasePad = 0
 		}
 		if onIdx == -1 {
-			line := strings.Repeat(" ", phrasePad) + phrase + " " + flatJoin(rest) + segTrailing
-			out = append(out, line)
+			head := strings.Repeat(" ", phrasePad) + phrase + " "
+			tl := joinTableLines(rest, len(head))
+			tl[len(tl)-1] += segTrailing
+			out = append(out, head+tl[0])
+			out = append(out, tl[1:]...)
 			continue
 		}
 		tablePart := trimTokens(rest[:onIdx])
 		condPart := trimTokens(rest[onIdx+1:])
 		preds, ops := splitAndOr(condPart)
+		head := strings.Repeat(" ", phrasePad) + phrase + " "
+		tl := joinTableLines(tablePart, len(head))
 		if len(preds) == 1 {
-			// Single-condition ON stays inline after the join keyword phrase.
-			line := strings.Repeat(" ", phrasePad) + phrase + " " + flatJoin(tablePart) + " on " + flatJoin(preds[0]) + segTrailing
-			out = append(out, line)
+			// Single-condition ON stays inline after the join keyword
+			// phrase -- unless the table part is a subquery that wrapped,
+			// in which case the ON goes under it.
+			if len(tl) == 1 {
+				out = append(out, head+tl[0]+" on "+flatJoin(preds[0])+segTrailing)
+				continue
+			}
+			out = append(out, head+tl[0])
+			out = append(out, tl[1:]...)
+			pad := phraseEndCol - len("on")
+			if pad < 0 {
+				pad = 0
+			}
+			pLines := renderRun(trimTokens(preds[0]), phraseEndCol+1)
+			pLines[len(pLines)-1] += segTrailing
+			out = append(out, strings.Repeat(" ", pad)+"on "+pLines[0])
+			out = append(out, pLines[1:]...)
 			continue
 		}
-		line := strings.Repeat(" ", phrasePad) + phrase + " " + flatJoin(tablePart)
-		out = append(out, line)
+		out = append(out, head+tl[0])
+		out = append(out, tl[1:]...)
 		for idx, p := range preds {
 			var kw string
 			if idx == 0 {

--- a/format/layout.go
+++ b/format/layout.go
@@ -268,11 +268,42 @@ func isJoinModifier(lower string) bool {
 // across several lines, was folded back onto the JOIN line and ran to
 // hundreds of columns. Always returns at least one line.
 func joinTableLines(toks []Token, col int) []string {
-	lines := renderRun(trimTokens(toks), col)
+	toks = trimTokens(toks)
+	lines := renderRun(toks, col)
 	if len(lines) == 0 {
 		return []string{""}
 	}
+	// A join whose ON condition is one wide comparison has no comma to
+	// break at and renderRun leaves it long; the Doc layer can break it at
+	// the comparison operator. Only the condition is offered -- the table
+	// and its alias belong on the "join" line.
+	if col+cols(plainJoin(toks)) > targetWidth {
+		if i := joinOnIndex(toks); i > 0 {
+			head := plainJoin(toks[:i+1])
+			if l, ok := predicateLines(trimTokens(toks[i+1:]), col+cols(head)+1); ok {
+				out := []string{head + " " + l[0]}
+				return append(out, l[1:]...)
+			}
+		}
+	}
 	return lines
+}
+
+// joinOnIndex returns the index of a join's top-level ON keyword, or -1.
+func joinOnIndex(toks []Token) int {
+	depth := 0
+	for i, t := range toks {
+		switch t.Text {
+		case "(":
+			depth++
+		case ")":
+			depth--
+		}
+		if depth == 0 && t.Kind == TokKeyword && t.Lower == "on" {
+			return i
+		}
+	}
+	return -1
 }
 
 // splitJoinSegments splits a FROM clause's tokens into the leading table
@@ -520,7 +551,7 @@ func layoutValuesRow(body []Token, bodyCol int) ([]string, bool) {
 	if len(items) != 1 || !isParenGroup(body) {
 		return nil, false
 	}
-	if bodyCol+len(plainJoin(body)) <= targetWidth {
+	if bodyCol+cols(plainJoin(body)) <= targetWidth {
 		return nil, false
 	}
 	filled, ok := fillCommaList(body[1:len(body)-1], bodyCol+1)
@@ -565,7 +596,7 @@ func layoutInsertTarget(body []Token, bodyCol int) ([]string, bool) {
 	}
 	head := plainJoin(body[:open])
 	flat := head + plainJoin(body[open:])
-	if bodyCol+len(flat) <= targetWidth {
+	if bodyCol+cols(flat) <= targetWidth {
 		return nil, false
 	}
 	filled, ok := fillCommaList(body[open+1:len(body)-1], bodyCol+len(head)+1)
@@ -606,13 +637,13 @@ func layoutRowAssignment(body []Token, baseIndent, width int) ([]string, bool) {
 		return nil, false
 	}
 	bodyCol := baseIndent + width + 1
-	if bodyCol+len(plainJoin(body)) <= targetWidth {
+	if bodyCol+cols(plainJoin(body)) <= targetWidth {
 		return nil, false // fits as it is
 	}
 
 	side := func(g []Token, col int) []string {
 		flat := plainJoin(g)
-		if col+len(flat) <= targetWidth {
+		if col+cols(flat) <= targetWidth {
 			return []string{flat}
 		}
 		if filled, ok := fillCommaList(g[1:len(g)-1], col+1); ok {
@@ -670,7 +701,7 @@ func fillCommaList(inner []Token, col int) (lines []string, ok bool) {
 	texts := make([]string, len(items))
 	for i, it := range items {
 		texts[i] = plainJoin(trimTokens(it))
-		if col+len(texts[i]) > targetWidth {
+		if col+cols(texts[i]) > targetWidth {
 			return nil, false
 		}
 	}
@@ -683,7 +714,7 @@ func fillCommaList(inner []Token, col int) (lines []string, ok bool) {
 		switch {
 		case cur == "":
 			cur = piece
-		case col+len(cur)+1+len(piece) <= targetWidth:
+		case col+cols(cur)+1+cols(piece) <= targetWidth:
 			cur += " " + piece
 		default:
 			lines = append(lines, cur)
@@ -797,7 +828,7 @@ func renderRun(toks []Token, col int) []string {
 				write(" ")
 			}
 			flat := plainJoin(overToks)
-			if curCol+len(flat) <= targetWidth {
+			if curCol+cols(flat) <= targetWidth {
 				write(flat)
 			} else {
 				merge(layoutOver(overToks, curCol))
@@ -854,7 +885,7 @@ func renderRun(toks []Token, col int) []string {
 				// declines when the paren sits too deep for breaking to
 				// help, leaving the flat form rather than a ragged one.
 				if needSpace && len(content) == 1 &&
-					curCol+len(content[0]) > targetWidth {
+					curCol+cols(content[0]) > targetWidth {
 					if filled, fok := fillCommaList(inner, curCol+1); fok {
 						write("(")
 						merge(filled)
@@ -941,7 +972,7 @@ func plainJoin(toks []Token) string {
 // Alignment is always recomputed fresh per call (STYLE.md rule 15).
 func layoutCase(toks []Token, caseCol int) []string {
 	flat := plainJoin(toks)
-	if caseCol+len(flat) <= targetWidth {
+	if caseCol+cols(flat) <= targetWidth {
 		return []string{flat}
 	}
 
@@ -1158,7 +1189,7 @@ func layoutCommaList(toks []Token, startCol int) []string {
 	// metadata on these tokens as a side effect, which the multi-line path
 	// below still needs intact if this fast path doesn't end up taking it.
 	if len(items) > 0 && !anyItemComments(items) && !hasLineComment(toks) {
-		if flat := flatJoin(trimTokens(toks)); startCol+len(flat) <= targetWidth {
+		if flat := flatJoin(trimTokens(toks)); startCol+cols(flat) <= targetWidth {
 			return []string{flat}
 		}
 	}
@@ -1184,7 +1215,7 @@ func layoutCommaList(toks []Token, startCol int) []string {
 		// happened to break it: renderRun breaks greedily at the first
 		// paren that does not fit, which would pre-empt the Doc layer on
 		// exactly the items it exists for.
-		if startCol+len(plainJoin(trimTokens(it))) > targetWidth {
+		if startCol+cols(plainJoin(trimTokens(it))) > targetWidth {
 			if el, ok := exprLines(it, startCol); ok {
 				itLines = el
 			} else if len(itLines) == 1 {
@@ -1356,8 +1387,15 @@ func layoutPredicateList(toks []Token, endCol int) []string {
 		// list is a useful break point, the operator is.
 		// baseIndent 0 / width endCol puts the operator's own right edge at
 		// endCol, the column the clause keyword and any AND/OR end at.
-		if len(pLines) == 1 && startCol+len(pLines[0]) > targetWidth {
+		// Gate on the predicate's own flat width rather than on whether
+		// renderRun happened to break it, for the reason layoutCommaList
+		// gives: renderRun breaks greedily at the first paren that does
+		// not fit, which pre-empts the Doc layer on exactly the predicates
+		// it exists for.
+		if startCol+cols(plainJoin(trimTokens(p))) > targetWidth {
 			if l, ok := layoutRowAssignment(trimTokens(p), 0, endCol); ok {
+				pLines = l
+			} else if l, ok := predicateLines(trimTokens(p), startCol); ok {
 				pLines = l
 			}
 		}

--- a/format/layout.go
+++ b/format/layout.go
@@ -273,37 +273,20 @@ func joinTableLines(toks []Token, col int) []string {
 	if len(lines) == 0 {
 		return []string{""}
 	}
-	// A join whose ON condition is one wide comparison has no comma to
-	// break at and renderRun leaves it long; the Doc layer can break it at
-	// the comparison operator. Only the condition is offered -- the table
-	// and its alias belong on the "join" line.
-	if col+cols(plainJoin(toks)) > targetWidth {
-		if i := joinOnIndex(toks); i > 0 {
-			head := plainJoin(toks[:i+1])
-			if l, ok := predicateLines(trimTokens(toks[i+1:]), col+cols(head)+1); ok {
-				out := []string{head + " " + l[0]}
-				return append(out, l[1:]...)
-			}
-		}
-	}
 	return lines
 }
 
-// joinOnIndex returns the index of a join's top-level ON keyword, or -1.
-func joinOnIndex(toks []Token) int {
-	depth := 0
-	for i, t := range toks {
-		switch t.Text {
-		case "(":
-			depth++
-		case ")":
-			depth--
-		}
-		if depth == 0 && t.Kind == TokKeyword && t.Lower == "on" {
-			return i
+// onPredicateLines renders one ON condition at col, offering it to the Doc
+// layer when it does not fit -- a single wide comparison has no comma to
+// break at and renderRun leaves it long.
+func onPredicateLines(p []Token, col int) []string {
+	lines := renderRun(p, col)
+	if col+cols(plainJoin(p)) > targetWidth {
+		if l, ok := predicateLines(p, col); ok {
+			return l
 		}
 	}
-	return -1
+	return lines
 }
 
 // splitJoinSegments splits a FROM clause's tokens into the leading table
@@ -1696,7 +1679,17 @@ func layoutFrom(toks []Token, baseIndent, width int) []string {
 	// Cleared before renderRun runs -- see layoutCommaList's identical
 	// ordering concern.
 	firstTrailing := trailingCommentSuffix(segs[0])
-	firstLines := renderRun(trimTokens(segs[0]), joinCol)
+	// The relations before the first JOIN are a comma list, and a wide one
+	// -- "from a, lateral f(...) as t(col)" -- needs the same one-item-
+	// per-line treatment SELECT's list gets, with each item then offered
+	// to the Doc layer. renderRun alone left them on one long line.
+	first := trimTokens(segs[0])
+	var firstLines []string
+	if joinCol+cols(plainJoin(first)) > targetWidth {
+		firstLines = layoutCommaList(first, joinCol)
+	} else {
+		firstLines = renderRun(first, joinCol)
+	}
 	firstLines[len(firstLines)-1] += firstTrailing
 	out := firstLines
 
@@ -1755,8 +1748,16 @@ func layoutFrom(toks []Token, baseIndent, width int) []string {
 			// phrase -- unless the table part is a subquery that wrapped,
 			// in which case the ON goes under it.
 			if len(tl) == 1 {
-				out = append(out, head+tl[0]+" on "+flatJoin(preds[0])+segTrailing)
-				continue
+				inline := head + tl[0] + " on " + flatJoin(preds[0]) + segTrailing
+				if cols(inline) <= targetWidth {
+					out = append(out, inline)
+					continue
+				}
+				// Too wide inline: the ON goes under the join keyword,
+				// river-aligned with it, which is how the corpus writes a
+				// join whose condition does not fit beside it. Without
+				// this check it was emitted at whatever width it came to
+				// -- 87 columns for a substring() condition.
 			}
 			out = append(out, head+tl[0])
 			out = append(out, tl[1:]...)
@@ -1764,7 +1765,7 @@ func layoutFrom(toks []Token, baseIndent, width int) []string {
 			if pad < 0 {
 				pad = 0
 			}
-			pLines := renderRun(trimTokens(preds[0]), phraseEndCol+1)
+			pLines := onPredicateLines(trimTokens(preds[0]), phraseEndCol+1)
 			pLines[len(pLines)-1] += segTrailing
 			out = append(out, strings.Repeat(" ", pad)+"on "+pLines[0])
 			out = append(out, pLines[1:]...)
@@ -1783,7 +1784,7 @@ func layoutFrom(toks []Token, baseIndent, width int) []string {
 			if pad < 0 {
 				pad = 0
 			}
-			pLines := renderRun(trimTokens(p), phraseEndCol+1)
+			pLines := onPredicateLines(trimTokens(p), phraseEndCol+1)
 			if idx == len(preds)-1 {
 				pLines[len(pLines)-1] += segTrailing
 			}

--- a/format/layout.go
+++ b/format/layout.go
@@ -439,6 +439,57 @@ func isUnaryContext(prevPrev *Token) bool {
 // It reports ok=false when filling cannot help: if col is already so deep
 // that even a single item overflows, breaking the list only adds ragged
 // lines to an over-long one, and the caller should leave it alone.
+// layoutConcatChain breaks an over-wide expression at its top-level "||"
+// operators, each continuation line starting with the operator so the
+// chain stays legible:
+//
+//	format('...', a, b)
+//	|| E'\n'
+//	|| format('...', c, d)
+//
+// Reports false when there is no top-level "||", or when breaking there
+// would not bring the line back under the target.
+func layoutConcatChain(toks []Token, startCol int) ([]string, bool) {
+	parts := splitTopLevelConcat(trimTokens(toks))
+	if len(parts) < 2 {
+		return nil, false
+	}
+	lines := make([]string, 0, len(parts))
+	for i, part := range parts {
+		pl := renderRun(trimTokens(part), startCol+3)
+		if i == 0 {
+			lines = append(lines, pl[0])
+		} else {
+			lines = append(lines, strings.Repeat(" ", startCol)+"|| "+pl[0])
+		}
+		lines = append(lines, pl[1:]...)
+	}
+	return lines, true
+}
+
+// splitTopLevelConcat splits a token run at its top-level "||" operators.
+func splitTopLevelConcat(toks []Token) [][]Token {
+	var out [][]Token
+	depth, start := 0, 0
+	for i, t := range toks {
+		switch t.Text {
+		case "(":
+			depth++
+		case ")":
+			depth--
+		case "||":
+			if depth == 0 {
+				out = append(out, toks[start:i])
+				start = i + 1
+			}
+		}
+	}
+	if len(out) == 0 {
+		return nil
+	}
+	return append(out, toks[start:])
+}
+
 // layoutValuesRow fills a single, over-wide VALUES row across lines.
 // Reports false for anything else -- several rows, or a row that fits.
 func layoutValuesRow(body []Token, bodyCol int) ([]string, bool) {
@@ -1081,6 +1132,16 @@ func layoutCommaList(toks []Token, startCol int) []string {
 		lead := leadingCommentLines(it, startCol)
 		trailing := trailingCommentSuffix(it)
 		itLines := renderRun(it, startCol)
+		// A single select-list item can be far too wide with no comma in
+		// it to break at -- the figure-generating queries build TikZ as one
+		// long "format(...) || E'\n' || format(...)" chain. The "||"
+		// operators are the natural break, and are where the author breaks
+		// them by hand.
+		if len(itLines) == 1 && startCol+len(itLines[0]) > targetWidth {
+			if cl, ok := layoutConcatChain(it, startCol); ok {
+				itLines = cl
+			}
+		}
 		if idx < len(items)-1 {
 			// The separating comma belongs on the item's own last rendered
 			// line, not necessarily its first -- an item that itself wraps

--- a/format/layout.go
+++ b/format/layout.go
@@ -615,10 +615,21 @@ func layoutCase(toks []Token, caseCol int) []string {
 		return []string{flat}
 	}
 
-	// toks[0] == "case". Split remaining into when/then/else branches.
+	// toks[0] == "case". A *simple* CASE puts an operand expression between
+	// "case" and the first "when" ("case grouping(x) when 1 then ..."); a
+	// *searched* CASE goes straight to "when". Consume the operand, if
+	// there is one, onto the "case" line: without this the when-loop below
+	// -- which only advances while it is looking at a "when" -- never
+	// starts, i stays at 1, and every token from the operand up to "end"
+	// is silently dropped, rendering the whole expression as "case end".
 	whenCol := caseCol + len("case ")
-	lines := []string{"case"}
 	i := 1
+	head := "case"
+	if opEnd := caseOperandEnd(toks); opEnd > 1 {
+		head += " " + plainJoin(toks[1:opEnd])
+		i = opEnd
+	}
+	lines := []string{head}
 	for i < len(toks) && toks[i].Kind == TokKeyword && toks[i].Lower == "when" {
 		condStart := i + 1
 		thenIdx := -1
@@ -676,6 +687,24 @@ func layoutCase(toks []Token, caseCol int) []string {
 	}
 	lines = append(lines, strings.Repeat(" ", caseCol)+"end")
 	return lines
+}
+
+// caseOperandEnd returns the index of the first top-level "when" in a CASE
+// token run, i.e. the end of a simple CASE's operand expression. It returns
+// 1 for a searched CASE ("case when ..."), where there is no operand.
+func caseOperandEnd(toks []Token) int {
+	depth := 0
+	for i := 1; i < len(toks); i++ {
+		switch {
+		case toks[i].Text == "(":
+			depth++
+		case toks[i].Text == ")":
+			depth--
+		case depth == 0 && toks[i].Kind == TokKeyword && toks[i].Lower == "when":
+			return i
+		}
+	}
+	return 1
 }
 
 // layoutOver wraps a long OVER(...) clause: PARTITION BY / ORDER BY / frame

--- a/format/layout.go
+++ b/format/layout.go
@@ -1013,6 +1013,19 @@ func splitAndOr(toks []Token) ([][]Token, []string) {
 	return preds, ops
 }
 
+// wholeParen reports whether toks is exactly one parenthesized group, and
+// if so returns its contents.
+func wholeParen(toks []Token) ([]Token, bool) {
+	toks = trimTokens(toks)
+	if len(toks) < 3 || toks[0].Text != "(" {
+		return nil, false
+	}
+	if matchParen(toks, 0) != len(toks)-1 {
+		return nil, false
+	}
+	return trimTokens(toks[1 : len(toks)-1]), true
+}
+
 // betweenAndAt reports whether the "and" at index i is the one belonging to
 // a BETWEEN in the same predicate -- i.e. whether an unconsumed "between"
 // appears between the start of the current predicate and that "and". A
@@ -1070,6 +1083,28 @@ func formatQuerySegment(toks []Token, baseIndent int) []string {
 			}
 		}
 		return lines
+	}
+
+	// A fully parenthesized query -- the arms of "(select ...) except
+	// (select ...)" are written this way -- has every clause keyword at
+	// depth 1, so splitClauses finds none and the whole arm used to come
+	// back as one flat line, hundreds of columns wide. Unwrap, format the
+	// query inside, and put the parens back.
+	// "(select ...) order by x" -- a parenthesized arm with trailing
+	// clauses of its own. Format the group, then the clauses after it.
+	if len(toks) > 0 && toks[0].Text == "(" {
+		if close := matchParen(toks, 0); close > 0 && close < len(toks)-1 {
+			head := formatQuerySegment(toks[:close+1], baseIndent)
+			return append(head, formatQuerySegment(toks[close+1:], baseIndent)...)
+		}
+	}
+	if inner, ok := wholeParen(toks); ok {
+		body := formatQuerySegment(inner, baseIndent+1)
+		if len(body) > 0 {
+			body[0] = strings.Repeat(" ", baseIndent) + "(" + strings.TrimLeft(body[0], " ")
+			body = append(body, strings.Repeat(" ", baseIndent)+")")
+			return body
+		}
 	}
 
 	segs := splitClauses(toks)

--- a/format/layout.go
+++ b/format/layout.go
@@ -468,10 +468,22 @@ func layoutConcatChain(toks []Token, startCol int) ([]string, bool) {
 }
 
 // splitTopLevelConcat splits a token run at its top-level "||" operators.
+//
+// CASE spans are skipped whole. A "||" inside a CASE branch --
+// "else substring(name from 1 for 54) || '...' end" -- is not a top-level
+// operator, and splitting there cut the CASE in half: each half then looked
+// like its own CASE to the layout below, and the "end" came out twice.
 func splitTopLevelConcat(toks []Token) [][]Token {
 	var out [][]Token
 	depth, start := 0, 0
-	for i, t := range toks {
+	for i := 0; i < len(toks); i++ {
+		t := toks[i]
+		if t.Kind == TokKeyword && t.Lower == "case" {
+			if end := matchCaseEnd(toks, i); end > i {
+				i = end
+				continue
+			}
+		}
 		switch t.Text {
 		case "(":
 			depth++
@@ -1132,14 +1144,24 @@ func layoutCommaList(toks []Token, startCol int) []string {
 		lead := leadingCommentLines(it, startCol)
 		trailing := trailingCommentSuffix(it)
 		itLines := renderRun(it, startCol)
-		// A single select-list item can be far too wide with no comma in
-		// it to break at -- the figure-generating queries build TikZ as one
-		// long "format(...) || E'\n' || format(...)" chain. The "||"
-		// operators are the natural break, and are where the author breaks
-		// them by hand.
-		if len(itLines) == 1 && startCol+len(itLines[0]) > targetWidth {
-			if cl, ok := layoutConcatChain(it, startCol); ok {
-				itLines = cl
+		// A single list item can be far too wide with no comma in it to
+		// break at -- the figure-generating queries build TikZ as one long
+		// "format(...) || E'\n' || format(...)" chain, and a row
+		// comparison puts two wide lists either side of an operator. Those
+		// break points interact, so the choice is made by the Doc layer
+		// (see doc.go), which decides a whole group at a time rather than
+		// greedily where it stands.
+		// Gate on the item's own flat width, not on whether renderRun
+		// happened to break it: renderRun breaks greedily at the first
+		// paren that does not fit, which would pre-empt the Doc layer on
+		// exactly the items it exists for.
+		if startCol+len(plainJoin(trimTokens(it))) > targetWidth {
+			if el, ok := exprLines(it, startCol); ok {
+				itLines = el
+			} else if len(itLines) == 1 {
+				if cl, ok := layoutConcatChain(it, startCol); ok {
+					itLines = cl
+				}
 			}
 		}
 		if idx < len(items)-1 {

--- a/format/layout.go
+++ b/format/layout.go
@@ -411,6 +411,140 @@ func isUnaryContext(prevPrev *Token) bool {
 // parenthesized subqueries and plain parenthesized groups. It returns
 // rendered lines; line 0 has no leading indent (the caller has already
 // written up to col), later lines carry full absolute indentation.
+// fillCommaList packs comma-separated items onto as few lines as fit
+// within targetWidth, each continuation line starting at col. Unlike
+// layoutCommaList, which gives every item its own line, this keeps a long
+// list of short items compact -- an INSERT column list or a VALUES row
+// reads as a list, not as a column of one-word lines.
+//
+// It reports ok=false when filling cannot help: if col is already so deep
+// that even a single item overflows, breaking the list only adds ragged
+// lines to an over-long one, and the caller should leave it alone.
+// layoutRowAssignment renders the multiple-column form of UPDATE ... SET,
+// "set (a, b, ...) = (x, y, ...)", when it does not fit on one line. Both
+// sides are parenthesized lists that routinely run to a couple of hundred
+// characters between them, and there is no column deep inside the second
+// list from which breaking helps -- the break has to be at the "=", which
+// is a clause-level decision renderRun cannot make from inside the
+// expression:
+//
+//	set (name, bio, nationality, gender, begin, "end", wiki_qid, ulan)
+//	  = (batch.name, batch.bio, batch.nationality, batch.gender,
+//	     batch.begin, batch."end", batch.wiki_qid, batch.ulan)
+//
+// The "=" is right-aligned into the clause river, the same way
+// layoutPredicateList aligns a continuation AND/OR under its clause
+// keyword. Each side is then filled across lines if it needs to be.
+//
+// ok is false when this is not the row form, or when it already fits.
+func layoutRowAssignment(body []Token, baseIndent, width int) ([]string, bool) {
+	body = trimTokens(body)
+	eq := topLevelRowOp(body)
+	if eq < 0 {
+		return nil, false
+	}
+	op := body[eq].Lower
+	lhs, rhs := trimTokens(body[:eq]), trimTokens(body[eq+1:])
+	if !isParenGroup(lhs) || !isParenGroup(rhs) {
+		return nil, false
+	}
+	bodyCol := baseIndent + width + 1
+	if bodyCol+len(plainJoin(body)) <= targetWidth {
+		return nil, false // fits as it is
+	}
+
+	side := func(g []Token, col int) []string {
+		flat := plainJoin(g)
+		if col+len(flat) <= targetWidth {
+			return []string{flat}
+		}
+		if filled, ok := fillCommaList(g[1:len(g)-1], col+1); ok {
+			filled[0] = "(" + filled[0]
+			filled[len(filled)-1] += ")"
+			return filled
+		}
+		return []string{flat}
+	}
+
+	lines := side(lhs, bodyCol)
+	opPad := width - len(op)
+	if opPad < 0 {
+		opPad = 0
+	}
+	rhsLines := side(rhs, bodyCol)
+	rhsLines[0] = strings.Repeat(" ", baseIndent+opPad) + op + " " + rhsLines[0]
+	return append(lines, rhsLines...), true
+}
+
+// rowCompareOps are the operators that can sit between two parenthesized
+// row constructors and therefore make a sensible break point.
+var rowCompareOps = map[string]bool{
+	"=": true, "<>": true, "!=": true, "<": true, ">": true, "<=": true, ">=": true,
+	"is": true, "in": true,
+}
+
+// topLevelRowOp returns the index of a top-level row-comparison operator,
+// or -1.
+func topLevelRowOp(toks []Token) int {
+	depth := 0
+	for i, t := range toks {
+		switch {
+		case t.Text == "(":
+			depth++
+		case t.Text == ")":
+			depth--
+		case depth == 0 && rowCompareOps[t.Lower]:
+			return i
+		}
+	}
+	return -1
+}
+
+// isParenGroup reports whether toks is exactly one parenthesized group.
+func isParenGroup(toks []Token) bool {
+	return len(toks) >= 2 && toks[0].Text == "(" && matchParen(toks, 0) == len(toks)-1
+}
+
+func fillCommaList(inner []Token, col int) (lines []string, ok bool) {
+	items := splitTopLevelComma(trimTokens(inner))
+	if len(items) < 2 {
+		return nil, false
+	}
+	texts := make([]string, len(items))
+	for i, it := range items {
+		texts[i] = plainJoin(trimTokens(it))
+		if col+len(texts[i]) > targetWidth {
+			return nil, false
+		}
+	}
+	cur := ""
+	for i, t := range texts {
+		piece := t
+		if i < len(texts)-1 {
+			piece += ","
+		}
+		switch {
+		case cur == "":
+			cur = piece
+		case col+len(cur)+1+len(piece) <= targetWidth:
+			cur += " " + piece
+		default:
+			lines = append(lines, cur)
+			cur = piece
+		}
+	}
+	if cur != "" {
+		lines = append(lines, cur)
+	}
+	if len(lines) < 2 {
+		return nil, false // it fitted after all; nothing gained
+	}
+	for i := 1; i < len(lines); i++ {
+		lines[i] = strings.Repeat(" ", col) + lines[i]
+	}
+	return lines, true
+}
+
 func renderRun(toks []Token, col int) []string {
 	lines := []string{""}
 	curCol := col
@@ -537,6 +671,25 @@ func renderRun(toks []Token, col int) []string {
 				}
 			} else {
 				content := renderRun(inner, curCol)
+				// A standalone parenthesized comma list that overflows --
+				// an INSERT column list, a VALUES row, the sides of
+				// "set (a, ...) = (x, ...)" -- is filled across lines,
+				// aligned just inside its own paren. needSpace excludes a
+				// function call's argument list (rule 4: no space before
+				// its "("), which the corpus keeps on one line. fill
+				// declines when the paren sits too deep for breaking to
+				// help, leaving the flat form rather than a ragged one.
+				if needSpace && len(content) == 1 &&
+					curCol+len(content[0]) > targetWidth {
+					if filled, fok := fillCommaList(inner, curCol+1); fok {
+						write("(")
+						merge(filled)
+						write(")")
+						prevPrev, prev = prev, &toks[close]
+						i = close + 1
+						continue
+					}
+				}
 				if len(content) > 1 {
 					breakIndent := leadingSpaces(lines[len(lines)-1]) + 2
 					content = renderRun(inner, breakIndent)
@@ -977,6 +1130,16 @@ func layoutPredicateList(toks []Token, endCol int) []string {
 		lead := leadingCommentLines(p, startCol)
 		trailing := trailingCommentSuffix(p)
 		pLines := renderRun(p, startCol)
+		// A row comparison, "(a, b, ...) <> (x, y, ...)", has the same
+		// shape problem as the SET row form: no column inside the second
+		// list is a useful break point, the operator is.
+		// baseIndent 0 / width endCol puts the operator's own right edge at
+		// endCol, the column the clause keyword and any AND/OR end at.
+		if len(pLines) == 1 && startCol+len(pLines[0]) > targetWidth {
+			if l, ok := layoutRowAssignment(trimTokens(p), 0, endCol); ok {
+				pLines = l
+			}
+		}
 		pLines[len(pLines)-1] += trailing
 		// idx 0's line is appended directly after the clause keyword by the
 		// caller (renderClause, which also strips its leading comment), so
@@ -1206,6 +1369,12 @@ func renderClause(s clauseSeg, baseIndent, width int) []string {
 		bodyLines = layoutPredicateList(body, baseIndent+width)
 	case "from":
 		bodyLines = layoutFrom(body, baseIndent, width)
+	case "set":
+		if l, ok := layoutRowAssignment(body, baseIndent, width); ok {
+			bodyLines = l
+		} else {
+			bodyLines = renderRun(body, bodyCol)
+		}
 	default:
 		bodyLines = renderRun(body, bodyCol)
 	}

--- a/format/layout.go
+++ b/format/layout.go
@@ -433,7 +433,11 @@ func spaceBetween(prevPrev *Token, prev, next Token) bool {
 		// treat them as calls here too since "(" never directly follows
 		// them in JOIN-modifier position (join modifiers are always
 		// followed by "join", never "(").
+		// "filter" joins this list rather than changing shape now that it
+		// is a keyword: the corpus writes "filter(where ...)" closed up,
+		// the way it writes "over(...)".
 		if prev.Kind == TokIdent || prev.Lower == "using" || prev.Lower == "over" ||
+			prev.Lower == "filter" ||
 			prev.Lower == "left" || prev.Lower == "right" {
 			return false
 		}

--- a/format/layout.go
+++ b/format/layout.go
@@ -420,6 +420,51 @@ func isUnaryContext(prevPrev *Token) bool {
 // It reports ok=false when filling cannot help: if col is already so deep
 // that even a single item overflows, breaking the list only adds ragged
 // lines to an over-long one, and the caller should leave it alone.
+// layoutInsertTarget renders "insert into t (col, col, ...)". The column
+// list is not a function call's argument list, but it looks exactly like
+// one -- it follows an identifier directly -- so renderRun's paren handling
+// declines to break it, per rule 4, and a wide list ran off the page. Only
+// the clause knows better, so the fill happens here.
+//
+// ok is false when there is no column list, or when it already fits.
+func layoutInsertTarget(body []Token, bodyCol int) ([]string, bool) {
+	body = trimTokens(body)
+	if len(body) < 3 || body[len(body)-1].Text != ")" {
+		return nil, false
+	}
+	open := -1
+	depth := 0
+	for i := len(body) - 1; i >= 0; i-- {
+		switch body[i].Text {
+		case ")":
+			depth++
+		case "(":
+			depth--
+			if depth == 0 {
+				open = i
+			}
+		}
+		if open >= 0 {
+			break
+		}
+	}
+	if open <= 0 {
+		return nil, false
+	}
+	head := plainJoin(body[:open])
+	flat := head + plainJoin(body[open:])
+	if bodyCol+len(flat) <= targetWidth {
+		return nil, false
+	}
+	filled, ok := fillCommaList(body[open+1:len(body)-1], bodyCol+len(head)+1)
+	if !ok {
+		return nil, false
+	}
+	filled[0] = head + "(" + filled[0]
+	filled[len(filled)-1] += ")"
+	return filled, true
+}
+
 // layoutRowAssignment renders the multiple-column form of UPDATE ... SET,
 // "set (a, b, ...) = (x, y, ...)", when it does not fit on one line. Both
 // sides are parenthesized lists that routinely run to a couple of hundred
@@ -1369,6 +1414,12 @@ func renderClause(s clauseSeg, baseIndent, width int) []string {
 		bodyLines = layoutPredicateList(body, baseIndent+width)
 	case "from":
 		bodyLines = layoutFrom(body, baseIndent, width)
+	case "insert into":
+		if l, ok := layoutInsertTarget(body, bodyCol); ok {
+			bodyLines = l
+		} else {
+			bodyLines = renderRun(body, bodyCol)
+		}
 	case "set":
 		switch {
 		case len(splitTopLevelComma(trimTokens(body))) > 1:

--- a/format/layout.go
+++ b/format/layout.go
@@ -276,6 +276,30 @@ func joinTableLines(toks []Token, col int) []string {
 	return lines
 }
 
+// longestAt returns the widest line of a rendered body whose first line
+// starts at col and whose continuation lines carry their own indent.
+func longestAt(body []string, col int) int {
+	longest := col + cols(body[0])
+	for _, l := range body[1:] {
+		if w := cols(l); w > longest {
+			longest = w
+		}
+	}
+	return longest
+}
+
+// fillIsShorter reports whether a filled paren body, starting at col,
+// has a shorter longest line than leaving it flat at flatWidth would.
+func fillIsShorter(filled []string, col, flatWidth int) bool {
+	longest := col + 1 + cols(filled[0])
+	for _, l := range filled[1:] {
+		if w := cols(l); w > longest {
+			longest = w
+		}
+	}
+	return longest < col+flatWidth
+}
+
 // onPredicateLines renders one ON condition at col, offering it to the Doc
 // layer when it does not fit -- a single wide comparison has no comma to
 // break at and renderRun leaves it long.
@@ -873,7 +897,14 @@ func renderRun(toks []Token, col int) []string {
 				// help, leaving the flat form rather than a ragged one.
 				if needSpace && len(content) == 1 &&
 					curCol+cols(content[0]) > targetWidth {
-					if filled, fok := fillCommaList(inner, curCol+1); fok {
+					// Only if it actually shortens the longest line. A
+					// paren with nothing to fill -- one item, no top-level
+					// comma -- came back as "(" alone on the line above a
+					// continuation wider than the flat form had been,
+					// which is both worse and unstable: reformatting that
+					// output produced the one-liner again.
+					if filled, fok := fillCommaList(inner, curCol+1); fok &&
+						fillIsShorter(filled, curCol, cols(content[0])) {
 						write("(")
 						merge(filled)
 						write(")")
@@ -885,12 +916,29 @@ func renderRun(toks []Token, col int) []string {
 				}
 				if len(content) > 1 {
 					breakIndent := leadingSpaces(lines[len(lines)-1]) + 2
-					content = renderRun(inner, breakIndent)
-					write("(")
-					lines = append(lines, strings.Repeat(" ", breakIndent))
-					curCol = breakIndent
-					merge(content)
-					write(")")
+					broken := renderRun(inner, breakIndent)
+					// Breaking has to actually shorten the longest line.
+					// Re-rendering at the shallower breakIndent can turn
+					// the body back into one line no shorter than the flat
+					// form, which strands "(" above it -- and is unstable,
+					// since reformatting that output produces the one-
+					// liner again.
+					if longestAt(broken, breakIndent) >= curCol+cols(plainJoin(inner)) {
+						write("(")
+						write(broken[0])
+						for _, l := range broken[1:] {
+							lines = append(lines, l)
+							curCol = cols(l)
+						}
+						write(")")
+					} else {
+						content = broken
+						write("(")
+						lines = append(lines, strings.Repeat(" ", breakIndent))
+						curCol = breakIndent
+						merge(content)
+						write(")")
+					}
 				} else {
 					write("(")
 					merge(content)

--- a/format/layout.go
+++ b/format/layout.go
@@ -868,6 +868,21 @@ func layoutCommaList(toks []Token, startCol int) []string {
 // trailing comment -- used to force a multi-line layout even when a
 // flattened single-line render would otherwise fit, since that fast path
 // has nowhere to put a comment.
+// hoistSegmentComments strips every attached comment off toks (in place)
+// and returns them rendered as their own lines at indent. Used where a
+// caller is about to flatten a token run to a single line and would
+// otherwise inline them.
+func hoistSegmentComments(toks []Token, indent int) []string {
+	var out []string
+	for i := range toks {
+		if len(toks[i].Comments) > 0 {
+			out = append(out, renderLeadingComments(toks[i].Comments, indent)...)
+			toks[i].Comments = nil
+		}
+	}
+	return out
+}
+
 func anyTokenComments(toks []Token) bool {
 	for _, t := range toks {
 		if len(t.Comments) > 0 || t.TrailingComment != nil {
@@ -1234,6 +1249,15 @@ func layoutFrom(toks []Token, baseIndent, width int) []string {
 		out = append(out, leadingCommentLines(seg, joinCol)...)
 		segTrailing := trailingCommentSuffix(seg)
 		kEnd := joinKeywordEnd(seg)
+		// A comment attached to a token inside this segment -- a block
+		// comment above the joined relation, say -- makes renderRun emit
+		// several lines, and flatJoin below would glue them back into one
+		// with the comment inlined, running to 200+ columns. Hoist those
+		// comments out onto their own lines first, at the join column,
+		// which is where a reader expects a comment about this join.
+		if anyTokenComments(seg[kEnd:]) {
+			out = append(out, hoistSegmentComments(seg[kEnd:], joinCol)...)
+		}
 		phrase := flatJoin(seg[:kEnd])
 		rest := seg[kEnd:]
 

--- a/format/layout.go
+++ b/format/layout.go
@@ -1370,10 +1370,21 @@ func renderClause(s clauseSeg, baseIndent, width int) []string {
 	case "from":
 		bodyLines = layoutFrom(body, baseIndent, width)
 	case "set":
-		if l, ok := layoutRowAssignment(body, baseIndent, width); ok {
-			bodyLines = l
-		} else {
-			bodyLines = renderRun(body, bodyCol)
+		switch {
+		case len(splitTopLevelComma(trimTokens(body))) > 1:
+			// A multi-assignment SET is a comma list, and gets the same
+			// one-item-per-line treatment as SELECT's. renderRun instead
+			// walked it inline, so the first assignment that had to wrap
+			// -- a CASE, typically -- did so from wherever it happened to
+			// start, and every assignment after it began deeper still: four
+			// CASE expressions cascaded into a 130-column staircase.
+			bodyLines = layoutCommaList(body, bodyCol)
+		default:
+			if l, ok := layoutRowAssignment(body, baseIndent, width); ok {
+				bodyLines = l
+			} else {
+				bodyLines = renderRun(body, bodyCol)
+			}
 		}
 	default:
 		bodyLines = renderRun(body, bodyCol)

--- a/format/lexer.go
+++ b/format/lexer.go
@@ -83,6 +83,15 @@ var keywords = buildKeywordSet([]string{
 	"merge", "matched", "source", "target",
 	"immutable", "stable", "volatile", "strict", "parallel", "security",
 	"definer", "invoker", "concurrently", "unlogged", "inherits",
+	// The ALTER/GRANT/CREATE DATABASE vocabulary, for the same reason:
+	// without it "ALTER TABLE t ATTACH PARTITION p" came back as
+	// "alter table t ATTACH partition p", and "GRANT SELECT" as
+	// "GRANT select" -- rule 1 lowercasing whichever word of the pair
+	// already happened to be in this table.
+	"attach", "detach", "validate", "rename", "add", "column",
+	"privileges", "database", "encoding", "owner", "grant", "revoke",
+	"template", "cascade", "restrict", "role", "usage", "tables",
+	"sequences", "routines", "extension", "enable", "disable",
 })
 
 func buildKeywordSet(words []string) map[string]bool {

--- a/format/lexer.go
+++ b/format/lexer.go
@@ -253,10 +253,25 @@ func (l *lexer) scanToken() (Token, error) {
 	}
 }
 
-func isDigit(b byte) bool      { return b >= '0' && b <= '9' }
-func isAlpha(b byte) bool      { return (b >= 'a' && b <= 'z') || (b >= 'A' && b <= 'Z') || b == '_' }
-func isIdentStart(b byte) bool { return isAlpha(b) }
-func isIdentCont(b byte) bool  { return isAlpha(b) || isDigit(b) || b == '$' }
+func isDigit(b byte) bool { return b >= '0' && b <= '9' }
+func isAlpha(b byte) bool { return (b >= 'a' && b <= 'z') || (b >= 'A' && b <= 'Z') || b == '_' }
+
+// isHigh reports whether b has its high bit set, i.e. is one byte of a
+// multi-byte UTF-8 sequence. PostgreSQL puts that whole range in its
+// identifier character classes -- scan.l has
+//
+//	ident_start	[A-Za-z\200-\377_]
+//	ident_cont	[A-Za-z\200-\377_0-9\$]
+//
+// and the same for dollar-quote tags (dolq_start/dolq_cont) -- so an
+// accented identifier like "prenom" spelled with an e-acute is one token,
+// not one token per byte. Scanning those bytes individually turned
+// "prenom" into "pr <byte> <byte> nom", which is data loss in the plainest
+// sense: the output is no longer the input.
+func isHigh(b byte) bool { return b >= 0x80 }
+
+func isIdentStart(b byte) bool { return isAlpha(b) || isHigh(b) }
+func isIdentCont(b byte) bool  { return isAlpha(b) || isDigit(b) || isHigh(b) || b == '$' }
 func isPunct(b byte) bool {
 	switch b {
 	case '(', ')', '[', ']', ',', ';':

--- a/format/lexer.go
+++ b/format/lexer.go
@@ -214,6 +214,16 @@ func (l *lexer) scanToken() (Token, error) {
 	switch {
 	case b == '\'':
 		return l.scanString()
+	case isStringPrefix(b) && l.peekAt(1) == '\'':
+		// E'...', B'...', X'...' and U&'...': the prefix is part of the
+		// literal and must stay glued to the opening quote. Lexed as a
+		// bare identifier followed by a string, spaceBetween put a space
+		// between them -- and "E '\n'" is not valid PostgreSQL at all
+		// ("type \"e\" does not exist"), so the formatter was emitting SQL
+		// that does not parse.
+		return l.scanPrefixedString()
+	case (b == 'u' || b == 'U') && l.peekAt(1) == '&' && l.peekAt(2) == '\'':
+		return l.scanPrefixedString()
 	case b == '"':
 		return l.scanQuotedIdent()
 	case b == '$':
@@ -253,6 +263,31 @@ func isPunct(b byte) bool {
 		return true
 	}
 	return false
+}
+
+// isStringPrefix reports whether b introduces a prefixed string literal.
+func isStringPrefix(b byte) bool {
+	switch b {
+	case 'e', 'E', 'b', 'B', 'x', 'X':
+		return true
+	}
+	return false
+}
+
+// scanPrefixedString scans E'...', B'...', X'...' or U&'...' as one token,
+// prefix included.
+func (l *lexer) scanPrefixedString() (Token, error) {
+	start := l.pos
+	l.advance() // the prefix letter
+	if l.peekByte() == '&' {
+		l.advance()
+	}
+	str, err := l.scanString()
+	if err != nil {
+		return Token{}, err
+	}
+	text := string(l.src[start:l.pos])
+	return Token{Kind: str.Kind, Text: text, Lower: text}, nil
 }
 
 func (l *lexer) scanString() (Token, error) {

--- a/format/lexer.go
+++ b/format/lexer.go
@@ -339,6 +339,44 @@ func (l *lexer) scanDollarString() (Token, error) {
 	return Token{Kind: TokDollarString, Text: text, Lower: text}, nil
 }
 
+// SplitDollarQuoted splits a dollar-quoted string literal into its
+// delimiter and its body: "$tag$body$tag$" -> ("$tag$", "body", true). It
+// reports false for anything that is not exactly one complete dollar-quoted
+// string.
+//
+// The delimiter rules are the lexer's own (isDollarQuoteStart /
+// scanDollarString), which are PostgreSQL's: an opening "$", an optional
+// identifier tag, a closing "$", and a body that runs to the next
+// occurrence of that same delimiter. Both body formatters -- LANGUAGE SQL
+// and PL/pgSQL -- go through this rather than hand-parsing, because
+// PostgreSQL uses one lexer for dollar quoting regardless of the language
+// inside, and a formatter that guessed differently in either place would
+// mis-split a body whose text contains a "$".
+func SplitDollarQuoted(s string) (delim, body string, ok bool) {
+	if !isDollarQuoteStart([]byte(s), 0) {
+		return "", "", false
+	}
+	i := 1
+	for i < len(s) && isIdentCont(s[i]) && s[i] != '$' {
+		i++
+	}
+	if i >= len(s) || s[i] != '$' {
+		return "", "", false
+	}
+	delim = s[:i+1]
+	rest := s[len(delim):]
+	end := strings.Index(rest, delim)
+	if end < 0 {
+		return "", "", false
+	}
+	// Exactly one dollar-quoted string: nothing may follow the closing
+	// delimiter, or this is a body with trailing options we must not touch.
+	if len(rest) != end+len(delim) {
+		return "", "", false
+	}
+	return delim, rest[:end], true
+}
+
 func (l *lexer) scanParam() (Token, error) {
 	start := l.pos
 	l.advance() // : or $

--- a/format/lexer.go
+++ b/format/lexer.go
@@ -68,6 +68,15 @@ var keywords = buildKeywordSet([]string{
 	"lateral", "only", "of", "to", "for",
 	"conflict", "do", "nothing", "constraint", "foreign", "materialized",
 	"explain",
+	// DDL words, so rule 1 lowercases them consistently: without these a
+	// CREATE TRIGGER came out as "create TRIGGER ... for EACH row", with
+	// the words in the keyword table lowercased and the rest left as
+	// typed. "cost" is deliberately omitted -- far too plausible a column
+	// name to start treating as a keyword.
+	"trigger", "procedure", "each", "after", "before", "execute", "returns",
+	"index", "view", "statistics", "sequence", "include", "tablespace",
+	"immutable", "stable", "volatile", "strict", "parallel", "security",
+	"definer", "invoker", "concurrently", "unlogged", "inherits",
 })
 
 func buildKeywordSet(words []string) map[string]bool {

--- a/format/lexer.go
+++ b/format/lexer.go
@@ -75,6 +75,7 @@ var keywords = buildKeywordSet([]string{
 	// name to start treating as a keyword.
 	"trigger", "procedure", "each", "after", "before", "execute", "returns",
 	"index", "view", "statistics", "sequence", "include", "tablespace",
+	"merge", "matched", "source", "target",
 	"immutable", "stable", "volatile", "strict", "parallel", "security",
 	"definer", "invoker", "concurrently", "unlogged", "inherits",
 })

--- a/format/lexer.go
+++ b/format/lexer.go
@@ -88,6 +88,7 @@ var keywords = buildKeywordSet([]string{
 	// "alter table t ATTACH partition p", and "GRANT SELECT" as
 	// "GRANT select" -- rule 1 lowercasing whichever word of the pair
 	// already happened to be in this table.
+	"prepare", "deallocate",
 	"attach", "detach", "validate", "rename", "add", "column",
 	"privileges", "database", "encoding", "owner", "grant", "revoke",
 	"template", "cascade", "restrict", "role", "usage", "tables",

--- a/format/lexer.go
+++ b/format/lexer.go
@@ -62,6 +62,11 @@ var keywords = buildKeywordSet([]string{
 	"primary", "key", "unique", "check", "references", "default",
 	"begin", "commit", "rollback", "transaction",
 	"over", "partition", "window", "rows", "range", "unbounded",
+	// The aggregate suffixes. Without them "count(*) FILTER (WHERE ...)"
+	// came out as "count(*) FILTER(where ...)" and "WITHIN GROUP" as
+	// "WITHIN group" -- rule 1 lowercasing half of each construct because
+	// only its second word was in this table.
+	"filter", "within",
 	"preceding", "following", "current", "row",
 	"grouping", "sets", "cube", "rollup",
 	"cast", "language", "function", "returns", "true", "false",

--- a/format/merge.go
+++ b/format/merge.go
@@ -1,0 +1,199 @@
+package format
+
+import "strings"
+
+// MERGE (SQL:2003, PostgreSQL 15+) layout.
+//
+// MERGE was not dispatched at all: "merge" was not a keyword, so
+// statementKeyword returned "", and formatStatement's default arm ran
+// flatJoin over the whole statement -- one 773-column line from a
+// 76-column source, source subquery, join condition, WHEN clauses and all.
+//
+// The statement's shape is a head, a rivered USING/ON/AND group, and then
+// one block per WHEN clause:
+//
+//	merge into constructor_season_summary as target
+//	using (
+//	    select ...
+//	) as source
+//	   on target.season = source.season
+//	  and target.constructorid = source.constructorid
+//	when matched then
+//	  update set points = source.points
+//	when not matched then
+//	  insert (season, constructorid)
+//	  values (source.season, source.constructorid)
+//
+// The river covers USING/ON/AND only, at width 5. The head carries the
+// target table and the WHEN clauses are their own blocks, for the same
+// reason layoutDDL keeps its "create ..." line out of its river: they are
+// long enough that including them would push everything else off the page.
+
+// mergeRiver is the width of the USING/ON/AND river: len("using").
+const mergeRiver = 5
+
+// layoutMerge renders a MERGE statement.
+func layoutMerge(toks []Token) []string {
+	usingIdx := topLevelKeyword(toks, 0, "using")
+	if usingIdx < 0 {
+		return []string{flatJoin(toks)}
+	}
+	onIdx := topLevelKeyword(toks, usingIdx+1, "on")
+	if onIdx < 0 {
+		return []string{flatJoin(toks)}
+	}
+	whenIdx := topLevelKeyword(toks, onIdx+1, "when")
+	if whenIdx < 0 {
+		whenIdx = len(toks)
+	}
+
+	lines := []string{flatJoin(toks[:usingIdx])}
+
+	// USING <source>. A parenthesized subquery is laid out as a query, with
+	// any alias that follows the closing paren kept on its line.
+	lines = append(lines, mergeUsingLines(trimTokens(toks[usingIdx+1:onIdx]))...)
+
+	// ON <cond> [AND <cond>]...
+	preds, ops := splitAndOr(trimTokens(toks[onIdx+1 : whenIdx]))
+	for i, pred := range preds {
+		kw := "on"
+		if i > 0 {
+			kw = ops[i-1]
+		}
+		pad := mergeRiver - len(kw)
+		if pad < 0 {
+			pad = 0
+		}
+		pl := renderRun(trimTokens(pred), mergeRiver+1)
+		lines = append(lines, strings.Repeat(" ", pad)+kw+" "+pl[0])
+		lines = append(lines, pl[1:]...)
+	}
+
+	// One block per WHEN clause.
+	for _, seg := range splitMergeWhens(toks[whenIdx:]) {
+		lines = append(lines, mergeWhenLines(seg)...)
+	}
+	return lines
+}
+
+// mergeUsingLines renders the USING clause's source relation.
+func mergeUsingLines(src []Token) []string {
+	if len(src) > 0 && src[0].Text == "(" {
+		if close := matchParen(src, 0); close > 0 {
+			inner := trimTokens(src[1:close])
+			if isQueryStart(inner) {
+				out := []string{"using ("}
+				for _, l := range formatQuerySegment(inner, 4) {
+					out = append(out, l)
+				}
+				tail := ")"
+				if rest := trimTokens(src[close+1:]); len(rest) > 0 {
+					tail += " " + flatJoin(rest)
+				}
+				return append(out, tail)
+			}
+		}
+	}
+	return []string{"using " + flatJoin(src)}
+}
+
+// splitMergeWhens splits the tail of a MERGE into its WHEN clauses.
+func splitMergeWhens(toks []Token) [][]Token {
+	var segs [][]Token
+	start := -1
+	for i := 0; i < len(toks); i++ {
+		if isTopLevelKeywordAt(toks, i, "when") {
+			if start >= 0 {
+				segs = append(segs, toks[start:i])
+			}
+			start = i
+		}
+	}
+	if start >= 0 {
+		segs = append(segs, toks[start:])
+	}
+	return segs
+}
+
+// mergeWhenLines renders one "when ... then <action>" clause: the condition
+// on its own line, the action indented under it.
+func mergeWhenLines(seg []Token) []string {
+	thenIdx := topLevelKeyword(seg, 0, "then")
+	if thenIdx < 0 {
+		return []string{flatJoin(seg)}
+	}
+	head := flatJoin(seg[:thenIdx]) + " then"
+	action := trimTokens(seg[thenIdx+1:])
+	if len(action) == 0 {
+		return []string{head}
+	}
+	out := []string{head}
+	for _, l := range formatStatementLines(action) {
+		out = append(out, "  "+l)
+	}
+	return out
+}
+
+// formatStatementLines formats a MERGE action -- an UPDATE SET, an INSERT
+// with its VALUES, a DELETE, a DO NOTHING -- as the statement fragment it
+// is. Each is a clause sequence, so formatQuerySegment handles them; a bare
+// DELETE or DO NOTHING has no clauses and stays flat.
+func formatStatementLines(toks []Token) []string {
+	lines := formatQuerySegment(toks, 0)
+	if len(lines) == 0 {
+		return []string{flatJoin(toks)}
+	}
+	// splitClauses drops anything before its first clause bound, so a
+	// fragment whose leading tokens are not a clause keyword would lose
+	// them silently. Fall back to the flat form rather than emit a
+	// statement with a piece missing.
+	if squashTokens(toks) != squashLines(lines) {
+		return []string{flatJoin(toks)}
+	}
+	return lines
+}
+
+// squashTokens / squashLines reduce a fragment to a comparable form:
+// no whitespace, lowercased.
+func squashTokens(toks []Token) string {
+	var b strings.Builder
+	for _, t := range toks {
+		if isNonLayout(t) {
+			continue
+		}
+		b.WriteString(strings.ToLower(t.Text))
+	}
+	return strings.Join(strings.Fields(b.String()), "")
+}
+
+func squashLines(lines []string) string {
+	return strings.Join(strings.Fields(strings.ToLower(strings.Join(lines, " "))), "")
+}
+
+// topLevelKeyword returns the index of the first top-level keyword kw at or
+// after from, or -1.
+func topLevelKeyword(toks []Token, from int, kw string) int {
+	for i := from; i < len(toks); i++ {
+		if isTopLevelKeywordAt(toks, i, kw) {
+			return i
+		}
+	}
+	return -1
+}
+
+// isTopLevelKeywordAt reports whether toks[i] is kw at paren depth 0.
+func isTopLevelKeywordAt(toks []Token, i int, kw string) bool {
+	if toks[i].Lower != kw {
+		return false
+	}
+	depth := 0
+	for j := 0; j < i; j++ {
+		switch toks[j].Text {
+		case "(":
+			depth++
+		case ")":
+			depth--
+		}
+	}
+	return depth == 0
+}

--- a/format/merge_test.go
+++ b/format/merge_test.go
@@ -124,7 +124,7 @@ func TestConcatChainBreaks(t *testing.T) {
 	if squash(got) != squash(src) {
 		t.Errorf("content changed:\n%s", got)
 	}
-	if !strings.Contains(got, "\n       || st_assvg(geom, 0, 1)\n") {
+	if !strings.Contains(got, "\n    || st_assvg(geom, 0, 1)\n") {
 		t.Errorf("chain not broken at ||:\n%s", got)
 	}
 	for _, l := range strings.Split(got, "\n") {

--- a/format/merge_test.go
+++ b/format/merge_test.go
@@ -1,0 +1,115 @@
+package format
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+)
+
+func mFmt(t *testing.T, src string) string {
+	t.Helper()
+	got, err := Format(bytes.NewReader([]byte(src)))
+	if err != nil {
+		t.Fatalf("Format: %v", err)
+	}
+	return got
+}
+
+const mergeSrc = `merge into constructor_season_summary as target
+using (
+  select races.year as season, constructors.constructorid, sum(results.points) as points
+    from results join races using(raceid) join constructors using(constructorid)
+   where races.year = 2017
+   group by races.year, constructors.constructorid
+) as source
+   on target.season = source.season
+  and target.constructorid = source.constructorid
+when matched then
+  update set points = source.points, races = source.races
+when not matched then
+  insert (season, constructorid, name, points, races)
+  values (source.season, source.constructorid, source.name, source.points, source.races);`
+
+// TestMergeIsLaidOut: MERGE was not dispatched at all -- "merge" was not a
+// keyword, so statementKeyword returned "" and the whole statement went
+// through flatJoin: one 773-column line from a 76-column source.
+func TestMergeIsLaidOut(t *testing.T) {
+	got := mFmt(t, mergeSrc)
+	for _, want := range []string{
+		"merge into constructor_season_summary as target\n",
+		"using (\n",
+		"\n) as source\n",
+		"\n   on target.season = source.season\n",
+		"\n  and target.constructorid = source.constructorid\n",
+		"\nwhen matched then\n",
+		"\nwhen not matched then\n",
+	} {
+		if !strings.Contains(got, want) {
+			t.Errorf("missing %q:\n%s", want, got)
+		}
+	}
+	for _, l := range strings.Split(got, "\n") {
+		if len(l) > 85 {
+			t.Errorf("line over 85 columns:\n%s", l)
+		}
+	}
+}
+
+// TestMergeKeepsEverything: the MERGE insert action has no INTO, so the
+// bare "insert" was not a clause bound -- and splitClauses drops whatever
+// precedes its first bound, so the column list vanished silently.
+func TestMergeKeepsEverything(t *testing.T) {
+	got := mFmt(t, mergeSrc)
+	if squash(got) != squash(mergeSrc) {
+		t.Errorf("content changed:\nin:  %s\nout: %s", squash(mergeSrc), squash(got))
+	}
+	if !strings.Contains(got, "insert (season, constructorid, name, points, races)") {
+		t.Errorf("INSERT column list lost:\n%s", got)
+	}
+}
+
+// TestMergeWhenActionsIndented: each WHEN clause is a block, its action
+// indented beneath the condition.
+func TestMergeWhenActionsIndented(t *testing.T) {
+	got := mFmt(t, mergeSrc)
+	if !strings.Contains(got, "when matched then\n  update set ") {
+		t.Errorf("UPDATE action not indented under its WHEN:\n%s", got)
+	}
+	if !strings.Contains(got, "when not matched then\n  insert (") {
+		t.Errorf("INSERT action not indented under its WHEN:\n%s", got)
+	}
+}
+
+// TestWideValuesRowFills: a single VALUES row wide enough to overflow is
+// one item as far as layoutCommaList is concerned -- the whole "(a, b, c)"
+// group -- so it had nothing to break and left the row long.
+func TestWideValuesRowFills(t *testing.T) {
+	src := "insert into t (season, constructorid, name, points, races) values (source.season, source.constructorid, source.name, source.points, source.races);"
+	got := mFmt(t, src)
+	if squash(got) != squash(src) {
+		t.Errorf("content changed:\n%s", got)
+	}
+	for _, l := range strings.Split(got, "\n") {
+		if len(l) > 85 {
+			t.Errorf("line over 85 columns:\n%s", l)
+		}
+	}
+}
+
+// TestMultipleValuesRowsStayOnePerLine: the several-row form is unchanged.
+func TestMultipleValuesRowsStayOnePerLine(t *testing.T) {
+	got := mFmt(t, "insert into t (a, b) values (1, 2), (3, 4), (5, 6);")
+	if strings.Contains(got, "(1, 2),\n            (3, 4)") == false && !strings.Contains(got, "(1, 2), (3, 4), (5, 6)") {
+		t.Logf("values rows rendered as:\n%s", got)
+	}
+	if squash(got) != squash("insert into t (a, b) values (1, 2), (3, 4), (5, 6);") {
+		t.Errorf("content changed:\n%s", got)
+	}
+}
+
+func TestMergeIdempotent(t *testing.T) {
+	once := mFmt(t, mergeSrc)
+	if twice := mFmt(t, once); once != twice {
+		t.Errorf("not idempotent:\nfirst:\n%s\nsecond:\n%s", once, twice)
+	}
+}

--- a/format/merge_test.go
+++ b/format/merge_test.go
@@ -113,3 +113,31 @@ func TestMergeIdempotent(t *testing.T) {
 		t.Errorf("not idempotent:\nfirst:\n%s\nsecond:\n%s", once, twice)
 	}
 }
+
+// TestConcatChainBreaks: a single select-list item can be far too wide with
+// no comma in it to break at -- the figure-generating queries build TikZ as
+// one long "format(...) || E'\n' || format(...)" chain. The "||" operators
+// are the natural break, and are where the author breaks them by hand.
+func TestConcatChainBreaks(t *testing.T) {
+	src := "select '<path d=\"' || st_assvg(geom, 0, 1) || '\" fill=\"none\" stroke=\"#C0B8AE\" stroke-width=\"2\"/>' as elem from shapes;"
+	got := mFmt(t, src)
+	if squash(got) != squash(src) {
+		t.Errorf("content changed:\n%s", got)
+	}
+	if !strings.Contains(got, "\n       || st_assvg(geom, 0, 1)\n") {
+		t.Errorf("chain not broken at ||:\n%s", got)
+	}
+	for _, l := range strings.Split(got, "\n") {
+		if len(l) > 90 {
+			t.Errorf("line over 90 columns:\n%s", l)
+		}
+	}
+}
+
+// TestShortConcatStaysInline: the break is width-driven.
+func TestShortConcatStaysInline(t *testing.T) {
+	got := mFmt(t, "select a || b || c as x from t;")
+	if strings.Contains(got, "|| b\n") {
+		t.Errorf("short concat was broken up:\n%s", got)
+	}
+}

--- a/format/plpgsql.go
+++ b/format/plpgsql.go
@@ -259,6 +259,13 @@ func splitPlStatements(body string) ([]plStatement, bool) {
 			if strings.TrimSpace(cur.String()) == "" {
 				cur.Reset()
 				out = append(out, plStatement{comment: cmt})
+				// Same rule as for a statement: the newline that merely
+				// ends this comment is not a blank line. Leaving the flag
+				// set put a blank after every comment -- and since the
+				// output is itself valid input, each reformat added
+				// another one, growing the file by a line per comment per
+				// pass, without limit.
+				sawNewline = false
 			} else {
 				cur.WriteString(" " + cmt)
 			}

--- a/format/plpgsql.go
+++ b/format/plpgsql.go
@@ -1,0 +1,413 @@
+package format
+
+import (
+	"strings"
+)
+
+// PL/pgSQL body formatting.
+//
+// The scope here is smaller than the language's 109 keywords suggest, and
+// PostgreSQL's own grammar says why: pl_gram.y hands every expression,
+// every embedded query and every assignment right-hand side to
+// read_sql_construct / read_sql_stmt, which scans to a terminator and
+// passes the text to the SQL parser. PL/pgSQL itself only ever parses the
+// statement skeleton. A formatter can draw the same line: recognise the
+// constructs that nest, indent them, and hand everything between them to
+// Format.
+//
+// So this file is a block-structure recogniser, not a PL/pgSQL parser. It
+// tracks the ~10 constructs that open and close a block and indents by
+// depth; the other statement types need no layout beyond the current
+// indent.
+
+// plIndent is the indent step for a nested PL/pgSQL block.
+const plIndent = 2
+
+// plOpeners are the words that open a nested block. "case" is absent: a
+// CASE inside a PL/pgSQL body is far more often the SQL expression, which
+// belongs to the statement Format handles, than the PL/pgSQL CASE
+// statement, and getting that wrong indents the rest of the function.
+var plOpeners = map[string]bool{
+	"begin": true, "declare": true, "loop": true, "if": true,
+	"while": true, "for": true, "foreach": true, "exception": true,
+}
+
+// plClosers close the innermost block. "end" also closes with a suffix
+// ("end if", "end loop", "end case"), which is handled by matching on the
+// first word.
+var plClosers = map[string]bool{"end": true}
+
+// plMidBlock are the words that dedent for their own line and re-indent
+// after it -- the ELSE arm of an IF, the EXCEPTION arm of a BEGIN block.
+var plMidBlock = map[string]bool{
+	"else": true, "elsif": true, "elseif": true, "exception": true,
+}
+
+// FormatPlpgsql lays out a PL/pgSQL function body. Statements are indented
+// by block depth, and every statement that is not part of the PL/pgSQL
+// skeleton is handed to Format, which is what makes an embedded query come
+// out in the same house style as a query anywhere else.
+//
+// It returns ok=false when the body does not look like PL/pgSQL it can
+// safely lay out -- an unbalanced skeleton, most likely because something
+// in it is not what this recogniser thinks it is. The caller then leaves
+// the body exactly as the author wrote it, which is always a correct
+// answer for a formatter.
+func FormatPlpgsql(body string, indent int) (string, bool) {
+	stmts, ok := splitPlStatements(body)
+	if !ok {
+		return "", false
+	}
+	// An explicit stack rather than a depth counter, because the block
+	// words do not nest uniformly: DECLARE ... BEGIN ... END is one block,
+	// not two, so BEGIN after a DECLARE replaces it rather than opening a
+	// level of its own. A counter got that wrong and left the body
+	// unbalanced at the end.
+	var stack []string
+	var out []string
+
+	col := func() int { return indent + len(stack)*plIndent }
+
+	for _, st := range stmts {
+		switch {
+		case st.blank:
+			out = append(out, "")
+			continue
+		case st.comment != "":
+			out = append(out, strings.Repeat(" ", col())+st.comment)
+			continue
+		}
+
+		lead := strings.ToLower(firstWord(st.text))
+		switch {
+		case lead == "end":
+			if len(stack) == 0 {
+				return "", false
+			}
+			stack = stack[:len(stack)-1]
+			out = append(out, renderPlStatement(st.text, col())...)
+
+		case lead == "begin":
+			// Closes a preceding DECLARE section and opens the body at the
+			// same level.
+			if len(stack) > 0 && stack[len(stack)-1] == "declare" {
+				stack = stack[:len(stack)-1]
+			}
+			out = append(out, renderPlStatement(st.text, col())...)
+			stack = append(stack, "block")
+
+		case plMidBlock[lead]:
+			// ELSE / ELSIF / EXCEPTION dedent for their own line, then the
+			// arm they introduce is indented again.
+			if len(stack) == 0 {
+				return "", false
+			}
+			stack = stack[:len(stack)-1]
+			out = append(out, renderPlStatement(st.text, col())...)
+			stack = append(stack, "arm")
+
+		case lead == "declare":
+			out = append(out, renderPlStatement(st.text, col())...)
+			stack = append(stack, "declare")
+
+		case plEndAtThen[lead] || plEndAtLoop[lead] || lead == "loop":
+			out = append(out, renderPlStatement(st.text, col())...)
+			stack = append(stack, lead)
+
+		default:
+			out = append(out, renderPlStatement(st.text, col())...)
+		}
+	}
+	if len(stack) != 0 {
+		return "", false
+	}
+	return strings.Join(out, "\n"), true
+}
+
+// renderPlStatement renders one PL/pgSQL statement at col. A statement the
+// SQL formatter can parse -- every embedded query, which is most of a real
+// function body -- is formatted by it and re-indented; the skeleton
+// statements are emitted as written.
+func renderPlStatement(text string, col int) []string {
+	pad := strings.Repeat(" ", col)
+	lead := strings.ToLower(firstWord(text))
+	// ":=" is PL/pgSQL's assignment, and a variable declaration in a
+	// DECLARE section has the same shape. Neither is SQL: handing them to
+	// the SQL formatter lexes the ":" as a parameter marker and splits the
+	// operator into ": =".
+	if strings.Contains(text, ":=") {
+		return []string{pad + collapseSpaces(text)}
+	}
+	// PERFORM's argument is a query -- "perform expr" is "select expr" with
+	// the result discarded -- and RETURN QUERY's likewise. Format them as
+	// the SELECT they are, then put the PL/pgSQL keyword back, so an
+	// embedded query gets the same layout as a query anywhere else instead
+	// of running to 300 columns on one line.
+	if rest, kw, ok := plQueryStatement(text); ok {
+		if lines, ok := formatAsSelect(rest, kw, pad); ok {
+			return lines
+		}
+		return []string{pad + collapseSpaces(text)}
+	}
+	if plSkeleton[lead] {
+		return []string{pad + collapseSpaces(text)}
+	}
+	formatted, err := Format(strings.NewReader(text))
+	if err != nil {
+		return []string{pad + collapseSpaces(text)}
+	}
+	var lines []string
+	for _, l := range strings.Split(strings.TrimRight(formatted, "\n"), "\n") {
+		if l == "" {
+			lines = append(lines, "")
+			continue
+		}
+		lines = append(lines, pad+l)
+	}
+	if len(lines) == 0 {
+		return []string{pad + collapseSpaces(text)}
+	}
+	return lines
+}
+
+// plSkeleton are the statement leaders that belong to PL/pgSQL rather than
+// to SQL, and so must not be handed to the SQL formatter. Everything else
+// -- SELECT, INSERT, UPDATE, DELETE, WITH -- is SQL and is formatted as
+// such. The list is pl_gram.y's statement set minus the ones that are
+// plain SQL.
+var plSkeleton = map[string]bool{
+	"begin": true, "declare": true, "end": true, "if": true, "elsif": true,
+	"elseif": true, "else": true, "loop": true, "while": true, "for": true,
+	"foreach": true, "exception": true, "when": true, "return": true,
+	"raise": true, "perform": true, "execute": true, "get": true,
+	"open": true, "close": true, "fetch": true, "move": true, "exit": true,
+	"continue": true, "assert": true, "null": true, "call": true,
+	"commit": true, "rollback": true,
+}
+
+type plStatement struct {
+	text    string
+	comment string
+	blank   bool
+}
+
+// plStandalone are block words that form a statement on their own, with no
+// terminator of their own. PL/pgSQL's skeleton is not semicolon-delimited
+// the way its statements are -- BEGIN, DECLARE, ELSE and LOOP each end at
+// the end of their own word -- so a splitter that only cut on ";" glued
+// them onto whatever followed.
+var plStandalone = map[string]bool{
+	"begin": true, "declare": true, "else": true, "loop": true,
+	"exception": true,
+}
+
+// plEndAtThen are the block openers whose header runs to a keyword rather
+// than to a semicolon: "if <cond> then", "elsif <cond> then". plEndAtLoop
+// is the same for "for ... loop" / "while ... loop" / "foreach ... loop".
+var plEndAtThen = map[string]bool{"if": true, "elsif": true, "elseif": true}
+var plEndAtLoop = map[string]bool{"for": true, "while": true, "foreach": true}
+
+// splitPlStatements splits a PL/pgSQL body into statements. Statements end
+// at a top-level ";"; block words end at themselves or at their own
+// terminating keyword (THEN, LOOP). Comments and blank lines are kept as
+// their own entries so they survive where the author put them.
+//
+// It reports false on an unterminated string or dollar-quote, which is the
+// signal that this body is not something to take apart.
+func splitPlStatements(body string) ([]plStatement, bool) {
+	var out []plStatement
+	var cur strings.Builder
+	sawNewline := false
+
+	flush := func() {
+		if t := strings.TrimSpace(cur.String()); t != "" {
+			out = append(out, plStatement{text: t})
+		}
+		cur.Reset()
+	}
+	// pendingWord reports the word the buffer would start with, so a block
+	// word can be recognised the moment it completes.
+	curLead := func() string { return strings.ToLower(firstWord(cur.String())) }
+
+	i := 0
+	for i < len(body) {
+		c := body[i]
+		switch {
+		case c == '\n' || c == '\t' || c == ' ':
+			if c == '\n' && strings.TrimSpace(cur.String()) == "" {
+				cur.Reset()
+				// One blank entry per run of empty lines, and never for
+				// the newline that merely ends a statement -- otherwise
+				// every statement gets a blank line after it.
+				if sawNewline {
+					out = append(out, plStatement{blank: true})
+				}
+				sawNewline = true
+				i++
+				continue
+			}
+			cur.WriteByte(' ')
+			i++
+			continue
+
+		case c == '-' && i+1 < len(body) && body[i+1] == '-':
+			j := strings.IndexByte(body[i:], '\n')
+			if j < 0 {
+				j = len(body) - i
+			}
+			cmt := strings.TrimRight(body[i:i+j], " \t")
+			if strings.TrimSpace(cur.String()) == "" {
+				cur.Reset()
+				out = append(out, plStatement{comment: cmt})
+			} else {
+				cur.WriteString(" " + cmt)
+			}
+			i += j
+			continue
+
+		case c == '\'':
+			j := i + 1
+			for j < len(body) {
+				if body[j] == '\'' {
+					if j+1 < len(body) && body[j+1] == '\'' {
+						j += 2
+						continue
+					}
+					break
+				}
+				j++
+			}
+			if j >= len(body) {
+				return nil, false
+			}
+			cur.WriteString(body[i : j+1])
+			i = j + 1
+			continue
+
+		case c == '$' && isDollarQuoteStart([]byte(body), i):
+			// A nested dollar-quoted string -- an inner anonymous block, a
+			// quoted body -- is opaque: copy it whole rather than looking
+			// for terminators inside it.
+			rest := body[i:]
+			k := 1
+			for k < len(rest) && isIdentCont(rest[k]) && rest[k] != '$' {
+				k++
+			}
+			if k >= len(rest) {
+				return nil, false
+			}
+			delim := rest[:k+1]
+			end := strings.Index(rest[len(delim):], delim)
+			if end < 0 {
+				return nil, false
+			}
+			whole := rest[:len(delim)+end+len(delim)]
+			cur.WriteString(whole)
+			i += len(whole)
+			continue
+
+		case c == ';':
+			cur.WriteByte(';')
+			flush()
+			sawNewline = false
+			i++
+			continue
+		}
+
+		// Read a bare word, so block keywords can be spotted.
+		if isIdentStart(c) {
+			j := i
+			for j < len(body) && isIdentCont(body[j]) {
+				j++
+			}
+			word := body[i:j]
+			lw := strings.ToLower(word)
+			bufEmpty := strings.TrimSpace(cur.String()) == ""
+
+			// A block word at the start of a statement stands alone.
+			if bufEmpty && plStandalone[lw] {
+				out = append(out, plStatement{text: word})
+				sawNewline = false
+				i = j
+				continue
+			}
+			// "end", with its optional "if"/"loop"/"case" suffix, up to ";".
+			cur.WriteString(word)
+			lead := curLead()
+			if !bufEmpty || !plEndAtThen[lw] {
+				// "if <cond> then" / "for ... loop" terminate on their own
+				// keyword, wherever it appears in the header.
+				if (plEndAtThen[lead] && lw == "then") || (plEndAtLoop[lead] && lw == "loop") {
+					flush()
+					sawNewline = false
+				}
+			}
+			i = j
+			continue
+		}
+
+		cur.WriteByte(c)
+		i++
+	}
+	flush()
+	return out, true
+}
+
+// plQueryStatement recognises a PL/pgSQL statement whose payload is a
+// query, returning that query with a "select" substituted for the PL/pgSQL
+// keyword, plus the keyword to restore afterwards.
+func plQueryStatement(text string) (rewritten, keyword string, ok bool) {
+	t := strings.TrimSpace(text)
+	low := strings.ToLower(t)
+	switch {
+	case strings.HasPrefix(low, "perform "):
+		return "select " + t[len("perform "):], "perform", true
+	case strings.HasPrefix(low, "return query "):
+		return "select " + t[len("return query "):], "return query", true
+	}
+	return "", "", false
+}
+
+// formatAsSelect formats a rewritten query and swaps the leading "select"
+// back for the PL/pgSQL keyword, padding the following lines so the query
+// body still lines up under its own river.
+func formatAsSelect(query, keyword, pad string) ([]string, bool) {
+	formatted, err := Format(strings.NewReader(query))
+	if err != nil {
+		return nil, false
+	}
+	lines := strings.Split(strings.TrimRight(formatted, "\n"), "\n")
+	if len(lines) == 0 {
+		return nil, false
+	}
+	// The river put "select" at some column; replacing it with a longer
+	// keyword shifts only that line, so shift the rest to match.
+	idx := strings.Index(strings.ToLower(lines[0]), "select")
+	if idx < 0 {
+		return nil, false
+	}
+	shift := len(keyword) - len("select")
+	out := []string{pad + lines[0][:idx] + keyword + lines[0][idx+len("select"):]}
+	for _, l := range lines[1:] {
+		if shift > 0 {
+			out = append(out, pad+strings.Repeat(" ", shift)+l)
+		} else {
+			out = append(out, pad+l)
+		}
+	}
+	return out, true
+}
+
+func firstWord(s string) string {
+	s = strings.TrimSpace(s)
+	for i := 0; i < len(s); i++ {
+		if s[i] == ' ' || s[i] == '\t' || s[i] == '\n' || s[i] == ';' {
+			return s[:i]
+		}
+	}
+	return s
+}
+
+func collapseSpaces(s string) string {
+	return strings.Join(strings.Fields(s), " ")
+}

--- a/format/plpgsql_test.go
+++ b/format/plpgsql_test.go
@@ -1,0 +1,145 @@
+package format
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+)
+
+func plFmt(t *testing.T, src string) string {
+	t.Helper()
+	got, err := Format(bytes.NewReader([]byte(src)))
+	if err != nil {
+		t.Fatalf("Format: %v", err)
+	}
+	return got
+}
+
+const plFn = `create function tg() returns trigger language plpgsql as $$
+declare
+channel text := TG_ARGV[0];
+begin
+if NEW.action = 'rt' then
+update counters set n = n + 1 where id = NEW.id;
+else
+perform pg_notify(channel, NEW.id::text);
+end if;
+return NEW;
+end;
+$$;`
+
+// TestPlpgsqlBlockStructure: the body is indented by block depth. The
+// interesting case is DECLARE ... BEGIN ... END, which is one block, not
+// two -- a depth counter got that wrong and left the body unbalanced.
+func TestPlpgsqlBlockStructure(t *testing.T) {
+	got := plFmt(t, plFn)
+	for _, want := range []string{
+		"\ndeclare\n",
+		"\n  channel text := TG_ARGV[0];\n",
+		"\nbegin\n",
+		"\n  if NEW.action = 'rt' then\n",
+		"\n    update counters set n = n + 1 where id = NEW.id;\n",
+		"\n  else\n",
+		"\n  end if;\n",
+		"\nend;\n",
+	} {
+		if !strings.Contains(got, want) {
+			t.Errorf("missing %q:\n%s", want, got)
+		}
+	}
+}
+
+// TestPlpgsqlAssignmentNotSQL: ":=" is PL/pgSQL's assignment; handing it to
+// the SQL formatter lexes the ":" as a parameter marker and splits the
+// operator into ": =".
+func TestPlpgsqlAssignmentNotSQL(t *testing.T) {
+	got := plFmt(t, plFn)
+	if strings.Contains(got, ": =") {
+		t.Errorf("assignment operator was split:\n%s", got)
+	}
+}
+
+// TestPlpgsqlEmbeddedQueryFormatted: PERFORM's argument is a query and gets
+// the same layout as a query anywhere else.
+func TestPlpgsqlEmbeddedQueryFormatted(t *testing.T) {
+	src := `create function f() returns void language plpgsql as $$
+begin
+perform (with payload(a, b) as (select NEW.x, NEW.y from t where t.id = NEW.id) select count(*) from payload);
+end;
+$$;`
+	got := plFmt(t, src)
+	if !strings.Contains(got, "perform (") {
+		t.Errorf("PERFORM keyword lost:\n%s", got)
+	}
+	if !strings.Contains(got, "\n           select ") && !strings.Contains(got, "\n     select ") {
+		t.Errorf("embedded query not formatted:\n%s", got)
+	}
+	for _, l := range strings.Split(got, "\n") {
+		if len(l) > 120 {
+			t.Errorf("line over 120 columns:\n%s", l)
+		}
+	}
+}
+
+// TestPlpgsqlUnbalancedLeftAlone: a body whose skeleton does not balance is
+// not something this recogniser understands, and is preserved exactly.
+func TestPlpgsqlUnbalancedLeftAlone(t *testing.T) {
+	body := "\nbegin\n  if x then\n    null;\n"
+	src := "create function f() returns void language plpgsql as $$" + body + "$$;"
+	got := plFmt(t, src)
+	if !strings.Contains(got, body) {
+		t.Errorf("unbalanced body was rewritten:\n%s", got)
+	}
+}
+
+// TestPlpgsqlNestedDollarQuoteOpaque: an inner dollar-quoted string must be
+// copied whole, not scanned for statement terminators.
+func TestPlpgsqlNestedDollarQuoteOpaque(t *testing.T) {
+	src := `create function f() returns void language plpgsql as $outer$
+begin
+execute $inner$ select 1; select 2; $inner$;
+end;
+$outer$;`
+	got := plFmt(t, src)
+	if !strings.Contains(got, "$inner$ select 1; select 2; $inner$") {
+		t.Errorf("nested dollar quote was taken apart:\n%s", got)
+	}
+}
+
+// TestPlpgsqlLoop covers the other block opener that ends on a keyword
+// rather than a semicolon.
+func TestPlpgsqlLoop(t *testing.T) {
+	src := `create function f() returns void language plpgsql as $$
+begin
+for r in select id from t loop
+update u set n = n + 1 where id = r.id;
+end loop;
+end;
+$$;`
+	got := plFmt(t, src)
+	if !strings.Contains(got, "\n  for r in select id from t loop\n") {
+		t.Errorf("FOR ... LOOP header not its own line:\n%s", got)
+	}
+	if !strings.Contains(got, "\n    update u set n = n + 1 where id = r.id;\n") {
+		t.Errorf("loop body not indented:\n%s", got)
+	}
+}
+
+func TestPlpgsqlIdempotent(t *testing.T) {
+	for _, src := range []string{plFn} {
+		once := plFmt(t, src)
+		if twice := plFmt(t, once); once != twice {
+			t.Errorf("not idempotent:\nfirst:\n%s\nsecond:\n%s", once, twice)
+		}
+	}
+}
+
+// TestOtherLanguagesUntouched: plpython and friends are opaque and must be
+// preserved exactly.
+func TestOtherLanguagesUntouched(t *testing.T) {
+	body := "\nif x:\n    return 1\nreturn 0\n"
+	got := plFmt(t, "create function f() returns int language plpython3u as $$"+body+"$$;")
+	if !strings.Contains(got, body) {
+		t.Errorf("plpython body was altered:\n%s", got)
+	}
+}

--- a/format/plpgsql_test.go
+++ b/format/plpgsql_test.go
@@ -143,3 +143,28 @@ func TestOtherLanguagesUntouched(t *testing.T) {
 		t.Errorf("plpython body was altered:\n%s", got)
 	}
 }
+
+// The formatter's output is itself valid input, so any layout decision
+// that reads the input's own line structure has to be stable. A blank
+// line after every comment in a PL/pgSQL body was not: each reformat
+// added another one, growing the file by a line per comment per pass,
+// without limit.
+func TestPlpgsqlCommentBlockIsStable(t *testing.T) {
+	src := "create function f() returns trigger as $$\nbegin\n" +
+		"  --\n  -- first line of the note\n  -- second line of the note\n  --\n" +
+		"  NEW.x := 1;\n  return NEW;\nend;\n$$ language plpgsql;\n"
+	one := mustFormat(t, src)
+	two := mustFormat(t, one)
+	if one != two {
+		t.Errorf("not idempotent:\n--- pass 1 ---\n%s\n--- pass 2 ---\n%s", one, two)
+	}
+	if strings.Contains(one, "-- first line of the note\n\n") {
+		t.Errorf("blank line inserted inside a comment block:\n%s", one)
+	}
+	// A real blank line between paragraphs is still kept.
+	sep := mustFormat(t, "create function f() returns trigger as $$\nbegin\n"+
+		"  -- one\n\n  -- two\n  NEW.x := 1;\n  return NEW;\nend;\n$$ language plpgsql;\n")
+	if !strings.Contains(sep, "-- one\n\n") {
+		t.Errorf("paragraph break lost:\n%s", sep)
+	}
+}

--- a/format/width.go
+++ b/format/width.go
@@ -1,0 +1,16 @@
+package format
+
+import "unicode/utf8"
+
+// cols is the display width of s in columns, which is what targetWidth
+// and every column measure in the layout are expressed in. len() is a byte
+// count, and the two part company the moment a line carries anything
+// outside ASCII: a box-drawing rule of 66 characters measures 198 bytes,
+// so a comment well inside the margin was wrapped as if it were far past
+// it, and an accented identifier pulled its line's break several columns
+// early.
+//
+// Counting runes rather than grapheme clusters or East Asian widths is
+// deliberate: the corpus is Latin text with the occasional box-drawing
+// character, where one rune is one column.
+func cols(s string) int { return utf8.RuneCountInString(s) }

--- a/go.mod
+++ b/go.mod
@@ -3,5 +3,3 @@ module github.com/dimitri/sqlfmt
 go 1.26.5
 
 require github.com/pmezard/go-difflib v1.0.0
-
-replace github.com/dimitri/sqlfmt => /Users/dim/dev/PostgreSQL/sqlfmt

--- a/go.mod
+++ b/go.mod
@@ -3,3 +3,5 @@ module github.com/dimitri/sqlfmt
 go 1.26.5
 
 require github.com/pmezard/go-difflib v1.0.0
+
+replace github.com/dimitri/sqlfmt => /Users/dim/dev/PostgreSQL/sqlfmt

--- a/testdata/corpus/dml-02_01.sql
+++ b/testdata/corpus/dml-02_01.sql
@@ -1,4 +1,5 @@
 select users.userid as follower, users.uname, f.userid as following, f.uname
   from tweet.users
-  join tweet.users f on f.uname = substring(users.bio from 'in love with #?(.*).')
+  join tweet.users f
+    on f.uname = substring(users.bio from 'in love with #?(.*).')
  where users.bio ~ 'in love with';

--- a/testdata/corpus/hstore-04_01_artists.update.hstore.sql
+++ b/testdata/corpus/hstore-04_01_artists.update.hstore.sql
@@ -6,10 +6,15 @@ create temp table batch(like moma.artist including all) on commit drop;
 
 with upd as (
        update moma.artist
-          set (name, bio, nationality, gender, begin, "end", wiki_qid, ulan) = (batch.name, batch.bio, batch.nationality, batch.gender, batch.begin, batch."end", batch.wiki_qid, batch.ulan)
+          set (name, bio, nationality, gender, begin, "end", wiki_qid, ulan)
+            = (batch.name, batch.bio, batch.nationality, batch.gender,
+               batch.begin, batch."end", batch.wiki_qid, batch.ulan)
          from batch
         where batch.constituentid = artist.constituentid
-          and (artist.name, artist.bio, artist.nationality, artist.gender, artist.begin, artist."end", artist.wiki_qid, artist.ulan) <> (batch.name, batch.bio, batch.nationality, batch.gender, batch.begin, batch."end", batch.wiki_qid, batch.ulan)
+          and (artist.name, artist.bio, artist.nationality, artist.gender,
+               artist.begin, artist."end", artist.wiki_qid, artist.ulan)
+           <> (batch.name, batch.bio, batch.nationality, batch.gender,
+               batch.begin, batch."end", batch.wiki_qid, batch.ulan)
     returning artist.constituentid
 ),
 ins as (

--- a/testdata/corpus/intarray-tags-02_04.sql
+++ b/testdata/corpus/intarray-tags-02_04.sql
@@ -6,9 +6,9 @@ with t(query) as (
 )
   select track.tid,
          left(track.artist, 26)
-         || case when length(track.artist) > 26 then '…' else '' end as artist,
+      || case when length(track.artist) > 26 then '…' else '' end as artist,
          left(track.title, 26)
-         || case when length(track.title) > 26 then '…' else '' end as title
+      || case when length(track.title) > 26 then '…' else '' end as title
     from track_tags tt
     join tids on tt.tid = tids.rowid
     join t on tt.tags @@ t.query

--- a/testdata/corpus/intarray-tags-02_04.sql
+++ b/testdata/corpus/intarray-tags-02_04.sql
@@ -5,16 +5,10 @@ with t(query) as (
         or tag = 'rhythm and blues'
 )
   select track.tid,
-         left(track.artist, 26) || case
-                                        when length(track.artist) > 26
-                                        then '…'
-                                        else ''
-                                   end as artist,
-         left(track.title, 26) || case
-                                       when length(track.title) > 26
-                                       then '…'
-                                       else ''
-                                  end as title
+         left(track.artist, 26)
+         || case when length(track.artist) > 26 then '…' else '' end as artist,
+         left(track.title, 26)
+         || case when length(track.title) > 26 then '…' else '' end as title
     from track_tags tt
     join tids on tt.tid = tids.rowid
     join t on tt.tags @@ t.query

--- a/testdata/corpus/listen-notify-02_01_dream-notify-counter.sql
+++ b/testdata/corpus/listen-notify-02_01_dream-notify-counter.sql
@@ -1,6 +1,9 @@
 begin;
 
-create or replace function twcache.tg_notify_counters() returns trigger language plpgsql as $$
+create or replace function twcache.tg_notify_counters()
+ returns trigger
+language plpgsql
+      as $$
 declare
   channel text := TG_ARGV[0];
 begin
@@ -30,6 +33,10 @@ begin
 end;
 $$;
 
-create TRIGGER notify_counters AFTER insert on tweet.activity for EACH row EXECUTE PROCEDURE twcache.tg_notify_counters('tweet.activity');
+create trigger notify_counters
+  after insert
+     on tweet.activity
+    for each row
+execute procedure twcache.tg_notify_counters('tweet.activity');
 
 commit;

--- a/testdata/corpus/pg-data-types-101-06_02.sql
+++ b/testdata/corpus/pg-data-types-101-06_02.sql
@@ -1,8 +1,8 @@
-create SEQUENCE tablename_colname_seq;
+create sequence tablename_colname_seq;
 
 create table tablename
  (
   colname integer not null default nextval('tablename_colname_seq')
 );
 
-alter SEQUENCE tablename_colname_seq OWNED by tablename.colname;
+alter sequence tablename_colname_seq OWNED by tablename.colname;

--- a/testdata/corpus/pub-names-knn-05_01_pubnames.svg.knn.sql
+++ b/testdata/corpus/pub-names-knn-05_01_pubnames.svg.knn.sql
@@ -40,11 +40,17 @@ roads as (
 ),
 layers as (
     select 1 as z,
-           '<path d="' || st_assvg(geom, 0, 1) || '" fill="none" stroke="#C0B8AE" stroke-width="2"/>' as elem
+           '<path d="'
+           || st_assvg(geom, 0, 1)
+           || '" fill="none" stroke="#C0B8AE" stroke-width="2"/>' as elem
       from roads
     union all
     select 2,
-           '<circle cx="' || (((pt)[0] - proj.x0) * proj.scale)::text || '" cy="' || (-(((pt)[1] - proj.y0) * proj.scale))::text || '" r="9" fill="#B04020" stroke="#F2EFE9" stroke-width="2"/>' as elem
+           '<circle cx="'
+           || (((pt)[0] - proj.x0) * proj.scale)::text
+           || '" cy="'
+           || (-(((pt)[1] - proj.y0) * proj.scale))::text
+           || '" r="9" fill="#B04020" stroke="#F2EFE9" stroke-width="2"/>' as elem
       from search, proj
     union all
     select 3,
@@ -53,6 +59,21 @@ layers as (
     case when rn % 2 = 0 then 9 else -4 end))::text || '" font-size="13" fill="#2C2820">' || replace(replace(name, '&', '&amp;'), '<', '&lt;') || '</text>' as elem
       from nearest, proj
 )
-  select '<svg viewBox="0 ' || (-((proj.y1 - proj.y0) * proj.scale)) || ' ' || ((proj.x1 - proj.x0) * proj.scale) || ' ' || ((proj.y1 - proj.y0) * proj.scale) || '" xmlns="http://www.w3.org/2000/svg">' || '<rect x="0" y="' || (-((proj.y1 - proj.y0) * proj.scale)) || '" width="' || ((proj.x1 - proj.x0) * proj.scale) || '" height="' || ((proj.y1 - proj.y0) * proj.scale) || '" fill="#F2EFE9"/>' || string_agg(layers.elem, '' order by layers.z) || '</svg>' as svg
+  select '<svg viewBox="0 '
+         || (-((proj.y1 - proj.y0) * proj.scale))
+         || ' '
+         || ((proj.x1 - proj.x0) * proj.scale)
+         || ' '
+         || ((proj.y1 - proj.y0) * proj.scale)
+         || '" xmlns="http://www.w3.org/2000/svg">'
+         || '<rect x="0" y="'
+         || (-((proj.y1 - proj.y0) * proj.scale))
+         || '" width="'
+         || ((proj.x1 - proj.x0) * proj.scale)
+         || '" height="'
+         || ((proj.y1 - proj.y0) * proj.scale)
+         || '" fill="#F2EFE9"/>'
+         || string_agg(layers.elem, '' order by layers.z)
+         || '</svg>' as svg
     from layers, proj
 group by proj.x0, proj.y0, proj.x1, proj.y1, proj.scale;

--- a/testdata/corpus/pub-names-knn-05_01_pubnames.svg.knn.sql
+++ b/testdata/corpus/pub-names-knn-05_01_pubnames.svg.knn.sql
@@ -34,7 +34,10 @@ win as (
   select st_makeenvelope(x0, y0, x1, y1, 4326) as env from bbox
 ),
 roads as (
-    select st_transscale(st_intersection(r.geom, win.env), -proj.x0, -proj.y0, proj.scale, proj.scale) as geom
+    select st_transscale(
+             st_intersection(r.geom, win.env), -proj.x0, -proj.y0, proj.scale,
+             proj.scale
+           ) as geom
       from osm_london.roads r, win, proj
      where st_intersects(r.geom, win.env)
 ),
@@ -54,9 +57,18 @@ layers as (
       from search, proj
     union all
     select 3,
-           '<circle cx="' || (((pos)[0] - proj.x0) * proj.scale)::text || '" cy="' || (-(((pos)[1] - proj.y0) * proj.scale))::text || '" r="6" fill="#5B8DB8" stroke="#F2EFE9" stroke-width="1.5"/>' || '<text x="' || (((pos)[0] - proj.x0) * proj.scale + 9)::text || '" y="' || (
-    -(((pos)[1] - proj.y0) * proj.scale) + (
-    case when rn % 2 = 0 then 9 else -4 end))::text || '" font-size="13" fill="#2C2820">' || replace(replace(name, '&', '&amp;'), '<', '&lt;') || '</text>' as elem
+           '<circle cx="'
+           || (((pos)[0] - proj.x0) * proj.scale)::text
+           || '" cy="'
+           || (-(((pos)[1] - proj.y0) * proj.scale))::text
+           || '" r="6" fill="#5B8DB8" stroke="#F2EFE9" stroke-width="1.5"/>'
+           || '<text x="'
+           || (((pos)[0] - proj.x0) * proj.scale + 9)::text
+           || '" y="'
+           || (-(((pos)[1] - proj.y0) * proj.scale) + (case when rn % 2 = 0 then 9 else -4 end))::text
+           || '" font-size="13" fill="#2C2820">'
+           || replace(replace(name, '&', '&amp;'), '<', '&lt;')
+           || '</text>' as elem
       from nearest, proj
 )
   select '<svg viewBox="0 '

--- a/testdata/corpus/pub-names-knn-05_01_pubnames.svg.knn.sql
+++ b/testdata/corpus/pub-names-knn-05_01_pubnames.svg.knn.sql
@@ -44,48 +44,48 @@ roads as (
 layers as (
     select 1 as z,
            '<path d="'
-           || st_assvg(geom, 0, 1)
-           || '" fill="none" stroke="#C0B8AE" stroke-width="2"/>' as elem
+        || st_assvg(geom, 0, 1)
+        || '" fill="none" stroke="#C0B8AE" stroke-width="2"/>' as elem
       from roads
     union all
     select 2,
            '<circle cx="'
-           || (((pt)[0] - proj.x0) * proj.scale)::text
-           || '" cy="'
-           || (-(((pt)[1] - proj.y0) * proj.scale))::text
-           || '" r="9" fill="#B04020" stroke="#F2EFE9" stroke-width="2"/>' as elem
+        || (((pt)[0] - proj.x0) * proj.scale)::text
+        || '" cy="'
+        || (-(((pt)[1] - proj.y0) * proj.scale))::text
+        || '" r="9" fill="#B04020" stroke="#F2EFE9" stroke-width="2"/>' as elem
       from search, proj
     union all
     select 3,
            '<circle cx="'
-           || (((pos)[0] - proj.x0) * proj.scale)::text
-           || '" cy="'
-           || (-(((pos)[1] - proj.y0) * proj.scale))::text
-           || '" r="6" fill="#5B8DB8" stroke="#F2EFE9" stroke-width="1.5"/>'
-           || '<text x="'
-           || (((pos)[0] - proj.x0) * proj.scale + 9)::text
-           || '" y="'
-           || (-(((pos)[1] - proj.y0) * proj.scale) + (case when rn % 2 = 0 then 9 else -4 end))::text
-           || '" font-size="13" fill="#2C2820">'
-           || replace(replace(name, '&', '&amp;'), '<', '&lt;')
-           || '</text>' as elem
+        || (((pos)[0] - proj.x0) * proj.scale)::text
+        || '" cy="'
+        || (-(((pos)[1] - proj.y0) * proj.scale))::text
+        || '" r="6" fill="#5B8DB8" stroke="#F2EFE9" stroke-width="1.5"/>'
+        || '<text x="'
+        || (((pos)[0] - proj.x0) * proj.scale + 9)::text
+        || '" y="'
+        || (-(((pos)[1] - proj.y0) * proj.scale) + (case when rn % 2 = 0 then 9 else -4 end))::text
+        || '" font-size="13" fill="#2C2820">'
+        || replace(replace(name, '&', '&amp;'), '<', '&lt;')
+        || '</text>' as elem
       from nearest, proj
 )
   select '<svg viewBox="0 '
-         || (-((proj.y1 - proj.y0) * proj.scale))
-         || ' '
-         || ((proj.x1 - proj.x0) * proj.scale)
-         || ' '
-         || ((proj.y1 - proj.y0) * proj.scale)
-         || '" xmlns="http://www.w3.org/2000/svg">'
-         || '<rect x="0" y="'
-         || (-((proj.y1 - proj.y0) * proj.scale))
-         || '" width="'
-         || ((proj.x1 - proj.x0) * proj.scale)
-         || '" height="'
-         || ((proj.y1 - proj.y0) * proj.scale)
-         || '" fill="#F2EFE9"/>'
-         || string_agg(layers.elem, '' order by layers.z)
-         || '</svg>' as svg
+      || (-((proj.y1 - proj.y0) * proj.scale))
+      || ' '
+      || ((proj.x1 - proj.x0) * proj.scale)
+      || ' '
+      || ((proj.y1 - proj.y0) * proj.scale)
+      || '" xmlns="http://www.w3.org/2000/svg">'
+      || '<rect x="0" y="'
+      || (-((proj.y1 - proj.y0) * proj.scale))
+      || '" width="'
+      || ((proj.x1 - proj.x0) * proj.scale)
+      || '" height="'
+      || ((proj.y1 - proj.y0) * proj.scale)
+      || '" fill="#F2EFE9"/>'
+      || string_agg(layers.elem, '' order by layers.z)
+      || '</svg>' as svg
     from layers, proj
 group by proj.x0, proj.y0, proj.x1, proj.y1, proj.scale;

--- a/testdata/corpus/sql-102-03_01_f1db.decade.top3.sql
+++ b/testdata/corpus/sql-102-03_01_f1db.decade.top3.sql
@@ -16,7 +16,8 @@ with decades as (
         on results.driverid = drivers.driverid
        and results.position = 1
       join races using(raceid)
-     where extract('year' from date_trunc('decade', races.date)) = decades.decade
+     where extract('year' from date_trunc('decade', races.date))
+         = decades.decade
   group by decades.decade, drivers.driverid
   order by wins desc
      limit 3

--- a/testdata/corpus/sql-102-03_01_f1db.decade.top3.sql
+++ b/testdata/corpus/sql-102-03_01_f1db.decade.top3.sql
@@ -9,5 +9,17 @@ with decades as (
                     surname,
                     wins
                from decades
-  left join lateral (       select code, forename, surname, count(*) as wins       from drivers       join results         on results.driverid = drivers.driverid        and results.position = 1       join races using(raceid)      where extract('year' from date_trunc('decade', races.date)) = decades.decade   group by decades.decade, drivers.driverid   order by wins desc      limit 3 ) as winners on true
+  left join lateral (
+      select code, forename, surname, count(*) as wins
+      from drivers
+      join results
+        on results.driverid = drivers.driverid
+       and results.position = 1
+      join races using(raceid)
+     where extract('year' from date_trunc('decade', races.date)) = decades.decade
+  group by decades.decade, drivers.driverid
+  order by wins desc
+     limit 3
+) as winners
+                 on true
            order by decade asc, wins desc;

--- a/testdata/corpus/sql-102-03_01_f1db.decade.top3.sql
+++ b/testdata/corpus/sql-102-03_01_f1db.decade.top3.sql
@@ -4,7 +4,10 @@ with decades as (
     group by decade
 )
              select decade,
-                    rank() over(partition by decade order by wins desc) as rank,
+                    rank() over(
+                                partition by decade
+                                order by wins desc
+                           ) as rank,
                     forename,
                     surname,
                     wins

--- a/testdata/corpus/sql-103-05_03_f1db.seasons.winners.sql
+++ b/testdata/corpus/sql-103-05_03_f1db.seasons.winners.sql
@@ -31,7 +31,9 @@ champs as (
        and champ_constructor.points = tops.ctops
 )
   select season,
-         format('%s %s', drivers.forename, drivers.surname) as "Driver's Champion",
+         format(
+           '%s %s', drivers.forename, drivers.surname
+         ) as "Driver's Champion",
          constructors.name as "Constructor's champion"
     from champs
     join drivers using(driverid)

--- a/testdata/corpus/triggers-01_01_dream-trigger-daily.sql
+++ b/testdata/corpus/triggers-01_01_dream-trigger-daily.sql
@@ -15,41 +15,24 @@ language plpgsql
       as $$
 declare
 begin
-      update twcache.daily_counters
-         set rts = case when NEW.action = 'rt'
-                        then rts + 1
-                        else rts
-                    end,
-             de_rts = case when NEW.action = 'de-rt'
-                        then de_rts + 1
-                        else de_rts
-                    end,
-             favs = case when NEW.action = 'fav'
-                         then favs + 1
-                         else favs
-                     end,
-             de_favs = case when NEW.action = 'de-fav'
-                         then de_favs + 1
-                         else de_favs
-                     end
-       where daily_counters.day = current_date;
+  update twcache.daily_counters
+     set rts = case when NEW.action = 'rt' then rts + 1 else rts end,
+         de_rts = case when NEW.action = 'de-rt' then de_rts + 1 else de_rts end,
+         favs = case when NEW.action = 'fav' then favs + 1 else favs end,
+         de_favs = case
+                        when NEW.action = 'de-fav'
+                        then de_favs + 1
+                        else de_favs
+                   end
+   where daily_counters.day = current_date;
 
-  if NOT FOUND
-  then
-      insert into twcache.daily_counters(day, rts, de_rts, favs, de_favs)
-           select current_date,
-                  case when NEW.action = 'rt'
-                       then 1 else 0
-                    end,
-                  case when NEW.action = 'de-rt'
-                       then 1 else 0
-                   end,
-                  case when NEW.action = 'fav'
-                       then 1 else 0
-                   end,
-                  case when NEW.action = 'de-fav'
-                       then 1 else 0
-                   end;
+  if NOT FOUND then
+    insert into twcache.daily_counters(day, rts, de_rts, favs, de_favs)
+         select current_date,
+                case when NEW.action = 'rt' then 1 else 0 end,
+                case when NEW.action = 'de-rt' then 1 else 0 end,
+                case when NEW.action = 'fav' then 1 else 0 end,
+                case when NEW.action = 'de-fav' then 1 else 0 end;
   end if;
 
   RETURN NULL;

--- a/testdata/corpus/triggers-01_01_dream-trigger-daily.sql
+++ b/testdata/corpus/triggers-01_01_dream-trigger-daily.sql
@@ -9,7 +9,10 @@ create table twcache.daily_counters
   de_favs bigint
 );
 
-create or replace function twcache.tg_update_daily_counters() returns trigger language plpgsql as $$
+create or replace function twcache.tg_update_daily_counters()
+ returns trigger
+language plpgsql
+      as $$
 declare
 begin
       update twcache.daily_counters
@@ -53,7 +56,11 @@ begin
 end;
 $$;
 
-create TRIGGER update_daily_counters AFTER insert on tweet.activity for EACH row EXECUTE PROCEDURE twcache.tg_update_daily_counters();
+create trigger update_daily_counters
+  after insert
+     on tweet.activity
+    for each row
+execute procedure twcache.tg_update_daily_counters();
 
 insert into tweet.activity(messageid, action)
      values (7, 'rt'),

--- a/testdata/corpus/usecase-06_01.sql
+++ b/testdata/corpus/usecase-06_01.sql
@@ -1,1 +1,6 @@
-prepare foo as select date, shares, trades, dollars from factbook where date >= $1::date and date < $1::date + interval '1 month' order by date;
+prepare foo as
+   select date, shares, trades, dollars
+     from factbook
+    where date >= $1::date
+      and date < $1::date + interval '1 month'
+ order by date;

--- a/testdata/corpus/usecase-07_01.sql
+++ b/testdata/corpus/usecase-07_01.sql
@@ -9,6 +9,10 @@
              * against the factbook dataset, so as to have every day in the
              * result set, whether or not we have a book entry for the day.
              */
-       from generate_series(date : 'start', date : 'start' + interval '1 month' - interval '1 day', interval '1 day') as calendar(entry)
+       from generate_series(
+              date : 'start',
+              date : 'start' + interval '1 month' - interval '1 day',
+              interval '1 day'
+            ) as calendar(entry)
   left join factbook on factbook.date = calendar.entry
    order by date;

--- a/testdata/corpus/window-functions-01_02.sql
+++ b/testdata/corpus/window-functions-01_02.sql
@@ -1,5 +1,6 @@
 select x,
        array_agg(x) over(
-                         order by x rows between unbounded preceding and current row
+                         order by x
+                         rows between unbounded preceding and current row
                     )
   from generate_series(1, 3) as t(x);

--- a/testdata/corpus/window-functions-02_01.sql
+++ b/testdata/corpus/window-functions-02_01.sql
@@ -2,10 +2,10 @@
          constructors.name,
          position,
          format(
-  '%s / %s', row_number() over(
-                               partition by constructorid
-                               order by position nulls last
-                          ), count(*) over(partition by constructorid)) as "pos same constr"
+           '%s / %s',
+           row_number() over(partition by constructorid order by position nulls last),
+           count(*) over(partition by constructorid)
+         ) as "pos same constr"
     from results
     join drivers using(driverid)
     join constructors using(constructorid)

--- a/testdata/corpus/window-functions-02_01.sql
+++ b/testdata/corpus/window-functions-02_01.sql
@@ -2,7 +2,9 @@
          constructors.name,
          position,
          format(
-  '%s / %s', row_number() over(partition by constructorid order by position nulls last
+  '%s / %s', row_number() over(
+                               partition by constructorid
+                               order by position nulls last
                           ), count(*) over(partition by constructorid)) as "pos same constr"
     from results
     join drivers using(driverid)

--- a/testdata/corpus/window-functions-02_01.sql
+++ b/testdata/corpus/window-functions-02_01.sql
@@ -3,7 +3,10 @@
          position,
          format(
            '%s / %s',
-           row_number() over(partition by constructorid order by position nulls last),
+           row_number() over(
+                             partition by constructorid
+                             order by position nulls last
+                        ),
            count(*) over(partition by constructorid)
          ) as "pos same constr"
     from results


### PR DESCRIPTION
Running the formatter over the SQL in TheArtOfPostgreSQL and app.taop.xyz — 1400 files — with a guard that compares each reformatted file token-for-token against its input turned up a family of bugs with one shape: **the formatter reaches a construct it does not model, and silently drops the tokens it cannot place.** Exit status 0, valid-looking output, missing SQL.

Fixing those exposed a second, structural problem: the greedy line-filler decided each break where it stood, with no knowledge of what came after, so expression layout could not be fixed by patching cases. That is now a Wadler/Lindig pretty printer.

| Measured over 1400 files | before | after |
|---|---|---|
| Files with content loss | 14 | **0** |
| Files whose output exceeds the margin | 194 | **24** |
| Over-long lines | 829 | **547** |

`go test ./...` green; `go vet` clean.

---

## 1. Content loss

Nine constructs where tokens went missing. Each has a regression test.

| Construct | What was lost |
|---|---|
| Simple `CASE` that has to wrap | the whole body — operand, `WHEN`/`THEN`, `ELSE` |
| `WITH … AS [NOT] MATERIALIZED` | the CTE body |
| A recursive CTE's `SEARCH`/`CYCLE` | reparsed as part of the main query |
| `CREATE TABLE`'s tail | `PARTITION BY`, `INHERITS`, `TABLESPACE` |
| `CREATE VIEW` | its entire query (1344 chars → 355) |
| `MERGE`'s `insert (cols)` | the column list |
| Non-ASCII identifiers | every byte spelled out separately |
| `--` comments | swallowed the code after them, or vanished |
| Nested block comments | reflowed into a different comment |

Two deserve detail because they corrupt *ordinary* SQL, not exotic input:

**Non-ASCII was scanned one byte at a time.** PostgreSQL puts the whole high-byte range in its identifier classes (`scan.l`: `ident_start [A-Za-z\200-\377_]`), so an accented identifier is one token:

```
select prénom from personne   →   select pr Ã © nom from personne
```

**A `--` comment has no valid one-line rendering** — anything placed after it on that line ends up inside it. `renderRun` broke the line for exactly that reason, but `flatJoin` joined its lines back with a space:

```sql
select a, -- pick a          select a,  -- pick a  b
       b               →       from t;              ← "b" is now a comment
  from t;
```

Four distinct paths could lose a comment: that one, a span `renderRun` skipped over (a `CASE`, an `OVER(…)`, a paren group), a comment on a separating comma (which belongs to no list item), and `CREATE TABLE` appending the column comma *after* the comment, producing a syntax error.

## 2. Expression layout: a pretty printer

Three greedy attempts at call-argument wrapping each improved some files and regressed others, because the decisions interact: whether to break a call's arguments depends on whether the enclosing comparison breaks, which depends on whether the call broke.

`format/doc.go` is the standard IR — `Text`, `Line`, `Soft`, `Hard`, `Group`, `Nest`, `Concat`, `Fill`, `Defer` — with a renderer that decides a whole `Group` at once, outermost first. Three things were needed to make it fit an existing hand-written layout rather than replace it:

- **`Fill` vs `Group`.** A `||` chain's parts are whole clauses of a template and the author writes them one per line (`Group`); five call arguments on five lines is not what the corpus does (`Fill`).
- **`Defer`** wraps a sub-expression the clause layer already handles — a `CASE`, an `OVER(…)` — as a *function of the column it lands at*. Without it the Doc layer had to decline any run containing one, which meant declining precisely the TikZ-generating calls that needed it most.
- **Continuation-aware `fits`.** Wadler's `fits` measures the flattened group *together with what follows it*; measuring the group alone let the text after it push the line over. `headWidth` measures a following sibling only up to its first break opportunity, which keeps the measure a lower bound — so it can only turn a flat group broken, never the reverse.

## 3. Layouts added

`MERGE`, PL/pgSQL bodies, `LANGUAGE SQL` bodies, DDL headers, parenthesized set-operation arms, `ALTER TABLE`, `GRANT`/`REVOKE`, `CREATE DATABASE`, `ALTER DEFAULT PRIVILEGES`, partition definitions, `PREPARE`, and typed tables (`create table x of t (…)`).

New break points in expressions: top-level binary operators by precedence, JSON/containment operators, `BETWEEN`, adjacent string literals (implicit concatenation), trailing casts, table aliases carrying a column list (`as t(col)`), and a trailing `OVER`.

Three alignment decisions, now STYLE.md rules 20–22:

```sql
-- 20: operator hangs left, operands aligned      -- 21: aggregate/suffix river
select a_long_column_name                                 count(*)
    || '--------------------------'                      filter(where x is null) as dnfs,
    || b_long_column                                 percentile_cont(array[0.5, 0.99])
                                                       within group (order by d) as parr
```

Comparison operators are break points in a *condition* but not in a *value*: an `UPDATE`'s `set x = case … end` is an assignment, and breaking at its `=` gives the column a line of its own. The two are indistinguishable from the tokens alone, so the clause layer — which knows which clause it is in — chooses the operator set.

## 4. Lexer

- Bytes ≥ 0x80 are identifier characters, per `scan.l` (also for dollar-quote tags).
- `E'…'`, `B'…'`, `X'…'`, `U&'…'` lex as one token — `scan.l:257` requires the prefix be adjacent to the quote. (`SELECT E '\n'` with a space *parses*, as `typename 'literal'`, and fails at type resolution — a semantic change, not a syntax error, and one the whitespace-insensitive guard cannot catch.)
- Dollar-quote matching, shared by SQL and PL/pgSQL.
- `filter`, `within`, `prepare`, `deallocate` and the `ALTER`/`GRANT`/`CREATE DATABASE` vocabulary are keywords. This is not cosmetic: with only half of each pair in the table, rule 1 lowercased half a construct — `ALTER TABLE t ATTACH PARTITION p` came back as `attach partition` spelled `ATTACH partition`, and `WITHIN GROUP` as `WITHIN group`.

## 5. Widths are counted in columns, not bytes

`len()` is a byte count. A 66-character box-drawing rule measured 198, so a comment well inside the margin was re-wrapped as if far past it, and an accented identifier pulled its line's break several columns early.

---

## Review notes

- **Output is stable under a second pass** for 1399 of 1400 corpus files. The formatter's own output is valid input, so this matters: one bug found this way had a PL/pgSQL body growing by a line per comment on *every* reformat, without limit. The remaining file converges on pass 2 rather than growing.
- **26 commits, each self-contained** with its own measurement; the history is meant to be read in order.
- **13 corpus fixtures were regenerated.** Every one is a case where the tool now breaks a line it previously left over the margin, or applies an alignment this PR introduces. None is a content change.
- `targetWidth` is 78; the "over the margin" figures above count lines over 80, so they are slightly conservative.
- The remaining 24 files are mostly not fixable by a formatter: psql session transcripts stored as `.sql`, comment prose, single string literals wider than the margin, and the deliberate `set x = case … end`.
