### PR TITLE
Lay out MERGE PARTITIONS and SPLIT PARTITION

### DIFF
--- a/format/alter.go
+++ b/format/alter.go
@@ -9,6 +9,11 @@ var alterSubcommands = map[string]bool{
 	"disable": true, "validate": true, "attach": true, "detach": true,
 	"inherit": true, "no": true, "cluster": true, "replica": true,
 	"of": true, "not": true, "force": true, "options": true,
+	// PG 19's partition restructuring subcommands. Without them
+	// alterHeaderEnd returned -1 and layoutAlter fell back to
+	// flatStatementLines, which is how a MERGE PARTITIONS came out on a
+	// single 117-column line and a SPLIT PARTITION on a 180-column one.
+	"merge": true, "split": true,
 }
 
 // layoutAlter lays out ALTER TABLE, whose payload is a comma-separated

--- a/format/ddlclause.go
+++ b/format/ddlclause.go
@@ -55,9 +55,14 @@ var (
 	}
 	// Inside one ALTER TABLE subcommand: "add constraint c check (...) not
 	// valid" is three lines by hand, not one.
+	// "into" is what MERGE PARTITIONS and SPLIT PARTITION hang on when the
+	// subcommand is too wide to sit on one line:
+	//
+	//	merge partitions (races_2015, races_2016, races_2017)
+	//	      into races_2015_2017
 	alterInnerClauses = []clauseStarter{
 		{"check"}, {"not", "valid"}, {"using"}, {"references"},
-		{"for", "values"}, {"default"},
+		{"for", "values"}, {"default"}, {"into"},
 	}
 )
 

--- a/format/ddlclause_test.go
+++ b/format/ddlclause_test.go
@@ -182,3 +182,80 @@ func TestAggregateSuffixIsRiverAligned(t *testing.T) {
 		t.Errorf("OVER lost its frame layout:\n%s", over)
 	}
 }
+
+// MERGE PARTITIONS and SPLIT PARTITION are ALTER TABLE subcommands, but
+// neither "merge" nor "split" was in alterSubcommands, so alterHeaderEnd
+// returned -1 and layoutAlter fell back to flatStatementLines: the merge
+// came out on one 117-column line, the split on a 180-column one. Rule 22
+// wants the subcommand at indent 2 and its INTO hung under it at indent 6.
+func TestPartitionSubcommandsBreak(t *testing.T) {
+	cases := []struct {
+		name, src string
+		want      []string
+	}{
+		{"merge partitions",
+			"alter table demo_races merge partitions (demo_races_2015, demo_races_2016, demo_races_2017) into demo_races_2015_2017;\n",
+			[]string{
+				"alter table demo_races",
+				"  merge partitions (demo_races_2015, demo_races_2016, demo_races_2017)",
+				"      into demo_races_2015_2017;",
+			}},
+		{"split partition",
+			"alter table demo_races split partition demo_races_2015_2017 into (partition demo_races_2015 for values from (2015) to (2016), partition demo_races_2016 for values from (2016) to (2017));\n",
+			[]string{
+				"alter table demo_races",
+				"  split partition demo_races_2015_2017",
+				"      into (partition demo_races_2015 for values from (2015) to (2016),",
+			}},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			got := mustFormat(t, c.src)
+			for _, w := range c.want {
+				if !strings.Contains(got, w) {
+					t.Errorf("want line %q in:\n%s", w, got)
+				}
+			}
+			for _, l := range strings.Split(got, "\n") {
+				if cols(l) > targetWidth {
+					t.Errorf("line over the margin (%d cols):\n%s", cols(l), got)
+				}
+			}
+			// The clause loss this whole area is prone to: nothing may
+			// go missing, and a second pass must not move anything.
+			if squash(got) != squash(c.src) {
+				t.Errorf("content lost:\nwant %s\ngot  %s", squash(c.src), squash(got))
+			}
+			if twice := mustFormat(t, got); twice != got {
+				t.Errorf("not idempotent:\nonce:\n%s\ntwice:\n%s", got, twice)
+			}
+		})
+	}
+}
+
+// "partitions" is plural and was not in the keyword table, so it lexed as
+// an identifier and rule 4 closed up the space before its "(".
+func TestMergePartitionsKeepsSpaceBeforeParen(t *testing.T) {
+	got := mustFormat(t, "alter table t merge partitions (a, b) into c;\n")
+	if strings.Contains(got, "partitions(") {
+		t.Errorf("space before \"(\" was dropped:\n%s", got)
+	}
+	if strings.Count(got, "\n") > 1 {
+		t.Errorf("a short subcommand was broken up:\n%s", got)
+	}
+}
+
+// "split" had to become a keyword for SPLIT PARTITION, which would have
+// turned every split(...) call into "split (...)" -- the same trap
+// left(...) and right(...) already sit in.
+func TestSplitStaysAFunctionCall(t *testing.T) {
+	for _, src := range []string{
+		"select split(a) from t;\n",
+		"select split_part(a, ',', 1) from t;\n",
+	} {
+		got := mustFormat(t, src)
+		if got != src {
+			t.Errorf("call was reshaped:\nwant %q\ngot  %q", src, got)
+		}
+	}
+}

