### PR TITLE
Keep DO SELECT inline, and stop FOR UPDATE starting a clause

### DIFF
--- a/format/ddlclause_test.go
+++ b/format/ddlclause_test.go
@@ -259,3 +259,55 @@ func TestSplitStaysAFunctionCall(t *testing.T) {
 		}
 	}
 }
+
+// PG 19's ON CONFLICT ... DO SELECT is a two-word conflict action like DO
+// NOTHING -- "DO SELECT [FOR ...] [WHERE ...]", with no select list, since
+// the projection is the INSERT's own (mandatory) RETURNING. "select" was a
+// clauseWords entry, so it became a river segment with an empty body and
+// pushed RETURNING under it.
+func TestOnConflictDoSelectStaysInline(t *testing.T) {
+	got := mustFormat(t, "insert into demo_driver_seen (driverid, surname) values (1, 'Hamilton') on conflict (driverid) do select returning driverid, surname, first_seen_at;\n")
+	for _, w := range []string{
+		"on conflict (driverid) do select\n",
+		"  returning driverid, surname, first_seen_at;",
+	} {
+		if !strings.Contains(got, w) {
+			t.Errorf("want %q in:\n%s", w, got)
+		}
+	}
+	if strings.Contains(got, "do\n") {
+		t.Errorf("DO SELECT was split across lines:\n%s", got)
+	}
+	if twice := mustFormat(t, got); twice != got {
+		t.Errorf("not idempotent:\nonce:\n%s\ntwice:\n%s", got, twice)
+	}
+	// DO UPDATE keeps its split: its SET really is a clause with a body.
+	upd := mustFormat(t, "insert into t (a, b) values (1, 2) on conflict (a) do update set b = excluded.b returning a, b;\n")
+	if !strings.Contains(upd, "do\n     update\n") {
+		t.Errorf("DO UPDATE lost its layout:\n%s", upd)
+	}
+}
+
+// The UPDATE closing a row-locking clause is not the UPDATE statement's
+// clause keyword. This predates PG 19 -- the committed corpus had the
+// mangled "... messageid for\n      update skip locked" baked into it --
+// and DO SELECT's optional FOR UPDATE reaches the same code.
+func TestRowLockingClauseIsNotAnUpdateClause(t *testing.T) {
+	for _, c := range []struct{ src, want string }{
+		{"select a, b from t where a = 1 for update;\n", " where a = 1 for update;"},
+		{"select a, b from t where a = 1 for no key update;\n", " where a = 1 for no key update;"},
+		{"insert into t (a) values (1) on conflict (a) do select for update returning a;\n", "do select for update"},
+	} {
+		got := mustFormat(t, c.src)
+		if !strings.Contains(got, c.want) {
+			t.Errorf("want %q in:\n%s", c.want, got)
+		}
+		if strings.Contains(got, "\nupdate") {
+			t.Errorf("row-locking UPDATE started a clause:\n%s", got)
+		}
+	}
+	// A real UPDATE statement is untouched.
+	if got := mustFormat(t, "update t set a = 1 where b = 2;\n"); !strings.HasPrefix(got, "update t") {
+		t.Errorf("UPDATE statement was reshaped:\n%s", got)
+	}
+}

