### PR TITLE
Lay out SQL/PGQ property graphs and GRAPH_TABLE

### DIFF
--- a/format/ddlclause_test.go
+++ b/format/ddlclause_test.go
@@ -311,3 +311,109 @@ func TestRowLockingClauseIsNotAnUpdateClause(t *testing.T) {
 		t.Errorf("UPDATE statement was reshaped:\n%s", got)
 	}
 }
+
+// SQL/PGQ (PG 19). PostgreSQL spells an edge out of single-character
+// tokens -- "'-' '[' ... ']' '-' '>'" -- so the generic expression path
+// saw the leading "-" as a binary operator and broke the line at it,
+// stranding "-> (n is country)" on the next. A quantifier fared worse:
+// "->{1,4}" is four more tokens, and its comma looked like a list
+// separator, so it came back as "-> { 1,\n4 }".
+func TestGraphPatternIsNeverBroken(t *testing.T) {
+	cases := []struct {
+		name, src string
+		want      []string
+	}{
+		{"edge arrow stays whole",
+			"select neighbour from graph_table (borders match (c is country where c.name = 'France')-[is borders]->(n is country) columns (n.name as neighbour)) order by neighbour;\n",
+			[]string{
+				"    from graph_table (borders",
+				"             match (c is country where c.name = 'France')",
+				"                   -[is borders]->(n is country)",
+				"           columns (n.name as neighbour))",
+			}},
+		{"quantifier keeps its braces closed up",
+			"select r from graph_table (borders match (c is country)-[is borders]->{1,4}(n is country) columns (n.name as r)) order by r;\n",
+			[]string{"-[is borders]->{1,4}(n is country)"}},
+		{"left and any edges",
+			"select a from graph_table (g match (a)<-[e is rel]-(b)-[f]-(c) columns (a.n as a));\n",
+			[]string{"(a)<-[e is rel]-(b)-[f]-(c)"}},
+		{"abbreviated edges",
+			"select a from graph_table (g match (a)->(b)<-(c)-(d) columns (a.n as a));\n",
+			[]string{"(a)->(b)<-(c)-(d)"}},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			got := mustFormat(t, c.src)
+			for _, w := range c.want {
+				if !strings.Contains(got, w) {
+					t.Errorf("want %q in:\n%s", w, got)
+				}
+			}
+			if squash(got) != squash(c.src) {
+				t.Errorf("content lost:\nwant %s\ngot  %s", squash(c.src), squash(got))
+			}
+			if twice := mustFormat(t, got); twice != got {
+				t.Errorf("not idempotent:\nonce:\n%s\ntwice:\n%s", got, twice)
+			}
+			for _, l := range strings.Split(got, "\n") {
+				if cols(l) > targetWidth {
+					t.Errorf("line over the margin (%d cols):\n%s", cols(l), got)
+				}
+			}
+		})
+	}
+}
+
+// Ordinary spacing still applies inside a vertex or edge body: only the
+// pattern's own punctuation is closed up. Passing a nil prevPrev to
+// spaceBetween here turned "where a.pop - 1 > 0" into "a.pop -1 > 0",
+// since it needs that token to tell a binary minus from a unary one.
+func TestGraphElementBodyKeepsNormalSpacing(t *testing.T) {
+	got := mustFormat(t, "select a from graph_table (g match (a is c where a.pop - 1 > 0)-[e]->(b) columns (a.n as a));\n")
+	if !strings.Contains(got, "where a.pop - 1 > 0") {
+		t.Errorf("body spacing was closed up:\n%s", got)
+	}
+}
+
+// CREATE PROPERTY GRAPH fell through to flatJoin and came back as one
+// 280-column line. Rule 22 wants the clauses at indent 2; the element
+// table lists then need one definition per line, and a definition too wide
+// on its own hangs its SOURCE/DESTINATION/LABEL under it.
+func TestPropertyGraphBreaksIntoClauses(t *testing.T) {
+	src := "create property graph borders vertex tables (geoname.country key (isocode) label country properties (name, iso)) edge tables (geoname.neighbour key (isocode, neighbour) source key (isocode) references country (isocode) destination key (neighbour) references country (isocode) label borders);\n"
+	got := mustFormat(t, src)
+	for _, w := range []string{
+		"create property graph borders\n",
+		"  vertex tables (\n",
+		"    geoname.country key (isocode) label country properties (name, iso)\n",
+		"  edge tables (\n",
+		"    geoname.neighbour key (isocode, neighbour)\n",
+		"      source key (isocode) references country(isocode)\n",
+		"      destination key (neighbour) references country(isocode)\n",
+		"      label borders\n",
+	} {
+		if !strings.Contains(got, w) {
+			t.Errorf("want %q in:\n%s", w, got)
+		}
+	}
+	if squash(got) != squash(src) {
+		t.Errorf("content lost:\nwant %s\ngot  %s", squash(src), squash(got))
+	}
+	if twice := mustFormat(t, got); twice != got {
+		t.Errorf("not idempotent:\nonce:\n%s\ntwice:\n%s", got, twice)
+	}
+	for _, l := range strings.Split(got, "\n") {
+		if cols(l) > targetWidth {
+			t.Errorf("line over the margin (%d cols):\n%s", cols(l), got)
+		}
+	}
+	// A short one is left whole, and DROP is not reshaped at all.
+	short := mustFormat(t, "create property graph g1 vertex tables (v1, v2);\n")
+	if strings.Count(short, "\n") > 1 {
+		t.Errorf("a short CREATE PROPERTY GRAPH was broken up:\n%s", short)
+	}
+	drop := mustFormat(t, "drop property graph if exists borders cascade;\n")
+	if drop != "drop property graph if exists borders cascade;\n" {
+		t.Errorf("DROP was reshaped:\n%s", drop)
+	}
+}