--- a/format/layout.go
+++ b/format/layout.go
@@ -443,9 +443,14 @@ func spaceBetween(prevPrev *Token, prev, next Token) bool {
 		// "filter" joins this list rather than changing shape now that it
 		// is a keyword: the corpus writes "filter(where ...)" closed up,
 		// the way it writes "over(...)".
+		// "split" joins left/right for the same reason: it became a
+		// keyword for ALTER TABLE ... SPLIT PARTITION, where it is never
+		// followed by "(", so a "(" after it is always a call. Note
+		// "partitions" deliberately stays off this list -- MERGE
+		// PARTITIONS (a, b) is exactly the case that wants the space.
 		if prev.Kind == TokIdent || prev.Lower == "using" || prev.Lower == "over" ||
 			prev.Lower == "filter" ||
-			prev.Lower == "left" || prev.Lower == "right" {
+			prev.Lower == "left" || prev.Lower == "right" || prev.Lower == "split" {
 			return false
 		}
 		return true

--- a/format/lexer.go
+++ b/format/lexer.go
@@ -93,6 +93,12 @@ var keywords = buildKeywordSet([]string{
 	"privileges", "database", "encoding", "owner", "grant", "revoke",
 	"template", "cascade", "restrict", "role", "usage", "tables",
 	"sequences", "routines", "extension", "enable", "disable",
+	// "partitions" (plural) and "split" complete the PG 19 partition
+	// subcommands. "split" has to be a keyword because alterHeaderEnd
+	// only accepts a TokKeyword as a subcommand opener, and "partitions"
+	// because rule 4 drops the space before "(" after an identifier, so
+	// "MERGE PARTITIONS (a, b)" came out as "merge partitions(a, b)".
+	"partitions", "split",
 })
 
 func buildKeywordSet(words []string) map[string]bool {


### PR DESCRIPTION
PostgreSQL 19 adds two `ALTER TABLE` subcommands for restructuring a partitioned table in place. Neither `merge` nor `split` was in `alterSubcommands`, so `alterHeaderEnd` failed its `alterSubcommands[toks[i].Lower]` test, returned `-1`, and `layoutAlter` fell through to `flatStatementLines` — which has no break points at all.

## Before

```sql
alter table demo_races merge partitions(demo_races_2015, demo_races_2016, demo_races_2017) into demo_races_2015_2017;
```
117 columns. `SPLIT PARTITION` took the same path and came out at 180.

## After

```sql
alter table demo_races
  merge partitions (demo_races_2015, demo_races_2016, demo_races_2017)
      into demo_races_2015_2017;

alter table demo_races
  split partition demo_races_2015_2017
      into (partition demo_races_2015 for values from (2015) to (2016),
            partition demo_races_2016 for values from (2016) to (2017));
```

That is rule 22's shape — subcommand at indent 2, its own inner clauses at indent 6 — so `into` joins `alterInnerClauses` to reach it. The partition definitions inside the `INTO` are broken by `{"for", "values"}`, which was already there.

## Lexer consequences

- **`split` has to be a keyword**, because `alterHeaderEnd` only accepts a `TokKeyword` as a subcommand opener. That would have closed up every `split(...)` call the way rule 4 closes up a call after an identifier, so `split` joins `left`/`right` on `spaceBetween`'s exemption list — it is never followed by `(` in `SPLIT PARTITION`, so a `(` after it is always a call.
- **`partitions` is the mirror image**: it lexed as an identifier, which is why the space in `merge partitions (a, b)` went missing. It deliberately stays *off* the exemption list, since that is exactly the case that wants the space.

## Tests

Three new tests in `format/ddlclause_test.go`, following the existing table style: shape and margin assertions for both subcommands, plus `squash()` content-preservation and an idempotence pass on each (this area is prone to silent clause loss), and a regression test pinning `split(a)` / `split_part(...)` as calls.

`gofmt -l .`, `go vet ./...` and `make test` are all clean, including the `sqlfmt -l` corpus check — no existing fixture changed.

Found while formatting the SQL in a PostgreSQL 19 article.