--- a/format/layout.go
+++ b/format/layout.go
@@ -200,6 +200,23 @@ func splitTopLevelComma(toks []Token) [][]Token {
 // splitClauses cuts a query's top-level tokens into clauses at recognized
 // clause-keyword boundaries (STYLE.md's clause list, plus limit/offset which
 // participate in the same river alignment in real corpus output).
+// isRowLockTail reports whether the "update" at toks[i] closes a row-level
+// locking clause: "for update" or "for no key update".
+func isRowLockTail(toks []Token, i int) bool {
+	// "no" is not in the keyword table, so match the two filler words on
+	// text alone and require only the "for" itself to be a keyword.
+	kw := func(n int, w string) bool {
+		return n >= 0 && toks[n].Kind == TokKeyword && toks[n].Lower == w
+	}
+	word := func(n int, w string) bool {
+		return n >= 0 && toks[n].Lower == w
+	}
+	if kw(i-1, "for") {
+		return true
+	}
+	return word(i-1, "key") && word(i-2, "no") && kw(i-3, "for")
+}
+
 func splitClauses(toks []Token) []clauseSeg {
 	var segs []clauseSeg
 	depth := 0
@@ -220,6 +237,38 @@ func splitClauses(toks []Token) []clauseSeg {
 			continue
 		}
 		if depth != 0 || t.Kind != TokKeyword {
+			continue
+		}
+		// "do select" is one of ON CONFLICT's three conflict actions, a
+		// two-word atom like "do nothing" -- not a SELECT introducing a
+		// body. PostgreSQL 19's grammar is "DO SELECT [FOR ...] [WHERE
+		// ...]" with no select list at all, because the projection is
+		// the INSERT's own RETURNING (which DO SELECT makes mandatory).
+		// Splitting at the "select" put it on a river line of its own
+		// with an empty body, and pushed RETURNING under it:
+		//
+		//	on conflict (driverid) do
+		//	     select
+		//	  returning driverid, surname
+		//	^ was
+		//
+		// "do update" deliberately still splits: its SET really is a
+		// clause with a body to lay out.
+		if t.Lower == "select" && i > 0 && toks[i-1].Kind == TokKeyword &&
+			toks[i-1].Lower == "do" {
+			continue
+		}
+		// The UPDATE in a row-locking clause -- FOR UPDATE, FOR NO KEY
+		// UPDATE -- is not the UPDATE statement's clause keyword. This
+		// is not new to PG 19: a plain "select ... where a = 1 for
+		// update" already came apart as
+		//
+		//	 where a = 1 for
+		//	update;
+		//
+		// with "update" starting a clause of its own. DO SELECT's
+		// optional FOR UPDATE hits the same path.
+		if t.Lower == "update" && isRowLockTail(toks, i) {
 			continue
 		}
 		for _, cw := range clauseWords {

--- a/testdata/corpus/hyperloglog-05_01_tweets.hll.sql
+++ b/testdata/corpus/hyperloglog-05_01_tweets.hll.sql
@@ -6,8 +6,7 @@ with new_visitors as (
         where id = any(
         select id
         from tweet.visitor
-    order by datetime, messageid for
-      update skip locked
+    order by datetime, messageid for update skip locked
        limit 1000
   )
     returning messageid,


### PR DESCRIPTION
Two fixes, one found while chasing the other.

## `ON CONFLICT ... DO SELECT`

PostgreSQL 19's `DO SELECT` is a two-word conflict action alongside `DO NOTHING` and `DO UPDATE`:

```
DO SELECT [ FOR { UPDATE | NO KEY UPDATE | SHARE | KEY SHARE } ] [ WHERE condition ]
```

There is no select list — the projection is the `INSERT`'s own `RETURNING`, which is why `DO SELECT` is the one conflict action that makes `RETURNING` mandatory. But `select` is a `clauseWords` entry, so `splitClauses` cut at it and left a river segment with an empty body:

```sql
on conflict (driverid) do
     select
  returning driverid, surname, first_seen_at;   -- was

on conflict (driverid) do select
  returning driverid, surname, first_seen_at;   -- now
```

`DO UPDATE` deliberately still splits — its `SET` is a real clause with a body to lay out.

## `FOR UPDATE` (pre-existing, unrelated to PG 19)

Chasing `DO SELECT`'s optional `FOR UPDATE` turned up an older bug: the `UPDATE` closing a row-locking clause was also taken for the UPDATE statement's clause keyword, so a plain `select ... where a = 1 for update` came apart as

```sql
 where a = 1 for
update;
```

The corpus had this baked in — `hyperloglog-05_01_tweets.hll.sql` carried `order by datetime, messageid for` / `      update skip locked` — so that fixture is regenerated here. It's the only golden that changed.

`FOR NO KEY UPDATE` needs its filler words matched on text rather than token kind, since `no` is not in the keyword table.

## Tests

Two new tests in `format/ddlclause_test.go`: `DO SELECT` inline plus an idempotence pass and a guard that `DO UPDATE` keeps its split; and the row-locking cases (`for update`, `for no key update`, `do select for update`) plus a check that a real `UPDATE` statement is untouched.

`gofmt -l .`, `go vet ./...` and `make test` clean.