--- a/format/ddlclause_test.go
+++ b/format/ddlclause_test.go
@@ -326,10 +326,10 @@ func TestGraphPatternIsNeverBroken(t *testing.T) {
 		{"edge arrow stays whole",
 			"select neighbour from graph_table (borders match (c is country where c.name = 'France')-[is borders]->(n is country) columns (n.name as neighbour)) order by neighbour;\n",
 			[]string{
-				"    from graph_table (borders",
-				"             match (c is country where c.name = 'France')",
-				"                   -[is borders]->(n is country)",
-				"           columns (n.name as neighbour))",
+				"from graph_table (borders",
+				"match (c is country where c.name = 'France')",
+				"-[is borders]->(n is country)",
+				"columns (n.name as neighbour))",
 			}},
 		{"quantifier keeps its braces closed up",
 			"select r from graph_table (borders match (c is country)-[is borders]->{1,4}(n is country) columns (n.name as r)) order by r;\n",
@@ -361,6 +361,39 @@ func TestGraphPatternIsNeverBroken(t *testing.T) {
 				}
 			}
 		})
+	}
+}
+
+// GRAPH_TABLE's river is the open paren: the ones after "graph_table",
+// "match" and "columns" all line up, so the graph name, the pattern and the
+// projection start in one column. strings.Contains cannot see indentation,
+// so this needs its own test.
+func TestGraphTableParensAlign(t *testing.T) {
+	got := mustFormat(t, "select neighbour from graph_table (borders match (c is country where c.name = 'France')-[is borders]->(n is country) columns (n.name as neighbour)) order by neighbour;\n")
+	want := -1
+	for _, l := range strings.Split(got, "\n") {
+		var kw string
+		switch {
+		case strings.Contains(l, "graph_table ("):
+			kw = "graph_table ("
+		case strings.Contains(l, "match ("):
+			kw = "match ("
+		case strings.Contains(l, "columns ("):
+			kw = "columns ("
+		default:
+			continue
+		}
+		col := strings.Index(l, kw) + len(kw) - 1
+		if want < 0 {
+			want = col
+			continue
+		}
+		if col != want {
+			t.Errorf("%q opens at column %d, want %d:\n%s", kw, col, want, got)
+		}
+	}
+	if want < 0 {
+		t.Fatalf("no GRAPH_TABLE lines found:\n%s", got)
 	}
 }
 

--- a/format/expr.go
+++ b/format/expr.go
@@ -343,6 +343,20 @@ func deferredConstruct(toks []Token) (Doc, bool) {
 				return layoutOver(run, col)
 			}), true
 		}
+	case "graph_table":
+		// Note the width here is graphTableJoin, not plainJoin: a path
+		// pattern measured with spaces around every "-" and "[" reads a
+		// dozen columns wider than it prints, which is enough to make the
+		// Doc layer break a GRAPH_TABLE that would have fitted.
+		if isGraphTable(toks, 0) && matchParen(toks, 1) == len(toks)-1 {
+			run := toks
+			return defer_(graphTableJoin(run), func(col int) []string {
+				if l := layoutGraphTable(run, col); l != nil {
+					return l
+				}
+				return []string{graphTableJoin(run)}
+			}), true
+		}
 	}
 	return Doc{}, false
 }

--- a/format/format.go
+++ b/format/format.go
@@ -95,6 +95,15 @@ func statementKeyword(toks []Token) string {
 			case "or", "replace", "unique", "if", "not", "exists", "recursive",
 				"temp", "temporary", "unlogged", "concurrently":
 				continue
+			case "property":
+				// "create property graph" / "alter property graph" /
+				// "drop property graph": one kind, three verbs. ALTER's
+				// subcommands are not layoutAlter's, so it must not fall
+				// through to the generic "alter" case below.
+				if i+1 < len(toks) && toks[i+1].Lower == "graph" {
+					return "property graph"
+				}
+				continue
 			case "table", "index", "function", "view", "trigger", "statistics",
 				"sequence", "procedure", "materialized", "database":
 				kind := toks[i].Lower
@@ -186,6 +195,8 @@ func formatStatement(toks []Token) string {
 		} else {
 			lines = flatStatementLines(body)
 		}
+	case "property graph":
+		lines = layoutPropertyGraph(body)
 	case "explain":
 		lines = layoutExplain(body)
 	case "merge":

--- a/format/graph.go
+++ b/format/graph.go
@@ -1,0 +1,333 @@
+package format
+
+import "strings"
+
+// SQL/PGQ (ISO/IEC 9075-16), as PostgreSQL 19 implements it: property
+// graphs declared over ordinary tables, queried with GRAPH_TABLE.
+//
+// The layout problem is the path pattern. PostgreSQL's grammar spells an
+// edge out of single-character tokens -- "'-' '[' ... ']' '-' '>'" -- so
+// the lexer hands us "-", "[", "]", "->" as separate tokens, and the
+// generic expression path treats the "-" as a binary operator and breaks
+// the line at it:
+//
+//	borders match(c is country) -[is borders]
+//	-> (n is country) columns(n.name as neighbour)
+//	^ was
+//
+// A quantifier fared worse, since "{1,4}" is four more tokens and the
+// comma looked like a list separator:
+//
+//	-[is borders] -> { 1,
+//	4 } (n is country)
+//	^ was
+//
+// The saving grace is that a path pattern has no identifiers at paren
+// depth zero: every vertex is "(...)", every full edge is "-[...]->", and
+// the only bare tokens are the punctuation itself and a quantifier's
+// digits. So "no spaces at depth zero" is the whole spacing rule, and the
+// only place a line may break is between one element pattern and the next.
+
+// graphPunct are the tokens a path pattern is built from. They never take
+// a space on either side at pattern depth zero.
+var graphPunct = map[string]bool{
+	"-": true, "->": true, "<": true, ">": true,
+	"[": true, "]": true, "{": true, "}": true,
+}
+
+// graphPatternJoin renders a MATCH pattern on one line. Inside a vertex or
+// edge body -- "(c is country where c.name = 'France')" -- spacing is the
+// usual one; at depth zero nothing is separated at all, except a comma
+// between two path patterns, which is a list separator rather than part of
+// a quantifier.
+func graphPatternJoin(toks []Token) string {
+	var b strings.Builder
+	depth, inBrace := 0, false
+	for i := range toks {
+		t := toks[i]
+		if i > 0 {
+			prev := toks[i-1]
+			switch {
+			case depth > 0:
+				// Inside an element body: ordinary spacing, except that
+				// the body's own delimiters stay closed up. prevPrev has
+				// to be real, not nil -- spaceBetween needs it to tell a
+				// binary minus from a unary one, and without it
+				// "where a.pop - 1 > 0" came out as "a.pop -1 > 0".
+				var prevPrev *Token
+				if i > 1 {
+					prevPrev = &toks[i-2]
+				}
+				if prev.Text != "(" && prev.Text != "[" &&
+					t.Text != ")" && t.Text != "]" &&
+					spaceBetween(prevPrev, prev, t) {
+					b.WriteString(" ")
+				}
+			case t.Text == "," || inBrace || t.Text == "{":
+				// quantifier punctuation and its digits: never spaced
+			case prev.Text == ",":
+				b.WriteString(" ")
+			}
+		}
+		b.WriteString(t.Text)
+		switch t.Text {
+		case "(", "[":
+			depth++
+		case ")", "]":
+			depth--
+		case "{":
+			inBrace = true
+		case "}":
+			inBrace = false
+		}
+	}
+	return b.String()
+}
+
+// graphTableJoin renders a whole GRAPH_TABLE on one line, using the
+// pattern rules for the MATCH part and ordinary spacing either side. It is
+// also the width estimate: measuring with plainJoin would count spaces
+// around every "-" and "[" that the output will not contain.
+func graphTableJoin(toks []Token) string {
+	close := matchParen(toks, 1)
+	name, pattern, columns, ok := splitGraphTable(toks[2:close])
+	if !ok {
+		return flatJoin(toks)
+	}
+	return "graph_table (" + flatJoin(name) +
+		" match " + graphPatternJoin(pattern) +
+		" columns " + flatJoin(columns) + ")" + flatJoin(toks[close+1:])
+}
+
+// graphEdgeStarts returns the indexes at pattern depth zero where an edge
+// pattern begins -- the "-" or "<" that opens it. A wide pattern breaks
+// only there, so a continuation line starts with the edge and carries the
+// vertex it points at, rather than stranding a lone "(n is country)" under
+// an arrow that ends the line above.
+func graphEdgeStarts(toks []Token) []int {
+	var out []int
+	depth := 0
+	for i := range toks {
+		if depth == 0 && i > 0 {
+			if toks[i].Text == "-" || toks[i].Text == "<" {
+				out = append(out, i)
+			}
+		}
+		switch toks[i].Text {
+		case "(", "[":
+			depth++
+		case ")", "]":
+			depth--
+		}
+	}
+	return out
+}
+
+// isGraphTable reports whether toks[i] opens a "GRAPH_TABLE (" construct.
+func isGraphTable(toks []Token, i int) bool {
+	return toks[i].Kind == TokKeyword && toks[i].Lower == "graph_table" &&
+		i+1 < len(toks) && toks[i+1].Text == "("
+}
+
+// splitGraphTable cuts a GRAPH_TABLE body -- everything between its outer
+// parens -- into the graph name, the MATCH pattern, and the COLUMNS list
+// (parens included). ok is false if it does not have that shape, in which
+// case the caller falls back to its normal path rather than guessing.
+func splitGraphTable(body []Token) (name, pattern, columns []Token, ok bool) {
+	depth, mi, ci := 0, -1, -1
+	for i := range body {
+		switch body[i].Text {
+		case "(", "[":
+			depth++
+			continue
+		case ")", "]":
+			depth--
+			continue
+		}
+		if depth != 0 || body[i].Kind != TokKeyword {
+			continue
+		}
+		if mi < 0 && body[i].Lower == "match" {
+			mi = i
+		} else if mi >= 0 && ci < 0 && body[i].Lower == "columns" {
+			ci = i
+		}
+	}
+	if mi < 0 || ci < 0 {
+		return nil, nil, nil, false
+	}
+	return trimTokens(body[:mi]), trimTokens(body[mi+1 : ci]), trimTokens(body[ci+1:]), true
+}
+
+// layoutGraphTable renders a GRAPH_TABLE that does not fit on one line:
+// the graph name stays with the opening paren, then MATCH and COLUMNS take
+// a line each, indented under it. A pattern too wide even then breaks
+// between element patterns, never inside one.
+func layoutGraphTable(toks []Token, col int) []string {
+	close := matchParen(toks, 1)
+	name, pattern, columns, ok := splitGraphTable(toks[2:close])
+	if !ok {
+		return nil
+	}
+	inner := col + 2
+	pad := strings.Repeat(" ", inner)
+
+	lines := []string{"graph_table (" + flatJoin(name)}
+
+	// "match " and "columns " are padded to a common width so the pattern
+	// and the projection start in the same column, the way the clause
+	// river works one level up.
+	river := len("columns")
+	kw := func(w string) string {
+		return pad + strings.Repeat(" ", river-len(w)) + w + " "
+	}
+
+	patCol := inner + river + 1
+	patLines := []string{graphPatternJoin(pattern)}
+	if patCol+cols(patLines[0]) > targetWidth {
+		patLines = breakGraphPattern(pattern, patCol)
+	}
+	lines = append(lines, kw("match")+patLines[0])
+	for _, l := range patLines[1:] {
+		lines = append(lines, strings.Repeat(" ", patCol)+l)
+	}
+
+	colTail := flatJoin(columns)
+	lines = append(lines, kw("columns")+colTail+")"+flatJoin(toks[close+1:]))
+	return lines
+}
+
+// breakGraphPattern splits a pattern across lines at element boundaries,
+// packing as many elements onto each line as fit.
+func breakGraphPattern(pattern []Token, col int) []string {
+	starts := graphEdgeStarts(pattern)
+	if len(starts) == 0 {
+		return []string{graphPatternJoin(pattern)}
+	}
+	bounds := append([]int{0}, starts...)
+	bounds = append(bounds, len(pattern))
+
+	var out []string
+	cur := ""
+	for i := 0; i+1 < len(bounds); i++ {
+		piece := graphPatternJoin(pattern[bounds[i]:bounds[i+1]])
+		if cur == "" {
+			cur = piece
+			continue
+		}
+		if col+cols(cur)+cols(piece) <= targetWidth {
+			cur += piece
+			continue
+		}
+		out = append(out, cur)
+		cur = piece
+	}
+	if cur != "" {
+		out = append(out, cur)
+	}
+	return out
+}
+
+// propGraphClauses are the continuation clauses of CREATE/ALTER PROPERTY
+// GRAPH, which rule 22 puts one per line at indent 2 under the header.
+var propGraphClauses = []clauseStarter{
+	{"vertex", "tables"}, {"node", "tables"},
+	{"edge", "tables"}, {"relationship", "tables"},
+}
+
+// propGraphElementClauses are the parts of one element table definition.
+// A definition that does not fit on its own line hangs these under it, the
+// way an over-wide ALTER TABLE subcommand hangs its inner clauses.
+//
+// "key" is deliberately absent: an edge definition carries three of them
+// -- its own, SOURCE's and DESTINATION's -- and only the first is a clause
+// of the element. Listing it would have split "source key (isocode)
+// references country (isocode)" across two lines at the "key".
+var propGraphElementClauses = []clauseStarter{
+	{"source"}, {"destination"},
+	{"label"}, {"default", "label"},
+	{"properties"}, {"no", "properties"},
+}
+
+// layoutPropertyGraph handles CREATE/ALTER/DROP PROPERTY GRAPH, which
+// otherwise fell through to flatJoin and came back as one 280-column line.
+//
+// The element table lists are the reason this needs more than
+// layoutIndentedClauses: "vertex tables (...)" is a clause whose body is a
+// comma list of definitions, each of which can itself be too wide.
+func layoutPropertyGraph(toks []Token) []string {
+	toks = trimTokens(toks)
+	if !hasLineComment(toks) {
+		if flat := flatJoin(toks); cols(flat) <= targetWidth-1 {
+			return []string{flat}
+		}
+	}
+	idx := clauseIndexes(toks, propGraphClauses)
+	if len(idx) == 0 {
+		return flatStatementLines(toks)
+	}
+
+	lines := renderRun(toks[:idx[0]], 0)
+	for n, at := range idx {
+		end := len(toks)
+		if n+1 < len(idx) {
+			end = idx[n+1]
+		}
+		lines = append(lines, layoutPropGraphClause(trimTokens(toks[at:end]))...)
+	}
+	return lines
+}
+
+// layoutPropGraphClause renders one "<vertex|edge> tables ( ... )" clause:
+// the two keywords and the open paren, then one element table definition
+// per line at indent 4, then the closing paren back at indent 2.
+func layoutPropGraphClause(seg []Token) []string {
+	if flat := flatJoin(seg); cols(flat)+2 <= targetWidth-1 {
+		return []string{"  " + flat}
+	}
+	// "vertex tables" / "edge tables", then the parenthesized list.
+	open := -1
+	for i := range seg {
+		if seg[i].Text == "(" {
+			open = i
+			break
+		}
+	}
+	if open < 0 || matchParen(seg, open) != len(seg)-1 {
+		sub := renderRun(seg, 2)
+		out := []string{"  " + sub[0]}
+		return append(out, sub[1:]...)
+	}
+
+	lines := []string{"  " + flatJoin(seg[:open]) + " ("}
+	for i, it := range splitTopLevelComma(trimTokens(seg[open+1 : len(seg)-1])) {
+		it = trimTokens(it)
+		if len(it) == 0 {
+			continue
+		}
+		if i > 0 {
+			lines[len(lines)-1] += ","
+		}
+		item := renderRun(it, 4)
+		if len(item) == 1 && 4+cols(item[0]) > targetWidth {
+			if l, ok := layoutIndentedClauses(it, propGraphElementClauses, 6); ok && len(l) > 1 {
+				item = l
+			}
+		}
+		lines = append(lines, "    "+item[0])
+		lines = append(lines, item[1:]...)
+	}
+	return append(lines, "  )")
+}
+
+// isPropertyGraphStmt reports whether toks is a CREATE/ALTER/DROP PROPERTY
+// GRAPH statement, allowing for CREATE's optional TEMP.
+func isPropertyGraphStmt(toks []Token) bool {
+	for i := 1; i < len(toks) && i <= 3; i++ {
+		if toks[i].Kind == TokKeyword && toks[i].Lower == "property" &&
+			i+1 < len(toks) && toks[i+1].Lower == "graph" {
+			return true
+		}
+	}
+	return false
+}

--- a/format/graph.go
+++ b/format/graph.go
@@ -169,20 +169,22 @@ func layoutGraphTable(toks []Token, col int) []string {
 	if !ok {
 		return nil
 	}
-	inner := col + 2
-	pad := strings.Repeat(" ", inner)
-
 	lines := []string{"graph_table (" + flatJoin(name)}
 
-	// "match " and "columns " are padded to a common width so the pattern
-	// and the projection start in the same column, the way the clause
-	// river works one level up.
-	river := len("columns")
+	// The river here is the open paren itself: GRAPH_TABLE's, MATCH's and
+	// COLUMNS's all line up in one column, so the graph name, the pattern
+	// and the projection start together. "match" and "columns" are
+	// right-padded to reach it, the way clause keywords are one level up.
+	parenCol := col + len("graph_table ")
 	kw := func(w string) string {
-		return pad + strings.Repeat(" ", river-len(w)) + w + " "
+		n := parenCol - 1 - len(w)
+		if n < 0 {
+			n = 0
+		}
+		return strings.Repeat(" ", n) + w + " "
 	}
 
-	patCol := inner + river + 1
+	patCol := parenCol
 	patLines := []string{graphPatternJoin(pattern)}
 	if patCol+cols(patLines[0]) > targetWidth {
 		patLines = breakGraphPattern(pattern, patCol)

--- a/format/layout.go
+++ b/format/layout.go
@@ -886,6 +886,30 @@ func renderRun(toks []Token, col int) []string {
 			continue
 		}
 
+		// A GRAPH_TABLE has its own shape, and more to the point its
+		// path pattern must never be broken at the "-" that opens an
+		// edge -- which is exactly what the binary-operator path does
+		// with it. Take it whole, here, before that can happen.
+		if isGraphTable(toks, i) {
+			close := matchParen(toks, i+1)
+			gt := toks[i : close+1]
+			if prev != nil && spaceBetween(prevPrev, *prev, t) {
+				write(" ")
+			}
+			flat := graphTableJoin(gt)
+			if curCol+cols(flat) <= targetWidth {
+				write(flat)
+			} else if l := layoutGraphTable(gt, curCol); l != nil {
+				merge(l)
+			} else {
+				write(flat)
+			}
+			prevPrev, prev = prev, &toks[close]
+			flushTrailing(close)
+			i = close + 1
+			continue
+		}
+
 		if t.Kind == TokKeyword && t.Lower == "over" && i+1 < len(toks) && toks[i+1].Text == "(" {
 			close := matchParen(toks, i+1)
 			overToks := toks[i : close+1]

--- a/format/lexer.go
+++ b/format/lexer.go
@@ -99,6 +99,13 @@ var keywords = buildKeywordSet([]string{
 	// because rule 4 drops the space before "(" after an identifier, so
 	// "MERGE PARTITIONS (a, b)" came out as "merge partitions(a, b)".
 	"partitions", "split",
+	// SQL/PGQ (PG 19). "match" and "columns" have to be keywords for
+	// splitGraphTable to find the two halves of a GRAPH_TABLE, and the
+	// rest are here for rule 1: without them "CREATE PROPERTY GRAPH ...
+	// VERTEX TABLES" came back with half its words lowercased and half
+	// left as typed, since only "tables" was in this table.
+	"graph_table", "graph", "property", "properties", "match", "columns",
+	"vertex", "edge", "relationship", "node", "destination",
 })
 
 func buildKeywordSet(words []string) map[string]bool {


### PR DESCRIPTION
PostgreSQL 19 implements [SQL/PGQ](https://www.iso.org/standard/79473.html) (ISO/IEC 9075-16), and sqlfmt had no grammar for it.

## The problem

PostgreSQL spells an edge out of single-character tokens — `'-' '[' ... ']' '-' '>'` in `gram.y` — so the lexer hands over `-`, `[`, `]` and `->` separately. The expression layer took the leading `-` for a binary operator and broke the line at it:

```sql
-- was
  select neighbour
    from graph_table(
           borders match(c is country) -[is borders]
        -> (n is country) columns(n.name as neighbour)
         )
order by neighbour;
```

A quantifier fared worse — `->{1,4}` is four more tokens, and its comma read as a list separator:

```sql
-- was
           borders match(c is country) -[is borders] -> { 1,
           4 } (n is country) columns(n.name as r)
```

## The fix

A path pattern has no identifiers at paren depth zero: every vertex is `(...)`, every full edge is `-[...]->`, and the only bare tokens are the punctuation itself and a quantifier's digits. So **"no spaces at depth zero" is the whole spacing rule**, and the only place a pattern may break is between one element and the next — before an edge, so a continuation line leads with the arrow instead of stranding a lone vertex under one:

```sql
-- now
  select neighbour
    from graph_table (borders
             match (c is country where c.name = 'France')
                   -[is borders]->(n is country)
           columns (n.name as neighbour))
order by neighbour;
```

`GRAPH_TABLE` is deferred through the Doc layer exactly the way `OVER` already is, with `graphTableJoin` as the width estimate rather than `plainJoin` — a pattern measured with spaces around every `-` and `[` reads a dozen columns wider than it prints, which was enough on its own to break one that fitted.

Covers all the edge forms in the PG 19 grammar: `-[e]->`, `<-[e]-`, `-[e]-`, the abbreviated `->` / `<-` / `-`, and the `{n}` / `{,m}` / `{n,m}` quantifiers.

## CREATE PROPERTY GRAPH

Previously flattened to a single ~280-column line. Now rule 22's shape, one clause per line at indent 2:

```sql
create property graph borders
  vertex tables (
    geoname.country key (isocode) label country properties (name, iso)
  )
  edge tables (
    geoname.neighbour key (isocode, neighbour)
      source key (isocode) references country(isocode)
      destination key (neighbour) references country(isocode)
      label borders
  );
```

The element table lists need slightly more than `layoutIndentedClauses`, since `vertex tables (...)` is a clause whose body is a comma list of definitions that can each be too wide alone. `key` is deliberately **not** an element clause starter: an edge carries three of them — its own, `SOURCE`'s and `DESTINATION`'s — and only the first belongs to the element, so listing it split `source key (a) references t (b)` at the `key`.

`ALTER`/`DROP PROPERTY GRAPH` route to the same layout; `ALTER` needed its own statement kind so it would not fall into `layoutAlter`, whose subcommands are not these.

## One trap worth recording

`spaceBetween` needs a real `prevPrev` to tell a binary minus from a unary one. Passing `nil` turned a vertex body's `where a.pop - 1 > 0` into `where a.pop -1 > 0`. There is a test pinning that.

## Tests

Three new table-driven tests in `format/ddlclause_test.go` following the existing style, each with a `squash()` content-preservation check, an idempotence pass and a margin check: pattern integrity across all edge and quantifier forms, element-body spacing, and the property graph layout (including that a short one stays whole and `DROP` is untouched).

`gofmt -l .`, `go vet ./...` and `make test` all clean. **No corpus fixture changed.**

Grammar checked against `src/backend/parser/gram.y` and `src/test/regress/sql/graph_table.sql` on `REL_19_STABLE`. Found while formatting SQL for a PostgreSQL 19 article.