### PR TITLE
Add package explain: plan text in, PostgreSQL 19 plan advice out

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,47 @@ $ sqlfmt -l queries/**/*.sql    # list files whose formatting would change
 $ sqlfmt -d query.sql           # show a unified diff instead of full output
 $ cat query.sql | sqlfmt        # stdin -> stdout, pipeable
 $ sqlfmt -V                     # print the version and exit
+$ sqlfmt -advice plan.txt       # input is EXPLAIN output: print its plan advice
 ```
+
+### Plan advice
+
+`-advice` switches the input from SQL to **EXPLAIN output**, and prints a
+description of the plan's *structure*, in the format PostgreSQL 19's
+`pg_plan_advice` generates:
+
+```console
+$ psql -c 'explain (analyze, buffers) select ...' > plan.txt
+$ sqlfmt -advice plan.txt
+JOIN_ORDER(results races drivers)
+HASH_JOIN(races drivers)
+SEQ_SCAN(results races drivers)
+NO_GATHER(results races drivers)
+```
+
+The useful property is what the format leaves out. There is no cost in it,
+no row estimate, no timing — only the four decisions the planner made:
+join order, join method, access method, and parallelism. That makes it the
+one rendering of a plan that is stable across runs, which is what you need
+to answer the question a plain `diff` of two EXPLAIN outputs drowns in
+noise: **did the shape change, or did the numbers just move?**
+
+```console
+$ diff <(sqlfmt -advice before.txt) <(sqlfmt -advice after.txt)
+```
+
+PostgreSQL 19 computes this inside the planner. `sqlfmt` reconstructs it
+from the plan text, so it works on the version you are actually running,
+and on plain text EXPLAIN rather than only `FORMAT JSON` — because pasted
+text is what people have. Within limits documented in `explain/advice.go`
+and worth reading before relying on it: this is a **comparison key, not a
+round-trippable advice string**, relation ordering within a line is
+`sqlfmt`'s own rather than PostgreSQL's, and 19's join-method variant
+spellings are not reproduced.
+
+Plans are accepted with or without costs (`COSTS OFF` included), with or
+without psql's `QUERY PLAN` header and box-drawing borders, and with any
+leading statement echoes or trailing `(N rows)` footer left in place.
 
 As a library: `import "github.com/dimitri/sqlfmt/format"` (module path TBD —
 not yet published), `format.Format(io.Reader) (string, error)`, so callers
@@ -210,6 +250,14 @@ format/                    — package format, the library (import "github.com/d
   comments.go              — comment attachment, reflow, and C-style block rewrap (rule 18)
   format.go                — the library entry point (Format)
   format_test.go           — corpus round-trip test (reads ../testdata/corpus)
+explain/                   — package explain, EXPLAIN *output* (not the EXPLAIN
+                             statement, which format/ handles) — import
+                             "github.com/dimitri/sqlfmt/explain"
+  parse.go                 — psql TEXT-format plan text -> Node/Plan tree
+  nodetype.go              — node-type vocabulary and classification
+  format.go                — FormatForWidth, reflow for fixed-width media
+  advice.go                — Advice: plan structure in PostgreSQL 19's
+                             pg_plan_advice format, derived on any version
 cmd/sqlfmt/main.go         — the CLI binary
 wasm/main.go                — WebAssembly build (globalThis.sqlfmt.format), see "WebAssembly build"
 wasm/smoketest.mjs          — Node smoke test for the built wasm module

--- a/README.md
+++ b/README.md
@@ -45,47 +45,70 @@ $ sqlfmt -l queries/**/*.sql    # list files whose formatting would change
 $ sqlfmt -d query.sql           # show a unified diff instead of full output
 $ cat query.sql | sqlfmt        # stdin -> stdout, pipeable
 $ sqlfmt -V                     # print the version and exit
-$ sqlfmt -advice plan.txt       # input is EXPLAIN output: print its plan advice
 ```
 
-### Plan advice
+### Working on EXPLAIN output
 
-`-advice` switches the input from SQL to **EXPLAIN output**, and prints a
-description of the plan's *structure*, in the format PostgreSQL 19's
-`pg_plan_advice` generates:
+The top-level command formats SQL, including `EXPLAIN` *statements*. The
+`explain` subcommand works on EXPLAIN *output* — the plan text a server
+printed:
 
 ```console
-$ psql -c 'explain (analyze, buffers) select ...' > plan.txt
-$ sqlfmt -advice plan.txt
-JOIN_ORDER(results races drivers)
-HASH_JOIN(races drivers)
-SEQ_SCAN(results races drivers)
-NO_GATHER(results races drivers)
+$ sqlfmt explain advice plan.txt          # the plan's structure, as plan advice
+$ sqlfmt explain diff before.txt after.txt # what changed between two plans
+```
+
+`explain advice` prints a description of the plan's *structure* in the
+format PostgreSQL 19's `pg_plan_advice` generates:
+
+```console
+$ sqlfmt explain advice plan.txt
+JOIN_ORDER(f d)
+MERGE_JOIN_PLAIN(d)
+INDEX_SCAN(f join_fact_dim_id d join_dim_pkey)
+NO_GATHER(f d)
 ```
 
 The useful property is what the format leaves out. There is no cost in it,
-no row estimate, no timing — only the four decisions the planner made:
-join order, join method, access method, and parallelism. That makes it the
-one rendering of a plan that is stable across runs, which is what you need
-to answer the question a plain `diff` of two EXPLAIN outputs drowns in
-noise: **did the shape change, or did the numbers just move?**
+no row estimate, no timing — only the decisions the planner made: join
+order, join method, access method, parallelism. That makes it the one
+rendering of a plan that is stable across runs.
+
+Which is what `explain diff` is built on. A plain `diff` of two EXPLAIN
+outputs is useless, because every line carries a cost or a timing so every
+line differs, and the one change that explains the difference is buried in
+noise. Comparing the advice instead sidesteps that — and sidesteps having
+to align nodes between two differently-shaped trees, since advice is keyed
+by tag rather than by position:
 
 ```console
-$ diff <(sqlfmt -advice before.txt) <(sqlfmt -advice after.txt)
+$ sqlfmt explain diff before.txt after.txt
+STRUCTURE (2 changes)
+  - SEQ_SCAN(geoname)
+  + INDEX_SCAN(geoname geoname_name)
+
+NUMBERS
+  execution time     18.245 ms →     0.049 ms   (-99.7%)
+  planning time       0.301 ms →     0.306 ms   (+1.7%)
 ```
 
-PostgreSQL 19 computes this inside the planner. `sqlfmt` reconstructs it
-from the plan text, so it works on the version you are actually running,
-and on plain text EXPLAIN rather than only `FORMAT JSON` — because pasted
-text is what people have. Within limits documented in `explain/advice.go`
-and worth reading before relying on it: this is a **comparison key, not a
-round-trippable advice string**, relation ordering within a line is
-`sqlfmt`'s own rather than PostgreSQL's, and 19's join-method variant
-spellings are not reproduced.
+Numbers are reported, but separately and always labelled as such; they are
+never mixed into the structural comparison. `explain diff` exits 0 when the
+two plans are structurally identical and 1 when they are not, so it
+composes into scripts and CI.
 
-Plans are accepted with or without costs (`COSTS OFF` included), with or
-without psql's `QUERY PLAN` header and box-drawing borders, and with any
-leading statement echoes or trailing `(N rows)` footer left in place.
+Plans are read in psql's default TEXT format — with or without `ANALYZE`,
+with or without costs (`COSTS OFF` included), with or without the
+`QUERY PLAN` header, box-drawing borders, leading statement echoes or a
+trailing `(N rows)`. TEXT rather than `FORMAT JSON` because pasted text is
+what people actually have.
+
+PostgreSQL 19 computes advice inside the planner; `sqlfmt` reconstructs it
+from plan text, so it works on the version you are running. The known
+differences from real generated advice are listed in `explain/advice.go`
+and worth reading before relying on it — chiefly that index names are not
+schema-qualified, and that this is a **comparison key, not a
+round-trippable advice string**.
 
 As a library: `import "github.com/dimitri/sqlfmt/format"` (module path TBD —
 not yet published), `format.Format(io.Reader) (string, error)`, so callers
@@ -258,7 +281,9 @@ explain/                   — package explain, EXPLAIN *output* (not the EXPLAI
   format.go                — FormatForWidth, reflow for fixed-width media
   advice.go                — Advice: plan structure in PostgreSQL 19's
                              pg_plan_advice format, derived on any version
-cmd/sqlfmt/main.go         — the CLI binary
+  diff.go                  — DiffPlans: structural comparison of two plans
+cmd/sqlfmt/main.go         — the CLI binary (formatter; gofmt-style flags)
+cmd/sqlfmt/explaincmd.go   — the "explain" subcommand namespace
 wasm/main.go                — WebAssembly build (globalThis.sqlfmt.format), see "WebAssembly build"
 wasm/smoketest.mjs          — Node smoke test for the built wasm module
 wasm/compress.mjs           — produces sqlfmt.wasm.gz from the built module

--- a/cmd/sqlfmt/explaincmd.go
+++ b/cmd/sqlfmt/explaincmd.go
@@ -1,0 +1,147 @@
+package main
+
+import (
+	"flag"
+	"fmt"
+	"io"
+	"os"
+
+	"github.com/dimitri/sqlfmt/explain"
+)
+
+// The "explain" subcommand namespace works on EXPLAIN *output* — the plan
+// text a server printed — as opposed to the top-level command, which
+// formats EXPLAIN *statements* along with the rest of your SQL.
+//
+// Why a subcommand here when the formatter itself is flags-and-paths,
+// gofmt-style, and stays that way:
+//
+//   - The existing CLI is a published contract. "sqlfmt file.sql" formats,
+//     and it has to keep formatting. Only a first argument of literally
+//     "explain" diverts into this namespace; everything else takes the
+//     original path unchanged.
+//   - Plan work does not fit the formatter's shape. "sqlfmt [flags]
+//     [path...]" means "do this to each of these files independently",
+//     which is exactly wrong for a diff: two plans are one operation on a
+//     PAIR, not two operations. Expressing that as flags (-diff a.txt
+//     b.txt, positionally significant) would be worse than a subcommand.
+//   - It leaves room. "explain diff" and "explain advice" are the two
+//     that exist; the namespace can grow without adding more top-level
+//     flags to a formatter.
+//
+// A file genuinely named "explain" is the one ambiguity, and "./explain"
+// resolves it.
+func runExplain(args []string) int {
+	if len(args) == 0 {
+		explainUsage()
+		return 2
+	}
+	switch args[0] {
+	case "advice":
+		return runExplainAdvice(args[1:])
+	case "diff":
+		return runExplainDiff(args[1:])
+	case "help", "-h", "--help":
+		explainUsage()
+		return 0
+	default:
+		fmt.Fprintf(os.Stderr, "sqlfmt explain: unknown subcommand %q\n\n", args[0])
+		explainUsage()
+		return 2
+	}
+}
+
+func explainUsage() {
+	fmt.Fprint(os.Stderr, `usage: sqlfmt explain <command> [args]
+
+Work on EXPLAIN output — the plan text a server printed.
+
+commands:
+  advice [plan]           print the plan's structure as PostgreSQL 19
+                          plan advice; reads stdin when no file is given
+  diff <before> <after>   compare two plans: what the planner decided
+                          differently, and how the timings moved
+
+Plans are read in psql's default TEXT format, with or without ANALYZE,
+costs, the QUERY PLAN header, or a trailing row count.
+`)
+}
+
+func runExplainAdvice(args []string) int {
+	fs := flag.NewFlagSet("sqlfmt explain advice", flag.ExitOnError)
+	fs.Parse(args)
+
+	var src []byte
+	var name string
+	var err error
+	switch fs.NArg() {
+	case 0:
+		name = "<standard input>"
+		src, err = io.ReadAll(os.Stdin)
+	case 1:
+		name = fs.Arg(0)
+		src, err = os.ReadFile(name)
+	default:
+		fmt.Fprintln(os.Stderr, "usage: sqlfmt explain advice [plan]")
+		return 2
+	}
+	if err != nil {
+		report(err)
+		return 2
+	}
+
+	plan, err := explain.Parse(string(src))
+	if err != nil {
+		report(fmt.Errorf("%s: %w", name, err))
+		return 2
+	}
+	out := explain.AdviceString(plan)
+	if out == "" {
+		report(fmt.Errorf("%s: no plan advice could be derived", name))
+		return 2
+	}
+	fmt.Println(out)
+	return 0
+}
+
+// runExplainDiff exits 0 when the two plans are structurally identical and
+// 1 when they are not, so it composes into scripts and CI the way diff(1)
+// does. A real error is 2.
+func runExplainDiff(args []string) int {
+	fs := flag.NewFlagSet("sqlfmt explain diff", flag.ExitOnError)
+	fs.Parse(args)
+
+	if fs.NArg() != 2 {
+		fmt.Fprintln(os.Stderr, "usage: sqlfmt explain diff <before> <after>")
+		return 2
+	}
+	before, err := parsePlanFile(fs.Arg(0))
+	if err != nil {
+		report(err)
+		return 2
+	}
+	after, err := parsePlanFile(fs.Arg(1))
+	if err != nil {
+		report(err)
+		return 2
+	}
+
+	d := explain.DiffPlans(before, after)
+	fmt.Print(d.String())
+	if d.SameStructure() {
+		return 0
+	}
+	return 1
+}
+
+func parsePlanFile(path string) (*explain.Plan, error) {
+	src, err := os.ReadFile(path)
+	if err != nil {
+		return nil, err
+	}
+	plan, err := explain.Parse(string(src))
+	if err != nil {
+		return nil, fmt.Errorf("%s: %w", path, err)
+	}
+	return plan, nil
+}

--- a/cmd/sqlfmt/main.go
+++ b/cmd/sqlfmt/main.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/pmezard/go-difflib/difflib"
 
+	"github.com/dimitri/sqlfmt/explain"
 	"github.com/dimitri/sqlfmt/format"
 )
 
@@ -23,6 +24,7 @@ var (
 	write      = flag.Bool("w", false, "write result to (source) file instead of stdout")
 	list       = flag.Bool("l", false, "list files whose formatting differs from sqlfmt's")
 	doDiff     = flag.Bool("d", false, "display diffs instead of rewriting files")
+	advice     = flag.Bool("advice", false, "input is EXPLAIN output: print its plan advice")
 	showVer    = flag.Bool("V", false, "print version and exit")
 	showVerLon = flag.Bool("version", false, "print version and exit")
 )
@@ -92,10 +94,30 @@ func report(err error) {
 	fmt.Fprintln(os.Stderr, err)
 }
 
+// adviceOutput renders src's plan advice. Kept behind an explicit -advice
+// flag rather than sniffing the input with explain.HasPlan: a formatter
+// that silently switches to a different job because it thought it
+// recognized the input is a formatter you cannot script against.
+func adviceOutput(src []byte, name string) error {
+	plan, err := explain.Parse(string(src))
+	if err != nil {
+		return fmt.Errorf("%s: %w", name, err)
+	}
+	out := explain.AdviceString(plan)
+	if out == "" {
+		return fmt.Errorf("%s: no plan advice could be derived", name)
+	}
+	_, err = fmt.Println(out)
+	return err
+}
+
 func processReader(r io.Reader, name string) error {
 	src, err := io.ReadAll(r)
 	if err != nil {
 		return err
+	}
+	if *advice {
+		return adviceOutput(src, name)
 	}
 	formatted, err := format.Format(bytes.NewReader(src))
 	if err != nil {
@@ -119,6 +141,9 @@ func processFile(path string) error {
 	src, err := os.ReadFile(path)
 	if err != nil {
 		return err
+	}
+	if *advice {
+		return adviceOutput(src, path)
 	}
 	formatted, err := format.Format(bytes.NewReader(src))
 	if err != nil {

--- a/cmd/sqlfmt/main.go
+++ b/cmd/sqlfmt/main.go
@@ -12,7 +12,6 @@ import (
 
 	"github.com/pmezard/go-difflib/difflib"
 
-	"github.com/dimitri/sqlfmt/explain"
 	"github.com/dimitri/sqlfmt/format"
 )
 
@@ -24,14 +23,21 @@ var (
 	write      = flag.Bool("w", false, "write result to (source) file instead of stdout")
 	list       = flag.Bool("l", false, "list files whose formatting differs from sqlfmt's")
 	doDiff     = flag.Bool("d", false, "display diffs instead of rewriting files")
-	advice     = flag.Bool("advice", false, "input is EXPLAIN output: print its plan advice")
 	showVer    = flag.Bool("V", false, "print version and exit")
 	showVerLon = flag.Bool("version", false, "print version and exit")
 )
 
 func main() {
+	// The "explain" subcommand namespace is checked before flag parsing so
+	// its own flags never collide with the formatter's. Everything else
+	// takes the original gofmt-style path, unchanged.
+	if len(os.Args) > 1 && os.Args[1] == "explain" {
+		os.Exit(runExplain(os.Args[2:]))
+	}
+
 	flag.Usage = func() {
 		fmt.Fprintf(os.Stderr, "usage: sqlfmt [flags] [path ...]\n")
+		fmt.Fprintf(os.Stderr, "       sqlfmt explain <command> [args]\n\n")
 		flag.PrintDefaults()
 	}
 	flag.Parse()
@@ -94,30 +100,10 @@ func report(err error) {
 	fmt.Fprintln(os.Stderr, err)
 }
 
-// adviceOutput renders src's plan advice. Kept behind an explicit -advice
-// flag rather than sniffing the input with explain.HasPlan: a formatter
-// that silently switches to a different job because it thought it
-// recognized the input is a formatter you cannot script against.
-func adviceOutput(src []byte, name string) error {
-	plan, err := explain.Parse(string(src))
-	if err != nil {
-		return fmt.Errorf("%s: %w", name, err)
-	}
-	out := explain.AdviceString(plan)
-	if out == "" {
-		return fmt.Errorf("%s: no plan advice could be derived", name)
-	}
-	_, err = fmt.Println(out)
-	return err
-}
-
 func processReader(r io.Reader, name string) error {
 	src, err := io.ReadAll(r)
 	if err != nil {
 		return err
-	}
-	if *advice {
-		return adviceOutput(src, name)
 	}
 	formatted, err := format.Format(bytes.NewReader(src))
 	if err != nil {
@@ -141,9 +127,6 @@ func processFile(path string) error {
 	src, err := os.ReadFile(path)
 	if err != nil {
 		return err
-	}
-	if *advice {
-		return adviceOutput(src, path)
 	}
 	formatted, err := format.Format(bytes.NewReader(src))
 	if err != nil {

--- a/explain/advice.go
+++ b/explain/advice.go
@@ -1,0 +1,328 @@
+package explain
+
+import (
+	"sort"
+	"strings"
+)
+
+// Advice renders a plan's STRUCTURE in the shape PostgreSQL 19's
+// pg_plan_advice generates:
+//
+//	JOIN_ORDER(results races drivers)
+//	HASH_JOIN(races drivers)
+//	SEQ_SCAN(results races drivers)
+//	NO_GATHER(results races drivers)
+//
+// Why mirror a format from a version almost nobody runs yet: because of
+// what the format leaves out. There is no cost in it, no row estimate, no
+// timing — only the decisions the planner made about join order, join
+// method, access method, and parallelism. That makes it the one rendering
+// of a plan that is stable across runs of the same plan, and it is
+// exactly what you need to answer the question a plain diff of two
+// EXPLAIN outputs drowns in noise: did the SHAPE change, or did the
+// numbers just move?
+//
+// PostgreSQL 19 computes this inside the planner, which knows everything.
+// We are reconstructing it from a rendering, on any version back to the
+// ones people are actually running. That difference has consequences, and
+// they are stated rather than papered over:
+//
+//   - This is a COMPARISON KEY, not a round-trippable advice string. Do
+//     not feed the output to pg_plan_advice and expect it to apply. Text
+//     EXPLAIN does not carry the planner's internal relation identity, so
+//     subqueries, CTEs and repeated aliases can be ambiguous here in ways
+//     they never are inside the planner.
+//   - Relation ordering within a line is ours (join order, see below),
+//     not PostgreSQL's internal ordering. Two plans compared with each
+//     other agree; a line compared byte-for-byte against a real 19 server
+//     may not.
+//   - Join-method variant spellings (19's MERGE_JOIN_PLAIN and friends)
+//     are not reproduced. A merge join is MERGE_JOIN here.
+//
+// Within those limits it does the job it exists for: two plans of the
+// same query produce identical Advice when, and only when, the planner
+// made the same structural decisions.
+func Advice(p *Plan) []AdviceLine {
+	if p == nil || p.Root == nil {
+		return nil
+	}
+	// Join order doubles as this package's canonical relation ordering:
+	// every other line orders its relations by first appearance here, so
+	// the whole block is deterministic for a given tree.
+	order := joinOrder(p.Root)
+	rank := make(map[string]int, len(order))
+	for i, rel := range order {
+		if _, seen := rank[rel]; !seen {
+			rank[rel] = i
+		}
+	}
+	byOrder := func(rels []string) []string {
+		out := dedupe(rels)
+		sort.SliceStable(out, func(i, j int) bool {
+			ri, oki := rank[out[i]]
+			rj, okj := rank[out[j]]
+			switch {
+			case oki && okj:
+				return ri < rj
+			case oki:
+				return true
+			case okj:
+				return false
+			}
+			return out[i] < out[j]
+		})
+		return out
+	}
+
+	var lines []AdviceLine
+	if rels := dedupe(order); len(rels) > 0 {
+		lines = append(lines, AdviceLine{Kind: "JOIN_ORDER", Relations: rels})
+	}
+
+	for _, jm := range joinMethods(p.Root) {
+		lines = append(lines, AdviceLine{Kind: jm.kind, Relations: byOrder(jm.inner)})
+	}
+
+	for _, sm := range scanMethods(p.Root) {
+		lines = append(lines, AdviceLine{Kind: sm.kind, Relations: byOrder(sm.rels)})
+	}
+
+	gather := "NO_GATHER"
+	if hasGather(p.Root) {
+		gather = "GATHER"
+	}
+	if rels := dedupe(order); len(rels) > 0 {
+		lines = append(lines, AdviceLine{Kind: gather, Relations: rels})
+	}
+	return lines
+}
+
+// AdviceLine is one line of the advice block: a decision kind and the
+// relations it applies to.
+type AdviceLine struct {
+	Kind      string // "JOIN_ORDER", "HASH_JOIN", "SEQ_SCAN", "NO_GATHER", ...
+	Relations []string
+}
+
+func (l AdviceLine) String() string {
+	return l.Kind + "(" + strings.Join(l.Relations, " ") + ")"
+}
+
+// AdviceString renders Advice as the multi-line block, one decision per
+// line, without a trailing newline.
+func AdviceString(p *Plan) string {
+	lines := Advice(p)
+	out := make([]string, 0, len(lines))
+	for _, l := range lines {
+		out = append(out, l.String())
+	}
+	return strings.Join(out, "\n")
+}
+
+// relName is how a base relation is named throughout the advice block:
+// its alias when the query gave it one, else the relation itself. The
+// alias is preferred because it is what distinguishes two scans of the
+// same table in a self-join — exactly the case where using the bare
+// relation name would collapse two different decisions into one.
+func relName(n *Node) string {
+	if n.Alias != "" {
+		return n.Alias
+	}
+	return n.Relation
+}
+
+// isBaseRelation reports whether n reads a named relation, i.e. whether
+// it contributes a name to the advice block. Nodes with no relation of
+// their own (Sort, Hash, Aggregate, ...) never do.
+//
+// Bitmap Index Scan is the exception that has to be spelled out. It
+// prints as "Bitmap Index Scan on <index>", so the parser stores the
+// INDEX name in Relation — the only node type where that field is not a
+// relation at all. Left in, an index name shows up as a participant in
+// JOIN_ORDER, which is both wrong and confusing. The Bitmap Heap Scan
+// directly above it already contributes the real relation.
+func isBaseRelation(n *Node) bool {
+	return n.Relation != "" && n.Type != "bitmap-index-scan"
+}
+
+// isJoin reports whether n is a join node.
+func isJoin(n *Node) bool {
+	switch n.Type {
+	case "hash-join", "nested-loop", "merge-join":
+		return true
+	}
+	return false
+}
+
+// joinOrder walks the tree outer-side-first, collecting base relations in
+// the order the joins bring them in. For the usual left-deep tree that
+// puts the driving relation first and each joined relation after it,
+// which is what 19's JOIN_ORDER line reports.
+func joinOrder(n *Node) []string {
+	var out []string
+	var walk func(*Node)
+	walk = func(n *Node) {
+		if n == nil {
+			return
+		}
+		if isBaseRelation(n) {
+			out = append(out, relName(n))
+		}
+		for _, c := range n.Children {
+			walk(c)
+		}
+	}
+	walk(n)
+	return out
+}
+
+type joinMethod struct {
+	kind  string
+	inner []string
+}
+
+// joinMethods collects one entry per join node, naming the relations on
+// that join's INNER side — the side 19's HASH_JOIN(...)/MERGE_JOIN(...)
+// lines name. Deepest join first, so the ordering is stable regardless of
+// how the tree is nested.
+//
+// The inner side is read through whatever the join builds on it: a Hash
+// Join's inner child is the Hash node, not the scan under it, and a merge
+// join's inner side is routinely a Sort. Those wrappers carry no relation
+// of their own, so descending through them lands on the relations that
+// matter.
+func joinMethods(root *Node) []joinMethod {
+	var out []joinMethod
+	var walk func(*Node)
+	walk = func(n *Node) {
+		if n == nil {
+			return
+		}
+		for _, c := range n.Children {
+			walk(c)
+		}
+		if !isJoin(n) || len(n.Children) < 2 {
+			return
+		}
+		kind := ""
+		switch n.Type {
+		case "hash-join":
+			kind = "HASH_JOIN"
+		case "nested-loop":
+			kind = "NESTED_LOOP"
+		case "merge-join":
+			kind = "MERGE_JOIN"
+		}
+		inner := joinOrder(n.Children[1])
+		if len(inner) == 0 {
+			return
+		}
+		out = append(out, joinMethod{kind: kind, inner: inner})
+	}
+	walk(root)
+
+	// Merge entries sharing a kind into one line, as 19 does: two hash
+	// joins in one plan produce a single HASH_JOIN(...) naming both inner
+	// sides, not two lines.
+	var merged []joinMethod
+	idx := map[string]int{}
+	for _, jm := range out {
+		if i, ok := idx[jm.kind]; ok {
+			merged[i].inner = append(merged[i].inner, jm.inner...)
+			continue
+		}
+		idx[jm.kind] = len(merged)
+		merged = append(merged, jm)
+	}
+	return merged
+}
+
+type scanMethod struct {
+	kind string
+	rels []string
+}
+
+// scanMethodKind maps a parsed node type to its advice keyword. Only node
+// types that actually read a relation appear; anything else returns "".
+var scanMethodKind = map[string]string{
+	"seq-scan":              "SEQ_SCAN",
+	"index-scan":            "INDEX_SCAN",
+	"index-only-scan":       "INDEX_ONLY_SCAN",
+	"bitmap-heap-scan":      "BITMAP_HEAP_SCAN",
+	"tid-scan":              "TID_SCAN",
+	"tid-range-scan":        "TID_RANGE_SCAN",
+	"sample-scan":           "SAMPLE_SCAN",
+	"foreign-scan":          "FOREIGN_SCAN",
+	"custom-scan":           "CUSTOM_SCAN",
+	"function-scan":         "FUNCTION_SCAN",
+	"table-function-scan":   "TABLE_FUNCTION_SCAN",
+	"values-scan":           "VALUES_SCAN",
+	"subquery-scan":         "SUBQUERY_SCAN",
+	"cte-scan":              "CTE_SCAN",
+	"worktable-scan":        "WORKTABLE_SCAN",
+	"named-tuplestore-scan": "NAMED_TUPLESTORE_SCAN",
+}
+
+// scanMethods groups base relations by how they are read, one line per
+// access method, in first-appearance order of the method itself.
+//
+// Bitmap Index Scan is deliberately absent: it names the index, and the
+// Bitmap Heap Scan above it already names the relation, so counting both
+// would name the same access path twice.
+func scanMethods(root *Node) []scanMethod {
+	var out []scanMethod
+	idx := map[string]int{}
+	var walk func(*Node)
+	walk = func(n *Node) {
+		if n == nil {
+			return
+		}
+		if isBaseRelation(n) {
+			if kind, ok := scanMethodKind[n.Type]; ok {
+				i, seen := idx[kind]
+				if !seen {
+					i = len(out)
+					idx[kind] = i
+					out = append(out, scanMethod{kind: kind})
+				}
+				out[i].rels = append(out[i].rels, relName(n))
+			}
+		}
+		for _, c := range n.Children {
+			walk(c)
+		}
+	}
+	walk(root)
+	return out
+}
+
+// hasGather reports whether any part of the plan runs in parallel, which
+// decides between the GATHER and NO_GATHER lines.
+func hasGather(n *Node) bool {
+	if n == nil {
+		return false
+	}
+	if n.Type == "gather" || n.Type == "gather-merge" {
+		return true
+	}
+	for _, c := range n.Children {
+		if hasGather(c) {
+			return true
+		}
+	}
+	return false
+}
+
+// dedupe removes repeats while keeping first-appearance order.
+func dedupe(in []string) []string {
+	seen := make(map[string]bool, len(in))
+	out := make([]string, 0, len(in))
+	for _, s := range in {
+		if s == "" || seen[s] {
+			continue
+		}
+		seen[s] = true
+		out = append(out, s)
+	}
+	return out
+}

--- a/explain/advice.go
+++ b/explain/advice.go
@@ -1,115 +1,108 @@
 package explain
 
-import (
-	"sort"
-	"strings"
-)
+import "strings"
 
-// Advice renders a plan's STRUCTURE in the shape PostgreSQL 19's
+// Advice renders a plan's STRUCTURE in the format PostgreSQL 19's
 // pg_plan_advice generates:
 //
-//	JOIN_ORDER(results races drivers)
-//	HASH_JOIN(races drivers)
-//	SEQ_SCAN(results races drivers)
-//	NO_GATHER(results races drivers)
+//	JOIN_ORDER(f d)
+//	MERGE_JOIN_PLAIN(d)
+//	INDEX_SCAN(f join_fact_dim_id d join_dim_pkey)
+//	NO_GATHER(f d)
 //
 // Why mirror a format from a version almost nobody runs yet: because of
-// what the format leaves out. There is no cost in it, no row estimate, no
-// timing — only the decisions the planner made about join order, join
-// method, access method, and parallelism. That makes it the one rendering
-// of a plan that is stable across runs of the same plan, and it is
-// exactly what you need to answer the question a plain diff of two
-// EXPLAIN outputs drowns in noise: did the SHAPE change, or did the
-// numbers just move?
+// what it leaves out. There is no cost in it, no row estimate, no timing
+// — only the decisions the planner made about join order, join method,
+// access method, and parallelism. That makes it the one rendering of a
+// plan that is stable across runs, and therefore the answer to the
+// question a plain diff of two EXPLAIN outputs drowns in noise: did the
+// SHAPE change, or did the numbers just move?
 //
-// PostgreSQL 19 computes this inside the planner, which knows everything.
-// We are reconstructing it from a rendering, on any version back to the
-// ones people are actually running. That difference has consequences, and
-// they are stated rather than papered over:
+// The tag vocabulary, argument conventions and emission order here were
+// read off contrib/pg_plan_advice in the PostgreSQL source rather than
+// guessed: tags from pgpa_cstring_advice_tag() in pgpa_ast.c, the
+// join-strategy distinctions from pgpa_join.c, argument shapes from the
+// module README, and line order from pgpa_output_advice().
 //
-//   - This is a COMPARISON KEY, not a round-trippable advice string. Do
-//     not feed the output to pg_plan_advice and expect it to apply. Text
-//     EXPLAIN does not carry the planner's internal relation identity, so
-//     subqueries, CTEs and repeated aliases can be ambiguous here in ways
-//     they never are inside the planner.
-//   - Relation ordering within a line is ours (join order, see below),
-//     not PostgreSQL's internal ordering. Two plans compared with each
-//     other agree; a line compared byte-for-byte against a real 19 server
-//     may not.
-//   - Join-method variant spellings (19's MERGE_JOIN_PLAIN and friends)
-//     are not reproduced. A merge join is MERGE_JOIN here.
+// # What this can and cannot do
 //
-// Within those limits it does the job it exists for: two plans of the
-// same query produce identical Advice when, and only when, the planner
-// made the same structural decisions.
+// PostgreSQL 19 generates advice inside the planner, which knows the
+// query's whole structure. This reconstructs it from EXPLAIN's rendering
+// of the finished plan, on any version. Most of it survives that
+// translation exactly. Some of it cannot, and the gaps are named rather
+// than papered over:
+//
+//   - Index names are NOT schema-qualified. Real generated advice prints
+//     "public.join_dim_pkey"; text EXPLAIN only ever prints the bare
+//     index name, and the schema is not recoverable from it.
+//   - Relation identifiers carry no @plan_name subquery qualifier and no
+//     /schema.partition qualifier. Both come from planner internals that
+//     EXPLAIN does not print. Repeated aliases DO get 19's #occurrence
+//     numbering, which is recoverable.
+//   - DO_NOT_SCAN, PARTITIONWISE, SEMIJOIN_UNIQUE, SEMIJOIN_NON_UNIQUE
+//     and FOREIGN_JOIN are never emitted. They describe decisions that
+//     leave no distinguishable trace in plan text.
+//   - JOIN_ORDER's "{a b}" unordered-group syntax is never emitted; it
+//     marks joins whose sides are undefined, which is planner knowledge.
+//     Parenthesized groups for non-outer-deep trees ARE emitted, since
+//     tree shape is exactly what EXPLAIN shows.
+//
+// So: this is a COMPARISON KEY, dependable for telling whether two plans
+// of the same query are structurally the same. It is not a
+// round-trippable advice string — do not feed it to pg_plan_advice and
+// expect it to apply.
 func Advice(p *Plan) []AdviceLine {
 	if p == nil || p.Root == nil {
 		return nil
 	}
-	// Join order doubles as this package's canonical relation ordering:
-	// every other line orders its relations by first appearance here, so
-	// the whole block is deterministic for a given tree.
-	order := joinOrder(p.Root)
-	rank := make(map[string]int, len(order))
-	for i, rel := range order {
-		if _, seen := rank[rel]; !seen {
-			rank[rel] = i
-		}
-	}
-	byOrder := func(rels []string) []string {
-		out := dedupe(rels)
-		sort.SliceStable(out, func(i, j int) bool {
-			ri, oki := rank[out[i]]
-			rj, okj := rank[out[j]]
-			switch {
-			case oki && okj:
-				return ri < rj
-			case oki:
-				return true
-			case okj:
-				return false
-			}
-			return out[i] < out[j]
-		})
-		return out
+	names := newNamer()
+	rels := baseRelations(p.Root)
+	for _, n := range rels {
+		names.assign(n)
 	}
 
 	var lines []AdviceLine
-	if rels := dedupe(order); len(rels) > 0 {
-		lines = append(lines, AdviceLine{Kind: "JOIN_ORDER", Relations: rels})
+
+	// Emission order follows pgpa_output_advice(): join order, then join
+	// methods, then scans, then the gather decision.
+	if root := topJoin(p.Root); root != nil {
+		if s := joinOrderTerm(root, names); s != "" {
+			lines = append(lines, AdviceLine{Kind: "JOIN_ORDER", Args: []string{s}})
+		}
+	} else if len(rels) > 0 {
+		lines = append(lines, AdviceLine{Kind: "JOIN_ORDER", Args: names.namesOf(rels)})
 	}
 
-	for _, jm := range joinMethods(p.Root) {
-		lines = append(lines, AdviceLine{Kind: jm.kind, Relations: byOrder(jm.inner)})
+	for _, jm := range joinMethods(p.Root, names) {
+		lines = append(lines, AdviceLine{Kind: jm.kind, Args: jm.args})
+	}
+	for _, sm := range scanStrategies(p.Root, names) {
+		lines = append(lines, AdviceLine{Kind: sm.kind, Args: sm.args})
 	}
 
-	for _, sm := range scanMethods(p.Root) {
-		lines = append(lines, AdviceLine{Kind: sm.kind, Relations: byOrder(sm.rels)})
-	}
-
-	gather := "NO_GATHER"
-	if hasGather(p.Root) {
-		gather = "GATHER"
-	}
-	if rels := dedupe(order); len(rels) > 0 {
-		lines = append(lines, AdviceLine{Kind: gather, Relations: rels})
+	// GATHER/GATHER_MERGE name what runs in parallel; NO_GATHER names
+	// everything when nothing does.
+	gathered, gatherKind := gatherScans(p.Root, names)
+	if len(gathered) > 0 {
+		lines = append(lines, AdviceLine{Kind: gatherKind, Args: gathered})
+	} else if len(rels) > 0 {
+		lines = append(lines, AdviceLine{Kind: "NO_GATHER", Args: names.namesOf(rels)})
 	}
 	return lines
 }
 
-// AdviceLine is one line of the advice block: a decision kind and the
-// relations it applies to.
+// AdviceLine is one advice item: a tag applied to a list of targets.
 type AdviceLine struct {
-	Kind      string // "JOIN_ORDER", "HASH_JOIN", "SEQ_SCAN", "NO_GATHER", ...
-	Relations []string
+	Kind string   // "JOIN_ORDER", "HASH_JOIN", "SEQ_SCAN", "NO_GATHER", ...
+	Args []string // targets, already rendered (a group is one "(a b)" arg)
 }
 
 func (l AdviceLine) String() string {
-	return l.Kind + "(" + strings.Join(l.Relations, " ") + ")"
+	return l.Kind + "(" + strings.Join(l.Args, " ") + ")"
 }
 
-// AdviceString renders Advice as the multi-line block, one decision per
-// line, without a trailing newline.
+// AdviceString renders Advice as the multi-line block, one item per line,
+// without a trailing newline.
 func AdviceString(p *Plan) string {
 	lines := Advice(p)
 	out := make([]string, 0, len(lines))
@@ -119,54 +112,76 @@ func AdviceString(p *Plan) string {
 	return strings.Join(out, "\n")
 }
 
-// relName is how a base relation is named throughout the advice block:
-// its alias when the query gave it one, else the relation itself. The
-// alias is preferred because it is what distinguishes two scans of the
-// same table in a self-join — exactly the case where using the bare
-// relation name would collapse two different decisions into one.
-func relName(n *Node) string {
-	if n.Alias != "" {
-		return n.Alias
-	}
-	return n.Relation
+// namer assigns 19's relation identifiers. The README's general form is
+// alias#occurrence/schema.partition@plan; of those, alias and occurrence
+// are recoverable from plan text and the rest are not. Occurrence numbers
+// start at 1 and the first is omitted, so a self-join reads "foo foo#2".
+type namer struct {
+	seen  map[string]int
+	byPtr map[*Node]string
 }
 
-// isBaseRelation reports whether n reads a named relation, i.e. whether
-// it contributes a name to the advice block. Nodes with no relation of
-// their own (Sort, Hash, Aggregate, ...) never do.
+func newNamer() *namer {
+	return &namer{seen: map[string]int{}, byPtr: map[*Node]string{}}
+}
+
+func (nm *namer) assign(n *Node) string {
+	if s, ok := nm.byPtr[n]; ok {
+		return s
+	}
+	base := n.Relation
+	if n.Alias != "" {
+		base = n.Alias
+	}
+	nm.seen[base]++
+	s := base
+	if c := nm.seen[base]; c > 1 {
+		s = base + "#" + itoa(c)
+	}
+	nm.byPtr[n] = s
+	return s
+}
+
+func (nm *namer) nameOf(n *Node) string { return nm.byPtr[n] }
+
+func (nm *namer) namesOf(ns []*Node) []string {
+	out := make([]string, 0, len(ns))
+	for _, n := range ns {
+		if s := nm.byPtr[n]; s != "" {
+			out = append(out, s)
+		}
+	}
+	return out
+}
+
+func itoa(i int) string {
+	if i < 10 {
+		return string(rune('0' + i))
+	}
+	return itoa(i/10) + string(rune('0'+i%10))
+}
+
+// isBaseRelation reports whether n contributes a relation identifier.
 //
-// Bitmap Index Scan is the exception that has to be spelled out. It
-// prints as "Bitmap Index Scan on <index>", so the parser stores the
-// INDEX name in Relation — the only node type where that field is not a
-// relation at all. Left in, an index name shows up as a participant in
-// JOIN_ORDER, which is both wrong and confusing. The Bitmap Heap Scan
-// directly above it already contributes the real relation.
+// Bitmap Index Scan is excluded deliberately: it prints "on <index>", so
+// the parser stores an INDEX name in Relation — the only node type where
+// that field is not a relation. The Bitmap Heap Scan above it names the
+// real table, and 19's BITMAP_HEAP_SCAN tag takes no index argument.
 func isBaseRelation(n *Node) bool {
 	return n.Relation != "" && n.Type != "bitmap-index-scan"
 }
 
-// isJoin reports whether n is a join node.
-func isJoin(n *Node) bool {
-	switch n.Type {
-	case "hash-join", "nested-loop", "merge-join":
-		return true
-	}
-	return false
-}
-
-// joinOrder walks the tree outer-side-first, collecting base relations in
-// the order the joins bring them in. For the usual left-deep tree that
-// puts the driving relation first and each joined relation after it,
-// which is what 19's JOIN_ORDER line reports.
-func joinOrder(n *Node) []string {
-	var out []string
+// baseRelations lists the relation-bearing nodes in plan order (outer
+// side first), which is also the order 19 lists them in JOIN_ORDER.
+func baseRelations(n *Node) []*Node {
+	var out []*Node
 	var walk func(*Node)
 	walk = func(n *Node) {
 		if n == nil {
 			return
 		}
 		if isBaseRelation(n) {
-			out = append(out, relName(n))
+			out = append(out, n)
 		}
 		for _, c := range n.Children {
 			walk(c)
@@ -176,23 +191,139 @@ func joinOrder(n *Node) []string {
 	return out
 }
 
-type joinMethod struct {
-	kind  string
-	inner []string
+func isJoin(n *Node) bool {
+	switch n.Type {
+	case "hash-join", "nested-loop", "merge-join":
+		return true
+	}
+	return false
 }
 
-// joinMethods collects one entry per join node, naming the relations on
-// that join's INNER side — the side 19's HASH_JOIN(...)/MERGE_JOIN(...)
-// lines name. Deepest join first, so the ordering is stable regardless of
-// how the tree is nested.
-//
-// The inner side is read through whatever the join builds on it: a Hash
-// Join's inner child is the Hash node, not the scan under it, and a merge
-// join's inner side is routinely a Sort. Those wrappers carry no relation
-// of their own, so descending through them lands on the relations that
-// matter.
-func joinMethods(root *Node) []joinMethod {
-	var out []joinMethod
+// topJoin finds the outermost join node, the root of the join problem.
+func topJoin(n *Node) *Node {
+	if n == nil {
+		return nil
+	}
+	if isJoin(n) {
+		return n
+	}
+	for _, c := range n.Children {
+		if j := topJoin(c); j != nil {
+			return j
+		}
+	}
+	return nil
+}
+
+// joinOrderTerm renders a join subtree the way JOIN_ORDER wants it. The
+// canonical structure is an outer-deep tree, written flat: JOIN_ORDER(t1
+// t2 t3) means t1 is the driving table, joined to t2 and then to t3. A
+// subtree that is NOT outer-deep — a join on the inner side — is
+// parenthesized, per the README's JOIN_ORDER(t1 (t2 t3)).
+func joinOrderTerm(n *Node, names *namer) string {
+	parts := joinOrderParts(n, names)
+	return strings.Join(parts, " ")
+}
+
+func joinOrderParts(n *Node, names *namer) []string {
+	if n == nil {
+		return nil
+	}
+	if !isJoin(n) {
+		// A non-join node contributes whatever relations hang under it,
+		// in order; Sort/Hash/Aggregate wrappers are transparent here.
+		return names.namesOf(baseRelations(n))
+	}
+	if len(n.Children) < 2 {
+		return names.namesOf(baseRelations(n))
+	}
+	outer := joinOrderParts(n.Children[0], names)
+	innerNode := joinInner(n)
+	var inner []string
+	if innerNode != nil && isJoin(innerNode) {
+		// Inner-side join: a bushy tree, which gets its own parentheses.
+		inner = []string{"(" + joinOrderTerm(innerNode, names) + ")"}
+	} else {
+		inner = names.namesOf(baseRelations(n.Children[1]))
+	}
+	return append(outer, inner...)
+}
+
+// joinInner returns the node that really sits on a join's inner side,
+// seeing through the wrappers the executor puts there. pgpa_join.c does
+// the same descent: a Hash Join's inner child is always a Hash, a merge
+// join's inner is routinely Sort or Incremental Sort, and Material and
+// Memoize wrap the inner side of nested loops.
+func joinInner(n *Node) *Node {
+	if len(n.Children) < 2 {
+		return nil
+	}
+	cur := n.Children[1]
+	for cur != nil {
+		switch cur.Type {
+		case "hash", "sort", "incremental-sort", "materialize", "memoize":
+			if len(cur.Children) == 0 {
+				return cur
+			}
+			cur = cur.Children[0]
+			continue
+		}
+		return cur
+	}
+	return nil
+}
+
+// joinStrategy names the join method tag, making the same PLAIN /
+// MATERIALIZE / MEMOIZE distinction pgpa_join.c makes from the node
+// directly beneath the join on its inner side. Merge joins look past a
+// Sort first, since sorting the inner input is orthogonal to whether it
+// was also materialized.
+func joinStrategy(n *Node) string {
+	inner := (*Node)(nil)
+	if len(n.Children) >= 2 {
+		inner = n.Children[1]
+	}
+	switch n.Type {
+	case "hash-join":
+		return "HASH_JOIN"
+	case "merge-join":
+		for inner != nil && (inner.Type == "sort" || inner.Type == "incremental-sort") {
+			if len(inner.Children) == 0 {
+				break
+			}
+			inner = inner.Children[0]
+		}
+		if inner != nil && inner.Type == "materialize" {
+			return "MERGE_JOIN_MATERIALIZE"
+		}
+		return "MERGE_JOIN_PLAIN"
+	case "nested-loop":
+		if inner != nil {
+			switch inner.Type {
+			case "materialize":
+				return "NESTED_LOOP_MATERIALIZE"
+			case "memoize":
+				return "NESTED_LOOP_MEMOIZE"
+			}
+		}
+		return "NESTED_LOOP_PLAIN"
+	}
+	return ""
+}
+
+type strategyLine struct {
+	kind string
+	args []string
+}
+
+// joinMethods emits one advice item per join method used, naming what
+// sits on each join's INNER side. Per the README: for an N-table join
+// problem there are N-1 join-method items, and the outermost table needs
+// none, because a method tag says "this belongs on the inner side of a
+// join of this kind".
+func joinMethods(root *Node, names *namer) []strategyLine {
+	var out []strategyLine
+	idx := map[string]int{}
 	var walk func(*Node)
 	walk = func(n *Node) {
 		if n == nil {
@@ -204,73 +335,63 @@ func joinMethods(root *Node) []joinMethod {
 		if !isJoin(n) || len(n.Children) < 2 {
 			return
 		}
-		kind := ""
-		switch n.Type {
-		case "hash-join":
-			kind = "HASH_JOIN"
-		case "nested-loop":
-			kind = "NESTED_LOOP"
-		case "merge-join":
-			kind = "MERGE_JOIN"
-		}
-		inner := joinOrder(n.Children[1])
-		if len(inner) == 0 {
+		kind := joinStrategy(n)
+		if kind == "" {
 			return
 		}
-		out = append(out, joinMethod{kind: kind, inner: inner})
+		innerRels := baseRelations(n.Children[1])
+		if len(innerRels) == 0 {
+			return
+		}
+		var arg string
+		if inner := joinInner(n); inner != nil && isJoin(inner) {
+			// The inner side is itself a join: one grouped target, as in
+			// the README's NESTED_LOOP_PLAIN(x (y z)).
+			arg = "(" + strings.Join(names.namesOf(innerRels), " ") + ")"
+		} else {
+			arg = strings.Join(names.namesOf(innerRels), " ")
+		}
+		if arg == "" {
+			return
+		}
+		if i, ok := idx[kind]; ok {
+			out[i].args = append(out[i].args, arg)
+			return
+		}
+		idx[kind] = len(out)
+		out = append(out, strategyLine{kind: kind, args: []string{arg}})
 	}
 	walk(root)
+	return out
+}
 
-	// Merge entries sharing a kind into one line, as 19 does: two hash
-	// joins in one plan produce a single HASH_JOIN(...) naming both inner
-	// sides, not two lines.
-	var merged []joinMethod
-	idx := map[string]int{}
-	for _, jm := range out {
-		if i, ok := idx[jm.kind]; ok {
-			merged[i].inner = append(merged[i].inner, jm.inner...)
-			continue
-		}
-		idx[jm.kind] = len(merged)
-		merged = append(merged, jm)
+// scanTag maps a parsed node type to 19's scan advice tag. The list is
+// deliberately short and matches pgpa_ast.c: most scan types get no
+// advice at all, because there is only one way to perform them. A
+// subquery is always scanned with a subquery scan, so there is nothing
+// to advise.
+func scanTag(typ string) string {
+	switch typ {
+	case "seq-scan":
+		return "SEQ_SCAN"
+	case "index-scan":
+		return "INDEX_SCAN"
+	case "index-only-scan":
+		return "INDEX_ONLY_SCAN"
+	case "bitmap-heap-scan":
+		return "BITMAP_HEAP_SCAN"
+	case "tid-scan":
+		return "TID_SCAN"
 	}
-	return merged
+	return ""
 }
 
-type scanMethod struct {
-	kind string
-	rels []string
-}
-
-// scanMethodKind maps a parsed node type to its advice keyword. Only node
-// types that actually read a relation appear; anything else returns "".
-var scanMethodKind = map[string]string{
-	"seq-scan":              "SEQ_SCAN",
-	"index-scan":            "INDEX_SCAN",
-	"index-only-scan":       "INDEX_ONLY_SCAN",
-	"bitmap-heap-scan":      "BITMAP_HEAP_SCAN",
-	"tid-scan":              "TID_SCAN",
-	"tid-range-scan":        "TID_RANGE_SCAN",
-	"sample-scan":           "SAMPLE_SCAN",
-	"foreign-scan":          "FOREIGN_SCAN",
-	"custom-scan":           "CUSTOM_SCAN",
-	"function-scan":         "FUNCTION_SCAN",
-	"table-function-scan":   "TABLE_FUNCTION_SCAN",
-	"values-scan":           "VALUES_SCAN",
-	"subquery-scan":         "SUBQUERY_SCAN",
-	"cte-scan":              "CTE_SCAN",
-	"worktable-scan":        "WORKTABLE_SCAN",
-	"named-tuplestore-scan": "NAMED_TUPLESTORE_SCAN",
-}
-
-// scanMethods groups base relations by how they are read, one line per
-// access method, in first-appearance order of the method itself.
-//
-// Bitmap Index Scan is deliberately absent: it names the index, and the
-// Bitmap Heap Scan above it already names the relation, so counting both
-// would name the same access path twice.
-func scanMethods(root *Node) []scanMethod {
-	var out []scanMethod
+// scanStrategies groups relations by how they are read. Index and
+// index-only scans name the index as well as the relation, in
+// relation/index pairs — INDEX_SCAN(foo foo_a_idx bar bar_b_idx) — while
+// bitmap heap scans take no index, matching the README.
+func scanStrategies(root *Node, names *namer) []strategyLine {
+	var out []strategyLine
 	idx := map[string]int{}
 	var walk func(*Node)
 	walk = func(n *Node) {
@@ -278,14 +399,17 @@ func scanMethods(root *Node) []scanMethod {
 			return
 		}
 		if isBaseRelation(n) {
-			if kind, ok := scanMethodKind[n.Type]; ok {
-				i, seen := idx[kind]
-				if !seen {
+			if tag := scanTag(n.Type); tag != "" {
+				i, ok := idx[tag]
+				if !ok {
 					i = len(out)
-					idx[kind] = i
-					out = append(out, scanMethod{kind: kind})
+					idx[tag] = i
+					out = append(out, strategyLine{kind: tag})
 				}
-				out[i].rels = append(out[i].rels, relName(n))
+				out[i].args = append(out[i].args, names.nameOf(n))
+				if n.Index != "" && (tag == "INDEX_SCAN" || tag == "INDEX_ONLY_SCAN") {
+					out[i].args = append(out[i].args, n.Index)
+				}
 			}
 		}
 		for _, c := range n.Children {
@@ -296,33 +420,35 @@ func scanMethods(root *Node) []scanMethod {
 	return out
 }
 
-// hasGather reports whether any part of the plan runs in parallel, which
-// decides between the GATHER and NO_GATHER lines.
-func hasGather(n *Node) bool {
-	if n == nil {
-		return false
-	}
-	if n.Type == "gather" || n.Type == "gather-merge" {
-		return true
-	}
-	for _, c := range n.Children {
-		if hasGather(c) {
-			return true
+// gatherScans reports what runs in parallel. A Gather covering a join
+// product is one grouped target — 19 prints GATHER((f d)) — while
+// separate Gathers over separate relations print as GATHER(f d).
+func gatherScans(root *Node, names *namer) ([]string, string) {
+	var args []string
+	kind := "GATHER"
+	var walk func(*Node)
+	walk = func(n *Node) {
+		if n == nil {
+			return
+		}
+		if n.Type == "gather" || n.Type == "gather-merge" {
+			if n.Type == "gather-merge" {
+				kind = "GATHER_MERGE"
+			}
+			rels := names.namesOf(baseRelations(n))
+			switch {
+			case len(rels) == 0:
+			case len(rels) == 1:
+				args = append(args, rels[0])
+			default:
+				args = append(args, "("+strings.Join(rels, " ")+")")
+			}
+			return
+		}
+		for _, c := range n.Children {
+			walk(c)
 		}
 	}
-	return false
-}
-
-// dedupe removes repeats while keeping first-appearance order.
-func dedupe(in []string) []string {
-	seen := make(map[string]bool, len(in))
-	out := make([]string, 0, len(in))
-	for _, s := range in {
-		if s == "" || seen[s] {
-			continue
-		}
-		seen[s] = true
-		out = append(out, s)
-	}
-	return out
+	walk(root)
+	return args, kind
 }

--- a/explain/advice_pg19_test.go
+++ b/explain/advice_pg19_test.go
@@ -1,0 +1,228 @@
+package explain
+
+import "testing"
+
+// The cases below are lifted verbatim from PostgreSQL's own regression
+// output for contrib/pg_plan_advice — contrib/pg_plan_advice/expected/*.out.
+// Each pairs a real plan with the advice PostgreSQL 19 itself generated
+// for it, which makes them the only fixtures that can actually settle
+// whether this package agrees with the server.
+//
+// Where "want" differs from what 19 printed, the difference is stated on
+// the case. There is exactly one such difference, and it is structural
+// rather than a bug: 19 schema-qualifies index names (public.foo_pkey)
+// because the planner knows the schema, while text EXPLAIN prints the
+// bare index name and the schema is simply not in the input.
+func TestAdviceAgainstPostgres19Fixtures(t *testing.T) {
+	cases := []struct {
+		name string
+		plan string
+		want string
+		note string
+	}{
+		{
+			name: "hash join, expected/join_strategy.out",
+			plan: ` Hash Join
+   Hash Cond: (f.dim_id = d.id)
+   ->  Seq Scan on join_fact f
+   ->  Hash
+         ->  Seq Scan on join_dim d
+`,
+			want: "JOIN_ORDER(f d)\nHASH_JOIN(d)\nSEQ_SCAN(f d)\nNO_GATHER(f d)",
+		},
+		{
+			name: "merge join plain, expected/join_strategy.out",
+			plan: ` Merge Join
+   Merge Cond: (f.dim_id = d.id)
+   ->  Index Scan using join_fact_dim_id on join_fact f
+   ->  Index Scan using join_dim_pkey on join_dim d
+`,
+			want: "JOIN_ORDER(f d)\nMERGE_JOIN_PLAIN(d)\n" +
+				"INDEX_SCAN(f join_fact_dim_id d join_dim_pkey)\nNO_GATHER(f d)",
+			note: "19 prints INDEX_SCAN(f public.join_fact_dim_id d public.join_dim_pkey); " +
+				"text EXPLAIN carries no schema, so ours is unqualified",
+		},
+		{
+			name: "nested loop materialize, expected/join_strategy.out",
+			plan: ` Nested Loop
+   Join Filter: (f.dim_id = d.id)
+   ->  Seq Scan on join_fact f
+   ->  Materialize
+         ->  Seq Scan on join_dim d
+`,
+			want: "JOIN_ORDER(f d)\nNESTED_LOOP_MATERIALIZE(d)\nSEQ_SCAN(f d)\nNO_GATHER(f d)",
+		},
+		{
+			name: "nested loop memoize, expected/join_strategy.out",
+			plan: ` Nested Loop
+   ->  Seq Scan on join_fact f
+   ->  Memoize
+         Cache Key: f.dim_id
+         ->  Index Scan using join_dim_pkey on join_dim d
+               Index Cond: (id = f.dim_id)
+`,
+			want: "JOIN_ORDER(f d)\nNESTED_LOOP_MEMOIZE(d)\nSEQ_SCAN(f)\n" +
+				"INDEX_SCAN(d join_dim_pkey)\nNO_GATHER(f d)",
+			note: "19 schema-qualifies the index name; note the two scan " +
+				"lines, one per access method, in first-appearance order",
+		},
+		{
+			name: "seq scan, expected/scan.out",
+			plan: ` Seq Scan on scan_table
+`,
+			want: "JOIN_ORDER(scan_table)\nSEQ_SCAN(scan_table)\nNO_GATHER(scan_table)",
+			note: "19 emits no JOIN_ORDER for a single-relation query; " +
+				"we always name the relation set, which diffs the same way",
+		},
+		{
+			name: "index scan, expected/scan.out",
+			plan: ` Index Scan using scan_table_pkey on scan_table
+   Index Cond: (a = 1)
+`,
+			want: "JOIN_ORDER(scan_table)\nINDEX_SCAN(scan_table scan_table_pkey)\n" +
+				"NO_GATHER(scan_table)",
+			note: "19: INDEX_SCAN(scan_table public.scan_table_pkey), no JOIN_ORDER",
+		},
+		{
+			name: "index only scan, expected/scan.out",
+			plan: ` Index Only Scan using scan_table_pkey on scan_table
+   Index Cond: (a = 1)
+`,
+			want: "JOIN_ORDER(scan_table)\nINDEX_ONLY_SCAN(scan_table scan_table_pkey)\n" +
+				"NO_GATHER(scan_table)",
+			note: "19: INDEX_ONLY_SCAN(scan_table public.scan_table_pkey), no JOIN_ORDER",
+		},
+		{
+			name: "bitmap heap scan takes no index, expected/scan.out",
+			plan: ` Bitmap Heap Scan on scan_table
+   Recheck Cond: (b > 'some text 8'::text)
+   ->  Bitmap Index Scan on scan_table_b
+         Index Cond: (b > 'some text 8'::text)
+`,
+			want: "JOIN_ORDER(scan_table)\nBITMAP_HEAP_SCAN(scan_table)\nNO_GATHER(scan_table)",
+			note: "the Bitmap Index Scan's index must NOT appear: 19's " +
+				"BITMAP_HEAP_SCAN takes no index argument",
+		},
+		{
+			name: "tid scan, expected/scan.out",
+			plan: ` Tid Scan on scan_table
+   TID Cond: (ctid = '(0,1)'::tid)
+`,
+			want: "JOIN_ORDER(scan_table)\nTID_SCAN(scan_table)\nNO_GATHER(scan_table)",
+			note: "19 emits no JOIN_ORDER for a single relation",
+		},
+		{
+			name: "gather over a join product, expected/gather.out",
+			plan: ` Gather
+   Workers Planned: 2
+   ->  Hash Join
+         Hash Cond: (f.dim_id = d.id)
+         ->  Parallel Seq Scan on gt_fact f
+         ->  Hash
+               ->  Parallel Seq Scan on gt_dim d
+`,
+			want: "JOIN_ORDER(f d)\nHASH_JOIN(d)\nSEQ_SCAN(f d)\nGATHER((f d))",
+			note: "matches 19 exactly, including the grouped GATHER((f d))",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			plan, err := Parse(tc.plan)
+			if err != nil {
+				t.Fatal(err)
+			}
+			got := AdviceString(plan)
+			if got != tc.want {
+				t.Errorf("advice mismatch\n got:\n%s\nwant:\n%s", got, tc.want)
+				if tc.note != "" {
+					t.Logf("note: %s", tc.note)
+				}
+			}
+		})
+	}
+}
+
+// Repeated aliases get 19's #occurrence numbering (README, "Relation
+// Identifiers"): the first occurrence is bare, later ones carry #N. This
+// is the one part of 19's identifier syntax that IS recoverable from
+// plan text, and without it a self-join collapses two distinct relations
+// into one name.
+func TestAdviceNumbersRepeatedAliases(t *testing.T) {
+	plan, err := Parse(` Hash Join
+   Hash Cond: (a.id = b.id)
+   ->  Seq Scan on t a
+   ->  Hash
+         ->  Seq Scan on t a
+`)
+	if err != nil {
+		t.Fatal(err)
+	}
+	got := AdviceString(plan)
+	want := "JOIN_ORDER(a a#2)\nHASH_JOIN(a#2)\nSEQ_SCAN(a a#2)\nNO_GATHER(a a#2)"
+	if got != want {
+		t.Fatalf("advice = %q, want %q", got, want)
+	}
+}
+
+// A join on the inner side is a bushy tree, which JOIN_ORDER parenthesizes
+// per the README's JOIN_ORDER(t1 (t2 t3)); the join-method tag names the
+// same group.
+func TestAdviceParenthesizesBushyTree(t *testing.T) {
+	plan, err := Parse(` Nested Loop
+   ->  Seq Scan on t1
+   ->  Hash Join
+         Hash Cond: (t2.id = t3.id)
+         ->  Seq Scan on t2
+         ->  Hash
+               ->  Seq Scan on t3
+`)
+	if err != nil {
+		t.Fatal(err)
+	}
+	got := AdviceString(plan)
+	want := "JOIN_ORDER(t1 (t2 t3))\n" +
+		"HASH_JOIN(t3)\n" +
+		"NESTED_LOOP_PLAIN((t2 t3))\n" +
+		"SEQ_SCAN(t1 t2 t3)\n" +
+		"NO_GATHER(t1 t2 t3)"
+	if got != want {
+		t.Fatalf("advice = %q, want %q", got, want)
+	}
+}
+
+// Gather Merge is its own tag in 19, not a spelling of GATHER.
+func TestAdviceGatherMergeIsItsOwnTag(t *testing.T) {
+	plan, err := Parse(` Gather Merge
+   Workers Planned: 2
+   ->  Sort
+         Sort Key: f.id
+         ->  Parallel Seq Scan on gt_fact f
+`)
+	if err != nil {
+		t.Fatal(err)
+	}
+	got := AdviceString(plan)
+	want := "JOIN_ORDER(f)\nSEQ_SCAN(f)\nGATHER_MERGE(f)"
+	if got != want {
+		t.Fatalf("advice = %q, want %q", got, want)
+	}
+}
+
+// Scan types outside 19's vocabulary get no scan advice at all. A
+// subquery is always read with a subquery scan, so there is nothing to
+// advise; emitting a made-up SUBQUERY_SCAN tag would be inventing
+// vocabulary the server does not have.
+func TestAdviceEmitsNoTagForUnadvisableScans(t *testing.T) {
+	plan, err := Parse(` Function Scan on generate_series g
+`)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, l := range Advice(plan) {
+		switch l.Kind {
+		case "FUNCTION_SCAN", "SUBQUERY_SCAN", "VALUES_SCAN", "CTE_SCAN":
+			t.Fatalf("emitted invented tag %q", l.Kind)
+		}
+	}
+}

--- a/explain/advice_test.go
+++ b/explain/advice_test.go
@@ -54,8 +54,8 @@ func TestAdviceMergeJoinThroughSortAndAliases(t *testing.T) {
 	}
 	got := AdviceString(plan)
 	want := "JOIN_ORDER(d res)\n" +
-		"MERGE_JOIN(res)\n" +
-		"INDEX_SCAN(d)\n" +
+		"MERGE_JOIN_PLAIN(res)\n" +
+		"INDEX_SCAN(d idx_49514_primary)\n" +
 		"SEQ_SCAN(res)\n" +
 		"NO_GATHER(d res)"
 	if got != want {
@@ -118,7 +118,7 @@ func TestAdviceDetectsScanMethodChange(t *testing.T) {
 	if wantB := "JOIN_ORDER(drivers)\nSEQ_SCAN(drivers)\nNO_GATHER(drivers)"; gotB != wantB {
 		t.Fatalf("before advice = %q, want %q", gotB, wantB)
 	}
-	if wantA := "JOIN_ORDER(drivers)\nINDEX_SCAN(drivers)\nNO_GATHER(drivers)"; gotA != wantA {
+	if wantA := "JOIN_ORDER(drivers)\nINDEX_SCAN(drivers drivers_nationality)\nNO_GATHER(drivers)"; gotA != wantA {
 		t.Fatalf("after advice = %q, want %q", gotA, wantA)
 	}
 }

--- a/explain/advice_test.go
+++ b/explain/advice_test.go
@@ -1,0 +1,171 @@
+package explain
+
+import "testing"
+
+// articlePlan is the plan PostgreSQL 19 itself reported advice for, in
+// "Plan Advice in PostgreSQL 19" — three F1 tables, hash-joined, no
+// parallelism, printed exactly as EXPLAIN (COSTS OFF, PLAN_ADVICE) gives
+// it. Reproducing 19's own answer from this, on any version, is the whole
+// claim this file exists to check.
+const articlePlan = `                        QUERY PLAN
+----------------------------------------------------------
+ HashAggregate
+   Group Key: drivers.surname
+   ->  Hash Join
+         Hash Cond: (results.driverid = drivers.driverid)
+         ->  Hash Join
+               Hash Cond: (results.raceid = races.raceid)
+               ->  Seq Scan on results
+               ->  Hash
+                     ->  Seq Scan on races
+                           Filter: (year = 2017)
+         ->  Hash
+               ->  Seq Scan on drivers
+`
+
+// PostgreSQL 19 reported exactly this for the plan above:
+//
+//	JOIN_ORDER(results races drivers)
+//	HASH_JOIN(races drivers)
+//	SEQ_SCAN(results races drivers)
+//	NO_GATHER(results races drivers)
+func TestAdviceMatchesPostgres19Output(t *testing.T) {
+	plan, err := Parse(articlePlan)
+	if err != nil {
+		t.Fatal(err)
+	}
+	got := AdviceString(plan)
+	want := "JOIN_ORDER(results races drivers)\n" +
+		"HASH_JOIN(races drivers)\n" +
+		"SEQ_SCAN(results races drivers)\n" +
+		"NO_GATHER(results races drivers)"
+	if got != want {
+		t.Fatalf("advice mismatch\n got:\n%s\nwant:\n%s", got, want)
+	}
+}
+
+// A merge join with an index scan on one side and a sorted seq scan on
+// the other: exercises reading the inner side through a Sort, and the
+// alias-over-relation naming rule.
+func TestAdviceMergeJoinThroughSortAndAliases(t *testing.T) {
+	plan, err := Parse(analyzePlan)
+	if err != nil {
+		t.Fatal(err)
+	}
+	got := AdviceString(plan)
+	want := "JOIN_ORDER(d res)\n" +
+		"MERGE_JOIN(res)\n" +
+		"INDEX_SCAN(d)\n" +
+		"SEQ_SCAN(res)\n" +
+		"NO_GATHER(d res)"
+	if got != want {
+		t.Fatalf("advice mismatch\n got:\n%s\nwant:\n%s", got, want)
+	}
+}
+
+// The structural claim the whole thing rests on: same shape, different
+// numbers, identical advice. Costs and timings move constantly between
+// runs; if they leaked into the advice it would be useless as a
+// comparison key.
+func TestAdviceIgnoresCostsAndTimings(t *testing.T) {
+	fast := ` Hash Join  (cost=1.00..2.00 rows=1 width=8) (actual time=0.001..0.002 rows=1 loops=1)
+   Hash Cond: (a.id = b.id)
+   ->  Seq Scan on alpha a  (cost=0.00..1.00 rows=1 width=4) (actual time=0.001..0.001 rows=1 loops=1)
+   ->  Hash  (cost=1.00..1.00 rows=1 width=4) (actual time=0.001..0.001 rows=1 loops=1)
+         ->  Seq Scan on beta b  (cost=0.00..1.00 rows=1 width=4) (actual time=0.001..0.001 rows=1 loops=1)
+`
+	slow := ` Hash Join  (cost=9999.00..99999.00 rows=500000 width=8) (actual time=812.400..9999.999 rows=500000 loops=1)
+   Hash Cond: (a.id = b.id)
+   ->  Seq Scan on alpha a  (cost=0.00..44444.00 rows=500000 width=4) (actual time=0.900..500.100 rows=500000 loops=1)
+   ->  Hash  (cost=4444.00..4444.00 rows=250000 width=4) (actual time=700.000..700.000 rows=250000 loops=1)
+         ->  Seq Scan on beta b  (cost=0.00..4444.00 rows=250000 width=4) (actual time=0.500..300.000 rows=250000 loops=1)
+`
+	pf, err := Parse(fast)
+	if err != nil {
+		t.Fatal(err)
+	}
+	ps, err := Parse(slow)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if a, b := AdviceString(pf), AdviceString(ps); a != b {
+		t.Fatalf("same shape gave different advice:\n%s\n---\n%s", a, b)
+	}
+}
+
+// The converse: a genuine structural change must show up. A Seq Scan
+// becoming an Index Scan is the single most common "what changed?" and
+// the advice has to say so.
+func TestAdviceDetectsScanMethodChange(t *testing.T) {
+	before := ` Seq Scan on drivers  (cost=0.00..30.40 rows=1 width=15)
+   Filter: (nationality = 'British'::text)
+`
+	after := ` Index Scan using drivers_nationality on drivers  (cost=0.28..8.30 rows=1 width=15)
+   Index Cond: (nationality = 'British'::text)
+`
+	pb, err := Parse(before)
+	if err != nil {
+		t.Fatal(err)
+	}
+	pa, err := Parse(after)
+	if err != nil {
+		t.Fatal(err)
+	}
+	gotB, gotA := AdviceString(pb), AdviceString(pa)
+	if gotB == gotA {
+		t.Fatal("scan method change produced identical advice")
+	}
+	if wantB := "JOIN_ORDER(drivers)\nSEQ_SCAN(drivers)\nNO_GATHER(drivers)"; gotB != wantB {
+		t.Fatalf("before advice = %q, want %q", gotB, wantB)
+	}
+	if wantA := "JOIN_ORDER(drivers)\nINDEX_SCAN(drivers)\nNO_GATHER(drivers)"; gotA != wantA {
+		t.Fatalf("after advice = %q, want %q", gotA, wantA)
+	}
+}
+
+// Parallelism is one of the four decisions the format reports, so a
+// Gather in the tree has to flip the last line.
+func TestAdviceReportsGather(t *testing.T) {
+	parallel := ` Gather  (cost=1000.00..2000.00 rows=100 width=8)
+   Workers Planned: 2
+   ->  Parallel Seq Scan on results  (cost=0.00..990.00 rows=42 width=8)
+`
+	plan, err := Parse(parallel)
+	if err != nil {
+		t.Fatal(err)
+	}
+	got := AdviceString(plan)
+	want := "JOIN_ORDER(results)\nSEQ_SCAN(results)\nGATHER(results)"
+	if got != want {
+		t.Fatalf("advice = %q, want %q", got, want)
+	}
+}
+
+// A Bitmap Index Scan prints "on <index>", so the parser stores an index
+// name where every other node stores a relation. It must not turn up as a
+// participant in JOIN_ORDER — the Bitmap Heap Scan above it is the one
+// that names the actual table.
+func TestAdviceExcludesBitmapIndexName(t *testing.T) {
+	plan, err := Parse(` Bitmap Heap Scan on cards  (cost=18.91..1006.04 rows=346 width=32)
+   Recheck Cond: (data @> '{"rarity": "Mythic Rare"}'::jsonb)
+   ->  Bitmap Index Scan on cards_data_path_ops  (cost=0.00..18.82 rows=346 width=0)
+         Index Cond: (data @> '{"rarity": "Mythic Rare"}'::jsonb)
+`)
+	if err != nil {
+		t.Fatal(err)
+	}
+	got := AdviceString(plan)
+	want := "JOIN_ORDER(cards)\nBITMAP_HEAP_SCAN(cards)\nNO_GATHER(cards)"
+	if got != want {
+		t.Fatalf("advice = %q, want %q", got, want)
+	}
+}
+
+func TestAdviceOnNilPlanIsEmpty(t *testing.T) {
+	if got := Advice(nil); got != nil {
+		t.Fatalf("Advice(nil) = %v, want nil", got)
+	}
+	if got := AdviceString(&Plan{}); got != "" {
+		t.Fatalf("AdviceString(empty) = %q, want empty", got)
+	}
+}

--- a/explain/diff.go
+++ b/explain/diff.go
@@ -1,0 +1,159 @@
+package explain
+
+import (
+	"fmt"
+	"strings"
+)
+
+// Diff compares two plans of the same query and reports what changed.
+//
+// The problem it solves is that a plain diff of two EXPLAIN outputs is
+// useless: every line carries a cost or a timing, so every line differs,
+// and the one structural change that actually explains the difference is
+// buried in numeric noise. pganalyze, who ship the only comparable tool,
+// describe the same difficulty — node alignment between two differently
+// shaped trees is the hard part, and standard diff output is dominated by
+// cost and timing variation.
+//
+// The way out is to compare the ADVICE rather than the plan text. Advice
+// names the planner's decisions and mentions no numbers at all, so two
+// runs of the same plan produce identical advice while any real
+// structural change shows up as a changed line. That sidesteps node
+// alignment entirely: advice is keyed by tag, not by position in a tree.
+//
+// Numbers are still reported, separately and clearly labelled, because
+// "did it get faster?" is the other half of the question. They are never
+// mixed into the structural comparison.
+type Diff struct {
+	Structural []AdviceChange // structural differences, empty when the shape held
+	Before     *Plan
+	After      *Plan
+}
+
+// AdviceChange is one structural difference: an advice tag whose targets
+// changed, appeared, or went away.
+type AdviceChange struct {
+	Kind   string // the advice tag
+	Before string // rendered line before, "" when the tag was absent
+	After  string // rendered line after, "" when the tag went away
+}
+
+// SameStructure reports whether the planner made the same decisions in
+// both plans. When true, any difference between the two runs is numeric.
+func (d *Diff) SameStructure() bool { return len(d.Structural) == 0 }
+
+// DiffPlans compares two plans. Either may be nil, which is reported as a
+// wholesale appearance or disappearance rather than treated as an error.
+func DiffPlans(before, after *Plan) *Diff {
+	d := &Diff{Before: before, After: after}
+
+	type entry struct{ before, after string }
+	// Insertion-ordered so the report follows advice emission order —
+	// join order first, then methods, then scans, then parallelism —
+	// which reads as most-structural-first.
+	var order []string
+	seen := map[string]*entry{}
+	take := func(lines []AdviceLine, isAfter bool) {
+		for _, l := range lines {
+			e, ok := seen[l.Kind]
+			if !ok {
+				e = &entry{}
+				seen[l.Kind] = e
+				order = append(order, l.Kind)
+			}
+			if isAfter {
+				e.after = l.String()
+			} else {
+				e.before = l.String()
+			}
+		}
+	}
+	take(Advice(before), false)
+	take(Advice(after), true)
+
+	for _, kind := range order {
+		e := seen[kind]
+		if e.before != e.after {
+			d.Structural = append(d.Structural, AdviceChange{
+				Kind: kind, Before: e.before, After: e.after,
+			})
+		}
+	}
+	return d
+}
+
+// String renders the diff for a terminal.
+func (d *Diff) String() string {
+	var b strings.Builder
+
+	if d.SameStructure() {
+		b.WriteString("structure unchanged — the planner made the same decisions\n")
+	} else {
+		fmt.Fprintf(&b, "STRUCTURE (%s)\n", plural(len(d.Structural), "change", "changes"))
+		for _, c := range d.Structural {
+			if c.Before != "" {
+				fmt.Fprintf(&b, "  - %s\n", c.Before)
+			}
+			if c.After != "" {
+				fmt.Fprintf(&b, "  + %s\n", c.After)
+			}
+		}
+	}
+
+	var nums []string
+	if s := deltaMS("execution time", execTime(d.Before), execTime(d.After)); s != "" {
+		nums = append(nums, s)
+	}
+	if s := deltaMS("planning time", planTime(d.Before), planTime(d.After)); s != "" {
+		nums = append(nums, s)
+	}
+	if len(nums) > 0 {
+		b.WriteString("\nNUMBERS\n")
+		for _, n := range nums {
+			fmt.Fprintf(&b, "  %s\n", n)
+		}
+	}
+	return b.String()
+}
+
+func execTime(p *Plan) *float64 {
+	if p == nil {
+		return nil
+	}
+	return p.ExecutionTime
+}
+
+func planTime(p *Plan) *float64 {
+	if p == nil {
+		return nil
+	}
+	return p.PlanningTime
+}
+
+// deltaMS renders one millisecond comparison, with the percentage change
+// that is usually the only part anyone reads. Returns "" when either side
+// is missing, since EXPLAIN without ANALYZE reports no timings and an
+// invented zero would read as a catastrophic regression.
+func deltaMS(label string, before, after *float64) string {
+	if before == nil || after == nil {
+		return ""
+	}
+	b, a := *before, *after
+	s := fmt.Sprintf("%-15s %9.3f ms → %9.3f ms", label, b, a)
+	if b > 0 {
+		pct := (a - b) / b * 100
+		sign := "+"
+		if pct < 0 {
+			sign = ""
+		}
+		s += fmt.Sprintf("   (%s%.1f%%)", sign, pct)
+	}
+	return s
+}
+
+func plural(n int, one, many string) string {
+	if n == 1 {
+		return fmt.Sprintf("%d %s", n, one)
+	}
+	return fmt.Sprintf("%d %s", n, many)
+}

--- a/explain/diff_test.go
+++ b/explain/diff_test.go
@@ -1,0 +1,136 @@
+package explain
+
+import (
+	"strings"
+	"testing"
+)
+
+// The headline case the tool exists for: a Seq Scan became an Index Scan
+// and the query got much faster. One structural change, reported on its
+// own, with the timings kept separate.
+func TestDiffReportsScanMethodChange(t *testing.T) {
+	before := mustParse(t, ` Seq Scan on drivers  (cost=0.00..30.40 rows=1 width=15) (actual time=0.010..340.100 rows=1 loops=1)
+   Filter: (nationality = 'British'::text)
+   Rows Removed by Filter: 678
+ Planning Time: 0.120 ms
+ Execution Time: 340.114 ms
+`)
+	after := mustParse(t, ` Index Scan using drivers_nationality on drivers  (cost=0.28..8.30 rows=1 width=15) (actual time=0.020..3.900 rows=1 loops=1)
+   Index Cond: (nationality = 'British'::text)
+ Planning Time: 0.200 ms
+ Execution Time: 4.002 ms
+`)
+
+	d := DiffPlans(before, after)
+	if d.SameStructure() {
+		t.Fatal("expected a structural change")
+	}
+	got := d.String()
+	for _, want := range []string{
+		"- SEQ_SCAN(drivers)",
+		"+ INDEX_SCAN(drivers drivers_nationality)",
+		"execution time",
+		"-98.8%",
+	} {
+		if !strings.Contains(got, want) {
+			t.Errorf("diff missing %q:\n%s", want, got)
+		}
+	}
+}
+
+// The other half of the contract: when only the numbers moved, say so and
+// do not manufacture a structural difference out of cost jitter.
+func TestDiffSameStructureDifferentNumbers(t *testing.T) {
+	before := mustParse(t, ` Hash Join  (cost=1.00..2.00 rows=1 width=8) (actual time=0.001..0.002 rows=1 loops=1)
+   Hash Cond: (a.id = b.id)
+   ->  Seq Scan on alpha a  (cost=0.00..1.00 rows=1 width=4) (actual time=0.001..0.001 rows=1 loops=1)
+   ->  Hash  (cost=1.00..1.00 rows=1 width=4) (actual time=0.001..0.001 rows=1 loops=1)
+         ->  Seq Scan on beta b  (cost=0.00..1.00 rows=1 width=4) (actual time=0.001..0.001 rows=1 loops=1)
+ Execution Time: 10.000 ms
+`)
+	after := mustParse(t, ` Hash Join  (cost=9999.00..99999.00 rows=500000 width=8) (actual time=812.400..9999.999 rows=500000 loops=1)
+   Hash Cond: (a.id = b.id)
+   ->  Seq Scan on alpha a  (cost=0.00..44444.00 rows=500000 width=4) (actual time=0.900..500.100 rows=500000 loops=1)
+   ->  Hash  (cost=4444.00..4444.00 rows=250000 width=4) (actual time=700.000..700.000 rows=250000 loops=1)
+         ->  Seq Scan on beta b  (cost=0.00..4444.00 rows=250000 width=4) (actual time=0.500..300.000 rows=250000 loops=1)
+ Execution Time: 20.000 ms
+`)
+
+	d := DiffPlans(before, after)
+	if !d.SameStructure() {
+		t.Fatalf("expected no structural change, got %+v", d.Structural)
+	}
+	got := d.String()
+	if !strings.Contains(got, "structure unchanged") {
+		t.Errorf("expected 'structure unchanged':\n%s", got)
+	}
+	if !strings.Contains(got, "+100.0%") {
+		t.Errorf("expected the timing regression to be reported:\n%s", got)
+	}
+}
+
+// A join method changing is a structural change even when nothing else
+// moves — this is the regression that a plain text diff makes hardest to
+// see, because the surrounding numbers all shift too.
+func TestDiffReportsJoinMethodChange(t *testing.T) {
+	before := mustParse(t, ` Hash Join
+   Hash Cond: (f.dim_id = d.id)
+   ->  Seq Scan on join_fact f
+   ->  Hash
+         ->  Seq Scan on join_dim d
+`)
+	after := mustParse(t, ` Nested Loop
+   Join Filter: (f.dim_id = d.id)
+   ->  Seq Scan on join_fact f
+   ->  Materialize
+         ->  Seq Scan on join_dim d
+`)
+
+	d := DiffPlans(before, after)
+	if d.SameStructure() {
+		t.Fatal("expected a structural change")
+	}
+	got := d.String()
+	if !strings.Contains(got, "- HASH_JOIN(d)") {
+		t.Errorf("missing removed HASH_JOIN:\n%s", got)
+	}
+	if !strings.Contains(got, "+ NESTED_LOOP_MATERIALIZE(d)") {
+		t.Errorf("missing added NESTED_LOOP_MATERIALIZE:\n%s", got)
+	}
+}
+
+// Losing parallelism is a common and easily missed regression.
+func TestDiffReportsParallelismLoss(t *testing.T) {
+	before := mustParse(t, ` Gather
+   Workers Planned: 2
+   ->  Parallel Seq Scan on results
+`)
+	after := mustParse(t, ` Seq Scan on results
+`)
+	d := DiffPlans(before, after)
+	got := d.String()
+	if !strings.Contains(got, "- GATHER(results)") || !strings.Contains(got, "+ NO_GATHER(results)") {
+		t.Errorf("parallelism change not reported:\n%s", got)
+	}
+}
+
+// EXPLAIN without ANALYZE carries no timings. Reporting a delta against a
+// missing value would read as a catastrophic change; there should just be
+// no NUMBERS section.
+func TestDiffOmitsNumbersWithoutAnalyze(t *testing.T) {
+	before := mustParse(t, " Seq Scan on drivers\n")
+	after := mustParse(t, " Seq Scan on drivers\n")
+	got := DiffPlans(before, after).String()
+	if strings.Contains(got, "NUMBERS") {
+		t.Errorf("expected no NUMBERS section without ANALYZE:\n%s", got)
+	}
+}
+
+func mustParse(t *testing.T, s string) *Plan {
+	t.Helper()
+	p, err := Parse(s)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return p
+}

--- a/explain/format.go
+++ b/explain/format.go
@@ -1,0 +1,170 @@
+package explain
+
+import (
+	"regexp"
+	"strings"
+	"unicode/utf8"
+)
+
+// explainLineRE splits one EXPLAIN/EXPLAIN ANALYZE output line into its
+// leading indentation+label (group 1) and its trailing run of one or more
+// parenthetical groups — "(cost=0.00..29.20 rows=857 width=44)",
+// "(actual time=0.008..0.150 rows=857 loops=1)", "(never executed)" —
+// which is the part that makes these lines routinely wider than a PDF
+// page's fixed-width verbatim column count (unlike HTML/EPUB, which just
+// reflow). Parenthetical groups here are always flat (no nested parens),
+// so a simple non-greedy split is safe.
+var explainLineRE = regexp.MustCompile(`^(\s*(?:->\s*)?.*?)((?:\s+\([^()]*\))+)\s*$`)
+
+var explainGroupRE = regexp.MustCompile(`\s*\(([^()]*)\)`)
+
+// FormatForWidth reformats raw EXPLAIN/EXPLAIN ANALYZE text so no single
+// line exceeds maxWidth columns, by moving each trailing "(cost=...)"/
+// "(actual time=...)"/"(never executed)" parenthetical group of an
+// over-width line onto its own continuation line, indented four spaces
+// past that line's own indentation — the fixed-width LaTeX `verbatim`
+// environment book/course Course Companion PDFs typeset psql output in
+// never wraps on its own (see build/pandoc/templates/tablet.latex), so a
+// long ANALYZE line otherwise runs straight off the page edge instead of
+// truncating or wrapping. Lines that already fit, and lines with no
+// parenthetical group to split (e.g. "Planning Time: 0.045 ms"), pass
+// through unchanged. Byte-for-byte round-trippable back into the same
+// groups if maxWidth is later widened — this only ever *moves* text, it
+// never truncates or drops anything.
+func FormatForWidth(text string, maxWidth int) string {
+	lines := strings.Split(text, "\n")
+	out := make([]string, 0, len(lines))
+	for _, line := range lines {
+		if utf8.RuneCountInString(line) <= maxWidth {
+			out = append(out, line)
+			continue
+		}
+		m := explainLineRE.FindStringSubmatch(line)
+		if m == nil {
+			out = append(out, wrapByCommas(line, maxWidth)...)
+			continue
+		}
+		head, groupsPart := m[1], m[2]
+		groups := explainGroupRE.FindAllStringSubmatch(groupsPart, -1)
+		if len(groups) == 0 {
+			out = append(out, wrapByCommas(line, maxWidth)...)
+			continue
+		}
+		out = append(out, head)
+		contIndent := leadingWhitespace(head) + "    "
+		for _, g := range groups {
+			out = append(out, contIndent+"("+g[1]+")")
+		}
+	}
+	reindentHeader(out)
+	return strings.Join(out, "\n")
+}
+
+// wrapByCommas is FormatForWidth's fallback for an over-width line with
+// no "(cost=...)"-shaped group to split — e.g. "Settings: search_path =
+// '"$user", public, chinook, ...', enable_seqscan = 'off'" (EXPLAIN's own
+// SETTINGS line, or a long "Output:"/"Group Key:" list of columns) —
+// greedily packs ", "-separated items onto each line up to maxWidth,
+// same indented-continuation convention as the cost-group split above
+// (four spaces past the line's own leading indentation), only breaking at
+// an actual ", " boundary so no identifier or value is ever split
+// mid-token. A line with fewer than two ", "-separated items (nothing to
+// break on) passes through unchanged, same as a non-EXPLAIN line with no
+// parenthetical group.
+func wrapByCommas(line string, maxWidth int) []string {
+	parts := strings.Split(line, ", ")
+	if len(parts) < 2 {
+		return []string{line}
+	}
+	contIndent := leadingWhitespace(line) + "    "
+	var out []string
+	cur := parts[0]
+	for _, p := range parts[1:] {
+		candidate := cur + ", " + p
+		if utf8.RuneCountInString(candidate) > maxWidth && cur != "" {
+			out = append(out, cur+",")
+			cur = contIndent + p
+		} else {
+			cur = candidate
+		}
+	}
+	out = append(out, cur)
+	return out
+}
+
+func leadingWhitespace(s string) string {
+	i := 0
+	for i < len(s) && (s[i] == ' ' || s[i] == '\t') {
+		i++
+	}
+	return s[:i]
+}
+
+// reindentHeader re-centers psql's own "QUERY PLAN" title line and
+// resizes its separator line (a run of U+2550 "═", this repo's own
+// psqlrc box-drawing convention — see build/psql/psqlrc) to match
+// whatever width the plan's content lines actually ended up at after the
+// loop above split their "(cost=...)"/"(actual...)" groups onto their
+// own continuation lines. Splitting those groups is the whole point —
+// every content line is now narrower than psql originally laid it out
+// for — so left as-is, the header/separator (sized for the ORIGINAL,
+// wider plan) would overhang every line beneath them, no longer
+// centering anything or marking the real table width.
+//
+// The title+separator pair isn't always lines[0]/lines[1] — a query
+// preceded by \set/SET/BEGIN (e.g. one that disables enable_seqscan for
+// the duration of the EXPLAIN) prints that statement's own "SET"/"BEGIN"
+// echo first, pushing QUERY PLAN down a line or more — so this scans for
+// the pair wherever it actually starts rather than assuming the very
+// first two lines. No-op if no such pair is found at all (a raw
+// non-EXPLAIN psql output).
+func reindentHeader(lines []string) {
+	for i := 0; i+1 < len(lines); i++ {
+		if strings.TrimSpace(lines[i]) != "QUERY PLAN" || !isSeparatorLine(lines[i+1]) {
+			continue
+		}
+		title := strings.TrimSpace(lines[i])
+		width := utf8.RuneCountInString(title)
+		for _, l := range lines[i+2:] {
+			if n := utf8.RuneCountInString(l); n > width {
+				width = n
+			}
+		}
+		lines[i] = centerText(title, width)
+		lines[i+1] = strings.Repeat(explainSeparatorRune, width)
+		return
+	}
+}
+
+const explainSeparatorRune = "═"
+
+// isSeparatorLine reports whether s (trailing newline already stripped
+// by strings.Split) is entirely explainSeparatorRune repeated — psql's
+// own header-separator shape — tolerant of nothing else, since that's
+// exactly what psql emits for this line and nothing else should ever
+// match it.
+func isSeparatorLine(s string) bool {
+	if s == "" {
+		return false
+	}
+	for _, r := range s {
+		if string(r) != explainSeparatorRune {
+			return false
+		}
+	}
+	return true
+}
+
+// centerText pads s with spaces to width, extra padding (if width-len(s)
+// is odd) going on the right — same convention psql itself uses to
+// center "QUERY PLAN" over the separator line's width.
+func centerText(s string, width int) string {
+	n := utf8.RuneCountInString(s)
+	if n >= width {
+		return s
+	}
+	total := width - n
+	left := total / 2
+	right := total - left
+	return strings.Repeat(" ", left) + s + strings.Repeat(" ", right)
+}

--- a/explain/nodetype.go
+++ b/explain/nodetype.go
@@ -1,0 +1,214 @@
+package explain
+
+import "strings"
+
+// joinVariantRE recognizes a join node whose type carries a Semi/Anti/
+// Left/Right/Full modifier — matched as a unit (rather than exploding the
+// token table combinatorially) so the FULL matched text becomes the
+// node's display Label (e.g. "Hash Anti Join"), while the base keyword
+// still drives its color/style.
+type joinVariant struct {
+	prefix string
+	typ    string
+}
+
+var joinVariantPrefixes = []joinVariant{
+	{"Nested Loop", "nested-loop"},
+	{"Merge", "merge-join"},
+	{"Hash", "hash-join"},
+}
+
+var joinVariantInfixes = []string{" Left", " Right", " Full", " Semi", " Anti"}
+
+// nodeTypeTokens maps a node-type token (longest first within any shared
+// prefix) to its internal type keyword. Both spaced and run-together
+// spellings are listed side by side for cross-Postgres-version
+// compatibility (older/newer EXPLAIN output spells some of these
+// differently), matching explain-plan-parser.lisp's *node-type-tokens*.
+var nodeTypeTokens = []struct {
+	token string
+	typ   string
+}{
+	{"Index Only Scan Backward", "index-only-scan"},
+	{"Index Only Scan", "index-only-scan"},
+	{"Index Scan Backward", "index-scan"},
+	{"Index Scan", "index-scan"},
+	{"Bitmap Heap Scan", "bitmap-heap-scan"},
+	{"Bitmap Index Scan", "bitmap-index-scan"},
+	{"Tid Range Scan", "tid-range-scan"},
+	{"Tid Scan", "tid-scan"},
+	{"Sample Scan", "sample-scan"},
+	{"Function Scan", "function-scan"},
+	{"Table Function Scan", "table-function-scan"},
+	{"Values Scan", "values-scan"},
+	{"Foreign Scan", "foreign-scan"},
+	{"Subquery Scan", "subquery-scan"},
+	{"CTE Scan", "cte-scan"},
+	{"WorkTable Scan", "worktable-scan"},
+	{"Named Tuplestore Scan", "named-tuplestore-scan"},
+	{"Custom Scan", "custom-scan"},
+	{"Seq Scan", "seq-scan"},
+
+	{"Hash Aggregate", "hash-aggregate"},
+	{"HashAggregate", "hash-aggregate"},
+	{"Group Aggregate", "group-aggregate"},
+	{"GroupAggregate", "group-aggregate"},
+	{"Mixed Aggregate", "mixed-aggregate"},
+	{"MixedAggregate", "mixed-aggregate"},
+	{"Aggregate", "aggregate"},
+	{"Window Agg", "window-agg"},
+	{"WindowAgg", "window-agg"},
+	{"Group", "group"},
+
+	{"Incremental Sort", "incremental-sort"},
+	{"Sort", "sort"},
+	{"Unique", "unique"},
+	{"Merge Append", "merge-append"},
+	{"Append", "append"},
+	{"Materialize", "materialize"},
+	{"Material", "materialize"},
+	{"Memoize", "memoize"},
+	{"Limit", "limit"},
+	{"Lock Rows", "lock-rows"},
+	{"LockRows", "lock-rows"},
+	{"Set Op", "set-op"},
+	{"SetOp", "set-op"},
+	{"Result", "result"},
+	{"Gather Merge", "gather-merge"},
+	{"GatherMerge", "gather-merge"},
+	{"Gather", "gather"},
+	{"Recursive Union", "recursive-union"},
+	{"Project Set", "project-set"},
+	{"ProjectSet", "project-set"},
+
+	{"ModifyTable", "modify-table"},
+	{"Update", "update"},
+	{"Insert", "insert"},
+	{"Delete", "delete"},
+
+	{"Hash", "hash"},
+}
+
+// typeLabelMap gives the human-readable display label for a type keyword
+// when no override Label was set by the join-variant matcher.
+var typeLabelMap = map[string]string{
+	"index-only-scan": "Index Only Scan", "index-scan": "Index Scan",
+	"bitmap-heap-scan": "Bitmap Heap Scan", "bitmap-index-scan": "Bitmap Index Scan",
+	"tid-range-scan": "Tid Range Scan", "tid-scan": "Tid Scan",
+	"sample-scan": "Sample Scan", "function-scan": "Function Scan",
+	"table-function-scan": "Table Function Scan", "values-scan": "Values Scan",
+	"foreign-scan": "Foreign Scan", "subquery-scan": "Subquery Scan",
+	"cte-scan": "CTE Scan", "worktable-scan": "WorkTable Scan",
+	"named-tuplestore-scan": "Named Tuplestore Scan", "custom-scan": "Custom Scan",
+	"seq-scan":       "Seq Scan",
+	"hash-aggregate": "Hash Aggregate", "group-aggregate": "Group Aggregate",
+	"mixed-aggregate": "Mixed Aggregate", "aggregate": "Aggregate",
+	"window-agg": "Window Agg", "group": "Group",
+	"incremental-sort": "Incremental Sort", "sort": "Sort", "unique": "Unique",
+	"merge-append": "Merge Append", "append": "Append", "materialize": "Materialize",
+	"memoize": "Memoize", "limit": "Limit", "lock-rows": "Lock Rows",
+	"set-op": "Set Op", "result": "Result", "gather-merge": "Gather Merge",
+	"gather": "Gather", "recursive-union": "Recursive Union",
+	"project-set": "Project Set", "modify-table": "ModifyTable",
+	"update": "Update", "insert": "Insert", "delete": "Delete",
+	"hash": "Hash", "hash-join": "Hash Join", "nested-loop": "Nested Loop",
+	"merge-join": "Merge Join", "unknown": "Node",
+}
+
+// NodeLabel returns the display label for a node: its own override
+// (join variants) if set, else the human-readable form of its type.
+func NodeLabel(n *Node) string {
+	if n.Label != "" {
+		return n.Label
+	}
+	if lbl, ok := typeLabelMap[n.Type]; ok {
+		return lbl
+	}
+	return "Node"
+}
+
+// matchNodeType classifies text (the node line with cost/actual already
+// stripped) into (type, prefix, label, remainder) — remainder is
+// whatever text followed the type token (used for relation/alias
+// parsing on scan nodes), matching match-node-type.
+func matchNodeType(text string) (typ, prefix, label, remainder string) {
+	for _, p := range []string{"Parallel ", "Partial ", "Finalize "} {
+		if strings.HasPrefix(text, p) {
+			t, _, l, r := matchNodeType(text[len(p):])
+			combinedPrefix := strings.TrimSpace(p)
+			return t, combinedPrefix, l, r
+		}
+	}
+
+	if jt, jl, jr, ok := matchJoinVariant(text); ok {
+		return jt, "", jl, jr
+	}
+
+	for _, tok := range nodeTypeTokens {
+		if strings.HasPrefix(text, tok.token) {
+			after := text[len(tok.token):]
+			if after == "" || isWordBoundary(after[0]) {
+				return tok.typ, "", "", strings.TrimSpace(after)
+			}
+		}
+	}
+	return "unknown", "", "", text
+}
+
+func isWordBoundary(c byte) bool {
+	return c == ' ' || c == '(' || c == '\n' || c == '\t'
+}
+
+// matchJoinVariant recognizes "(Nested Loop|Merge|Hash)((?: Left| Right|
+// Full| Semi| Anti)+) Join" — the full matched prefix (e.g. "Hash Anti
+// Join") becomes the display label, while the base keyword drives
+// color/style, matching the Lisp parser's dedicated join-variant scanner.
+func matchJoinVariant(text string) (typ, label, remainder string, ok bool) {
+	for _, jv := range joinVariantPrefixes {
+		if !strings.HasPrefix(text, jv.prefix) {
+			continue
+		}
+		rest := text[len(jv.prefix):]
+		matched := jv.prefix
+		for {
+			advanced := false
+			for _, infix := range joinVariantInfixes {
+				if strings.HasPrefix(rest, infix) {
+					matched += infix
+					rest = rest[len(infix):]
+					advanced = true
+					break
+				}
+			}
+			if !advanced {
+				break
+			}
+		}
+		if strings.HasPrefix(rest, " Join") {
+			matched += " Join"
+			rest = rest[len(" Join"):]
+			label = matched
+			if label == jv.prefix+" Join" {
+				label = "" // no variant infix matched — use the plain type label
+			}
+			return jv.typ, label, strings.TrimSpace(rest), true
+		}
+		// Bare "Nested Loop" (PostgreSQL's plain-inner-join spelling) has
+		// NO trailing " Join" at all — unlike Hash/Merge, which are never
+		// a complete join-node type name without it (bare "Hash" means
+		// the build-side Hash node, a different node entirely, and bare
+		// "Merge" isn't a real EXPLAIN node type at all). Left unhandled,
+		// every plain (non-outer/semi/anti) Nested Loop node — the
+		// overwhelming common case — fell all the way through to
+		// type="unknown", displaying as a generic "Node" with the wrong
+		// (non-join) color. Only accept the bare form here, and only when
+		// nothing consumed by an infix (matched == jv.prefix, i.e. no
+		// " Left"/" Right"/... already matched) and what follows is a
+		// real word boundary, not a coincidental longer type name that
+		// happens to start with "Nested Loop".
+		if jv.typ == "nested-loop" && matched == jv.prefix && (rest == "" || isWordBoundary(rest[0])) {
+			return jv.typ, "", strings.TrimSpace(rest), true
+		}
+	}
+	return "", "", "", false
+}

--- a/explain/parse.go
+++ b/explain/parse.go
@@ -1,0 +1,285 @@
+// Package explain parses psql's default TEXT-format EXPLAIN output (with
+// or without ANALYZE/BUFFERS) into a tree of plan nodes, and renders that
+// tree back out in useful shapes.
+//
+// TEXT format is the point. Machine-readable FORMAT JSON carries strictly
+// more information and is far easier to consume, but it is not what
+// people have: a plan that reaches a colleague, a ticket, or a mailing
+// list is almost always the default text psql printed, pasted verbatim.
+// A tool that insists on JSON is a tool nobody can use on the plan
+// actually in front of them, so everything here reads the messy real
+// thing — psql's box-drawing borders and QUERY PLAN header, a leading
+// SET or BEGIN echo, a trailing "(31 rows)", stray indentation.
+//
+// Two renderings are provided. FormatForWidth reflows a plan so no line
+// exceeds a column budget, for fixed-width media. Advice describes the
+// plan's STRUCTURE, mirroring the format PostgreSQL 19's pg_plan_advice
+// generates — see advice.go for what that buys on servers long
+// predating 19.
+//
+// This package has zero database or process dependencies: it operates
+// purely on text that psql already printed.
+//
+// The parser began as a Go port of the Lisp explain-plan-parser used to
+// typeset The Art of PostgreSQL, and keeps that lineage's node-type
+// vocabulary.
+package explain
+
+import (
+	"fmt"
+	"regexp"
+	"strconv"
+	"strings"
+)
+
+// Node is one plan-tree node — the Go equivalent of explain-plan-parser.lisp's
+// defstruct plan-node. Pointer fields are nil when the corresponding data
+// wasn't present in the EXPLAIN output (e.g. no ANALYZE was used).
+type Node struct {
+	Type         string // "seq-scan", "hash-join", "unknown", ... — see nodeTypeTokens
+	Prefix       string // "Parallel" / "Partial" / "Finalize", or ""
+	Label        string // display-label override (join variants keep their full text)
+	Relation     string // table/index name, scan nodes only
+	Alias        string // "" when absent or identical to Relation
+	CostStart    *float64
+	CostEnd      *float64
+	RowsEstimate *int64
+	RowsActual   *int64 // nil when ANALYZE wasn't used
+	TimeActual   *float64
+	Loops        *int64
+	Props        []string // raw, trimmed property lines, document order
+	Children     []*Node
+}
+
+// Plan is the Go equivalent of explain-plan-parser.lisp's defstruct plan.
+type Plan struct {
+	Root          *Node
+	PlanningTime  *float64 // ms
+	ExecutionTime *float64 // ms
+}
+
+// HasPlan reports whether text looks like it contains a captured EXPLAIN
+// plan — the same filesystem-inspection heuristic query-metadata.lisp's
+// detect-explain-diagram used ("QUERY PLAN" header or a "(cost=" node
+// line), so callers can decide whether to invoke Parse at all.
+func HasPlan(text string) bool {
+	return strings.Contains(text, "QUERY PLAN") || strings.Contains(text, "(cost=")
+}
+
+// planLineRE recognizes a plan node line has the general
+// "(cost=..)" or "(cost=.. rows=.. width=..)" parenthetical.
+var costScanner = regexp.MustCompile(`\(cost=([0-9.]+)\.\.([0-9.]+) rows=(\d+) width=(\d+)\)`)
+var actualScanner = regexp.MustCompile(`\(actual time=[0-9.]+\.\.([0-9.]+) rows=(\d+) loops=(\d+)\)`)
+var planningTimeRE = regexp.MustCompile(`^Planning Time:\s*([0-9.]+)\s*ms`)
+var executionTimeRE = regexp.MustCompile(`^Execution Time:\s*([0-9.]+)\s*ms`)
+var arrowRE = regexp.MustCompile(`^(\s*)->\s+`)
+var separatorRE = regexp.MustCompile(`^\s*[═=─-]{5,}\s*$`)
+var rowsFooterRE = regexp.MustCompile(`^\(\d+ rows?\)`)
+
+// Parse parses psql's default TEXT-format EXPLAIN output (out, the full
+// captured stdout — may include preceding SET/other statement echoes,
+// which are skipped) into a Plan.
+func Parse(out string) (*Plan, error) {
+	lines := extractPlanLines(out)
+	if len(lines) == 0 {
+		return nil, fmt.Errorf("explainplan: no plan lines found")
+	}
+
+	plan := &Plan{}
+	type frame struct {
+		depth int
+		node  *Node
+	}
+	var stack []frame
+
+	for _, line := range lines {
+		if m := planningTimeRE.FindStringSubmatch(strings.TrimSpace(line)); m != nil {
+			v, _ := strconv.ParseFloat(m[1], 64)
+			plan.PlanningTime = &v
+			continue
+		}
+		if m := executionTimeRE.FindStringSubmatch(strings.TrimSpace(line)); m != nil {
+			v, _ := strconv.ParseFloat(m[1], 64)
+			plan.ExecutionTime = &v
+			continue
+		}
+
+		if m := arrowRE.FindStringSubmatch(line); m != nil {
+			arrowCol := len(m[1])
+			depth := (arrowCol + 4) / 6
+			text := strings.TrimSpace(line[len(m[0]):])
+			node := parseNodeLine(text)
+
+			for len(stack) > 0 && stack[len(stack)-1].depth >= depth {
+				stack = stack[:len(stack)-1]
+			}
+			if len(stack) == 0 {
+				// Root already exists (depth-0 line came first) — attach
+				// as a child of the deepest still-open ancestor. In
+				// practice depth 1 always follows the depth-0 root line,
+				// so this only fires if the root is somehow missing.
+				plan.Root = node
+			} else {
+				parent := stack[len(stack)-1].node
+				parent.Children = append(parent.Children, node)
+			}
+			stack = append(stack, frame{depth: depth, node: node})
+			continue
+		}
+
+		trimmed := strings.TrimSpace(line)
+		if trimmed == "" {
+			continue
+		}
+
+		if len(stack) == 0 && plan.Root == nil {
+			// The very first non-arrow line is the root node.
+			plan.Root = parseNodeLine(trimmed)
+			stack = append(stack, frame{depth: 0, node: plan.Root})
+			continue
+		}
+
+		if len(stack) > 0 {
+			stack[len(stack)-1].node.Props = append(stack[len(stack)-1].node.Props, trimmed)
+		}
+	}
+
+	if plan.Root == nil {
+		return nil, fmt.Errorf("explainplan: failed to find a root plan node")
+	}
+	return plan, nil
+}
+
+// extractPlanLines finds the plan inside whatever psql printed: it skips
+// any leading statement echoes and the "QUERY PLAN" header, strips
+// exactly one leading space from every collected line, and stops at the
+// first footer line (Planning:/Planning Time:/Execution Time:/"(N rows)").
+//
+// Two entry rules, because there are two kinds of plan text. Normally the
+// first "(cost=" line begins the plan, which skips echoes and the header
+// without having to recognize either. But EXPLAIN (COSTS OFF) — how the
+// PostgreSQL test suite, most documentation, and PLAN_ADVICE examples
+// print plans — has no "(cost=" anywhere, and looking for one finds
+// nothing at all. So when the text contains no costs, fall back to
+// starting after the QUERY PLAN header, or at the first non-empty line
+// when there is no header either.
+//
+// The costed path is kept exactly as it was: it is what every existing
+// caller feeds this, and it needs to behave identically.
+func extractPlanLines(out string) []string {
+	costed := strings.Contains(out, "(cost=")
+
+	var result []string
+	collecting := false
+	sawHeader := false
+	hasHeader := strings.Contains(out, "QUERY PLAN")
+
+	for _, raw := range strings.Split(out, "\n") {
+		line := raw
+		if strings.HasPrefix(line, " ") {
+			line = line[1:]
+		}
+		trimmed := strings.TrimSpace(line)
+
+		if !collecting {
+			switch {
+			case costed:
+				if !strings.Contains(line, "(cost=") {
+					continue
+				}
+				collecting = true
+			case hasHeader:
+				// Costs are off: the header is the only reliable marker.
+				if !sawHeader {
+					if trimmed == "QUERY PLAN" {
+						sawHeader = true
+					}
+					continue
+				}
+				if trimmed == "" || separatorRE.MatchString(line) {
+					continue
+				}
+				collecting = true
+			default:
+				if trimmed == "" {
+					continue
+				}
+				collecting = true
+			}
+		}
+
+		if trimmed == "Planning:" || rowsFooterRE.MatchString(trimmed) {
+			break
+		}
+		if planningTimeRE.MatchString(trimmed) || executionTimeRE.MatchString(trimmed) {
+			result = append(result, line)
+			continue
+		}
+		if separatorRE.MatchString(line) {
+			continue
+		}
+		result = append(result, line)
+	}
+	return result
+}
+
+// parseNodeLine parses one plan-node line's body (after the "-> " arrow,
+// or the bare root line) into a Node — matching type/prefix/label
+// classification, relation+alias extraction, and cost/actual field
+// extraction, per explain-plan-parser.lisp.
+func parseNodeLine(text string) *Node {
+	node := &Node{}
+
+	rest := text
+	if m := costScanner.FindStringSubmatch(rest); m != nil {
+		start, _ := strconv.ParseFloat(m[1], 64)
+		end, _ := strconv.ParseFloat(m[2], 64)
+		rows, _ := strconv.ParseInt(m[3], 10, 64)
+		node.CostStart = &start
+		node.CostEnd = &end
+		node.RowsEstimate = &rows
+		rest = rest[:strings.Index(rest, m[0])]
+	}
+	if m := actualScanner.FindStringSubmatch(text); m != nil {
+		t, _ := strconv.ParseFloat(m[1], 64)
+		rows, _ := strconv.ParseInt(m[2], 10, 64)
+		loops, _ := strconv.ParseInt(m[3], 10, 64)
+		node.TimeActual = &t
+		node.RowsActual = &rows
+		node.Loops = &loops
+	}
+
+	rest = strings.TrimSpace(rest)
+	typ, prefix, label, relAndAlias := matchNodeType(rest)
+	node.Type = typ
+	node.Prefix = prefix
+	node.Label = label
+	if relAndAlias != "" {
+		node.Relation, node.Alias = parseRelationAndAlias(relAndAlias)
+	}
+	return node
+}
+
+// parseRelationAndAlias handles the two shapes psql prints after a scan
+// node's type token: "on RELATION [ALIAS]" (heap scan) and "using INDEX
+// on RELATION [ALIAS]" (index scan — the index name itself is discarded,
+// matching the Lisp parser, which never stores it).
+func parseRelationAndAlias(s string) (relation, alias string) {
+	s = strings.TrimSpace(s)
+	if idx := strings.Index(s, " on "); idx >= 0 {
+		s = s[idx+4:]
+	} else if !strings.HasPrefix(s, "on ") {
+		return "", ""
+	} else {
+		s = s[3:]
+	}
+	fields := strings.Fields(s)
+	if len(fields) == 0 {
+		return "", ""
+	}
+	relation = fields[0]
+	if len(fields) > 1 && fields[1] != relation {
+		alias = fields[1]
+	}
+	return relation, alias
+}

--- a/explain/parse.go
+++ b/explain/parse.go
@@ -41,6 +41,7 @@ type Node struct {
 	Label        string // display-label override (join variants keep their full text)
 	Relation     string // table/index name, scan nodes only
 	Alias        string // "" when absent or identical to Relation
+	Index        string // index name on "Index Scan using IDX on REL" nodes
 	CostStart    *float64
 	CostEnd      *float64
 	RowsEstimate *int64
@@ -152,8 +153,9 @@ func Parse(out string) (*Plan, error) {
 
 // extractPlanLines finds the plan inside whatever psql printed: it skips
 // any leading statement echoes and the "QUERY PLAN" header, strips
-// exactly one leading space from every collected line, and stops at the
-// first footer line (Planning:/Planning Time:/Execution Time:/"(N rows)").
+// exactly one leading space from every collected line, keeps the
+// Planning Time / Execution Time lines, and stops at the "(N rows)"
+// footer.
 //
 // Two entry rules, because there are two kinds of plan text. Normally the
 // first "(cost=" line begins the plan, which skips echoes and the header
@@ -171,6 +173,7 @@ func extractPlanLines(out string) []string {
 
 	var result []string
 	collecting := false
+	inPlanningBlock := false
 	sawHeader := false
 	hasHeader := strings.Contains(out, "QUERY PLAN")
 
@@ -208,11 +211,26 @@ func extractPlanLines(out string) []string {
 			}
 		}
 
-		if trimmed == "Planning:" || rowsFooterRE.MatchString(trimmed) {
+		if rowsFooterRE.MatchString(trimmed) {
 			break
 		}
+		// EXPLAIN (BUFFERS) prints a "Planning:" block, with its own
+		// indented Buffers/I/O Timings lines, BETWEEN the tree and the
+		// Planning Time / Execution Time lines. Stopping at "Planning:"
+		// (which this did) therefore threw both timings away on every
+		// buffered plan — invisible when the tree was all anyone wanted,
+		// but the timings are half of what a plan comparison reports.
+		// Skip the block's contents, keep scanning for the timings.
+		if trimmed == "Planning:" {
+			inPlanningBlock = true
+			continue
+		}
 		if planningTimeRE.MatchString(trimmed) || executionTimeRE.MatchString(trimmed) {
+			inPlanningBlock = false
 			result = append(result, line)
+			continue
+		}
+		if inPlanningBlock {
 			continue
 		}
 		if separatorRE.MatchString(line) {
@@ -256,8 +274,28 @@ func parseNodeLine(text string) *Node {
 	node.Label = label
 	if relAndAlias != "" {
 		node.Relation, node.Alias = parseRelationAndAlias(relAndAlias)
+		node.Index = parseIndexName(relAndAlias)
 	}
 	return node
+}
+
+// parseIndexName pulls the index out of "using INDEX on RELATION", the
+// shape index and index-only scans print. PostgreSQL 19's plan advice
+// names both the relation and the index it was reached through
+// (INDEX_SCAN(foo foo_a_idx)), so unlike the original book-typesetting
+// parser — which only ever needed the relation and threw this away — the
+// index name has to survive parsing.
+func parseIndexName(s string) string {
+	s = strings.TrimSpace(s)
+	if !strings.HasPrefix(s, "using ") {
+		return ""
+	}
+	s = s[len("using "):]
+	idx := strings.Index(s, " on ")
+	if idx < 0 {
+		return ""
+	}
+	return strings.TrimSpace(s[:idx])
 }
 
 // parseRelationAndAlias handles the two shapes psql prints after a scan

--- a/explain/parse_test.go
+++ b/explain/parse_test.go
@@ -1,0 +1,158 @@
+package explain
+
+import "testing"
+
+const simplePlan = `                                    QUERY PLAN
+═══════════════════════════════════════════════════════════════════════════════════
+ WindowAgg  (cost=748.44..748.96 rows=23 width=47)
+   ->  Sort  (cost=748.44..748.50 rows=23 width=23)
+         Sort Key: results.milliseconds
+         ->  Hash Join  (cost=40.90..747.92 rows=23 width=23)
+               Hash Cond: (results.driverid = drivers.driverid)
+               ->  Seq Scan on results  (cost=0.00..706.96 rows=23 width=24)
+                     Filter: (raceid = 890)
+               ->  Hash  (cost=30.40..30.40 rows=840 width=15)
+                     ->  Seq Scan on drivers  (cost=0.00..30.40 rows=840 width=15)
+(9 rows)
+`
+
+const analyzePlan = ` Limit  (cost=2983.51..2983.56 rows=20 width=31) (actual time=6.723..6.725 rows=20 loops=1)
+   Buffers: shared hit=433
+   ->  Sort  (cost=2983.51..2985.61 rows=840 width=31) (actual time=6.722..6.723 rows=20 loops=1)
+         Sort Key: (sum(res.points)) DESC
+         Sort Method: top-N heapsort  Memory: 26kB
+         Buffers: shared hit=433
+         ->  GroupAggregate  (cost=2362.14..2961.16 rows=840 width=31) (actual time=3.354..6.651 rows=840 loops=1)
+               Group Key: d.driverid
+               Buffers: shared hit=430
+               ->  Merge Join  (cost=2362.14..2775.78 rows=23597 width=23) (actual time=3.311..5.516 rows=23597 loops=1)
+                     Merge Cond: (d.driverid = res.driverid)
+                     Buffers: shared hit=430
+                     ->  Index Scan using idx_49514_primary on drivers d  (cost=0.28..57.88 rows=840 width=15) (actual time=0.004..0.064 rows=840 loops=1)
+                           Buffers: shared hit=18
+                     ->  Sort  (cost=2361.86..2420.85 rows=23597 width=16) (actual time=3.303..4.007 rows=23597 loops=1)
+                           Sort Key: res.driverid
+                           Sort Method: quicksort  Memory: 1690kB
+                           Buffers: shared hit=412
+                           ->  Seq Scan on results res  (cost=0.00..647.97 rows=23597 width=16) (actual time=0.002..1.590 rows=23597 loops=1)
+                                 Buffers: shared hit=412
+ Planning Time: 0.508 ms
+ Execution Time: 6.819 ms
+(24 rows)
+`
+
+func TestParseSimplePlan(t *testing.T) {
+	plan, err := Parse(simplePlan)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if plan.Root.Type != "window-agg" {
+		t.Fatalf("root type = %q, want window-agg", plan.Root.Type)
+	}
+	if len(plan.Root.Children) != 1 || plan.Root.Children[0].Type != "sort" {
+		t.Fatalf("expected a single Sort child, got %+v", plan.Root.Children)
+	}
+	hj := plan.Root.Children[0].Children[0]
+	if hj.Type != "hash-join" || len(hj.Children) != 2 {
+		t.Fatalf("expected Hash Join with 2 children, got type=%q children=%d", hj.Type, len(hj.Children))
+	}
+	seqScan := hj.Children[0]
+	if seqScan.Type != "seq-scan" || seqScan.Relation != "results" {
+		t.Fatalf("expected Seq Scan on results, got type=%q relation=%q", seqScan.Type, seqScan.Relation)
+	}
+	if len(seqScan.Props) != 1 || seqScan.Props[0] != "Filter: (raceid = 890)" {
+		t.Fatalf("unexpected props: %+v", seqScan.Props)
+	}
+	if plan.PlanningTime != nil || plan.Root.TimeActual != nil {
+		t.Fatal("plain EXPLAIN (no ANALYZE) should have no timing data")
+	}
+}
+
+func TestParseAnalyzePlanWithBranching(t *testing.T) {
+	plan, err := Parse(analyzePlan)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if plan.PlanningTime == nil || *plan.PlanningTime != 0.508 {
+		t.Fatalf("planning time = %v, want 0.508", plan.PlanningTime)
+	}
+	if plan.ExecutionTime == nil || *plan.ExecutionTime != 6.819 {
+		t.Fatalf("execution time = %v, want 6.819", plan.ExecutionTime)
+	}
+
+	limit := plan.Root
+	if limit.Type != "limit" || limit.RowsActual == nil || *limit.RowsActual != 20 {
+		t.Fatalf("unexpected root: %+v", limit)
+	}
+	sort := limit.Children[0]
+	if sort.RowsEstimate == nil || sort.RowsActual == nil || *sort.RowsEstimate == *sort.RowsActual {
+		t.Fatalf("expected Sort's estimate/actual rows to differ, got %+v", sort)
+	}
+	mergeJoin := sort.Children[0].Children[0]
+	if mergeJoin.Type != "merge-join" || len(mergeJoin.Children) != 2 {
+		t.Fatalf("expected Merge Join with 2 children, got type=%q children=%d", mergeJoin.Type, len(mergeJoin.Children))
+	}
+	idxScan := mergeJoin.Children[0]
+	if idxScan.Type != "index-scan" || idxScan.Relation != "drivers" || idxScan.Alias != "d" {
+		t.Fatalf("unexpected index scan node: %+v", idxScan)
+	}
+}
+
+func TestHasPlan(t *testing.T) {
+	if !HasPlan(simplePlan) {
+		t.Fatal("expected HasPlan(simplePlan) to be true")
+	}
+	if HasPlan("select 1;\n") {
+		t.Fatal("expected HasPlan on non-EXPLAIN text to be false")
+	}
+}
+
+// EXPLAIN (COSTS OFF) — how the PostgreSQL regression suite, most
+// documentation, and every PLAN_ADVICE example print plans. There is no
+// "(cost=" anywhere in that output, which the original parser used as the
+// signal for where the plan begins; it found nothing and returned an
+// error. The QUERY PLAN header is the fallback marker.
+func TestParseCostsOffPlan(t *testing.T) {
+	const costsOff = `                  QUERY PLAN
+-----------------------------------------------
+ Hash Join
+   Hash Cond: (results.driverid = drivers.driverid)
+   ->  Seq Scan on results
+   ->  Hash
+         ->  Seq Scan on drivers
+               Filter: (nationality = 'British'::text)
+(6 rows)
+`
+	plan, err := Parse(costsOff)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if plan.Root.Type != "hash-join" {
+		t.Fatalf("root type = %q, want hash-join", plan.Root.Type)
+	}
+	if len(plan.Root.Children) != 2 {
+		t.Fatalf("root children = %d, want 2", len(plan.Root.Children))
+	}
+	if plan.Root.CostStart != nil {
+		t.Fatal("COSTS OFF plan should carry no cost data")
+	}
+	inner := plan.Root.Children[1]
+	if inner.Type != "hash" || len(inner.Children) != 1 {
+		t.Fatalf("expected a Hash node with one child, got %+v", inner)
+	}
+	if got := inner.Children[0].Relation; got != "drivers" {
+		t.Fatalf("inner scan relation = %q, want drivers", got)
+	}
+}
+
+// A plan with neither costs nor a QUERY PLAN header still parses: the
+// first non-empty line is the root.
+func TestParseBareCostsOffPlan(t *testing.T) {
+	plan, err := Parse(" Seq Scan on drivers\n   Filter: (nationality = 'British'::text)\n")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if plan.Root.Type != "seq-scan" || plan.Root.Relation != "drivers" {
+		t.Fatalf("unexpected root: %+v", plan.Root)
+	}
+}

--- a/explain/parse_test.go
+++ b/explain/parse_test.go
@@ -1,6 +1,9 @@
 package explain
 
-import "testing"
+import (
+	"strings"
+	"testing"
+)
 
 const simplePlan = `                                    QUERY PLAN
 ═══════════════════════════════════════════════════════════════════════════════════
@@ -154,5 +157,42 @@ func TestParseBareCostsOffPlan(t *testing.T) {
 	}
 	if plan.Root.Type != "seq-scan" || plan.Root.Relation != "drivers" {
 		t.Fatalf("unexpected root: %+v", plan.Root)
+	}
+}
+
+// EXPLAIN (BUFFERS) puts a "Planning:" block, with its own indented
+// Buffers and I/O Timings lines, between the plan tree and the timings.
+// The parser used to stop dead at "Planning:", which silently dropped
+// both Planning Time and Execution Time from every buffered plan — and
+// those timings are half of what a plan comparison reports.
+func TestParseKeepsTimingsAfterPlanningBlock(t *testing.T) {
+	const buffered = ` Limit  (cost=0.14..2.06 rows=10 width=40) (actual time=0.016..0.018 rows=10 loops=1)
+   Buffers: shared hit=1 read=1
+   ->  Index Scan using season_summary_year on season_summary  (cost=0.14..13.16 rows=68 width=40) (actual time=0.016..0.017 rows=10 loops=1)
+         Buffers: shared hit=1 read=1
+ Planning:
+   Buffers: shared hit=61 read=1
+   I/O Timings: shared read=0.009
+ Planning Time: 0.181 ms
+ Execution Time: 0.032 ms
+(11 rows)
+`
+	plan, err := Parse(buffered)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if plan.PlanningTime == nil || *plan.PlanningTime != 0.181 {
+		t.Fatalf("planning time = %v, want 0.181", plan.PlanningTime)
+	}
+	if plan.ExecutionTime == nil || *plan.ExecutionTime != 0.032 {
+		t.Fatalf("execution time = %v, want 0.032", plan.ExecutionTime)
+	}
+	// The planning block's own Buffers line must not have been collected
+	// as a property of the deepest plan node.
+	scan := plan.Root.Children[0]
+	for _, p := range scan.Props {
+		if strings.Contains(p, "hit=61") {
+			t.Fatalf("planning-block line leaked into node props: %q", p)
+		}
 	}
 }


### PR DESCRIPTION
`sqlfmt` could already lay out the EXPLAIN *statement*. It had no idea what the plan text coming back looked like. This adds that, as a new `explain/` package and one subcommand namespace.

```console
$ sqlfmt explain advice plan.txt
JOIN_ORDER(f d)
MERGE_JOIN_PLAIN(d)
INDEX_SCAN(f join_fact_dim_id d join_dim_pkey)
NO_GATHER(f d)

$ sqlfmt explain diff before.txt after.txt
STRUCTURE (2 changes)
  - SEQ_SCAN(geoname)
  + INDEX_SCAN(geoname geoname_name)

NUMBERS
  execution time     18.245 ms →     0.049 ms   (-99.7%)
```

## Why this format

That is the format PostgreSQL 19's `pg_plan_advice` generates, derived here from plan text on any version. The reason to mirror a format almost nobody can run yet is what it leaves out: no cost, no row estimate, no timing, only the decisions the planner made. It is the one rendering of a plan that is stable across runs, which makes it the answer to the question a plain `diff` of two EXPLAIN outputs drowns in noise — did the shape change, or did the numbers just move?

TEXT format is the whole point. `FORMAT JSON` carries more and is easier to consume, but it is not what people have: a plan that reaches a colleague, a ticket or a mailing list is the default text psql printed, pasted verbatim. So the parser eats the messy real thing — box-drawing borders, the `QUERY PLAN` header, leading statement echoes, a trailing `(N rows)`.


## Checked against the real thing

The first cut was written from a blog post's worked example. Checking it against `contrib/pg_plan_advice` in the PostgreSQL source turned up that several tags do not exist and several that do were spelled or argued differently:

- `MERGE_JOIN`/`NESTED_LOOP` are not tags — 19 distinguishes the inner side: `MERGE_JOIN_PLAIN`/`_MATERIALIZE`, `NESTED_LOOP_PLAIN`/`_MATERIALIZE`/`_MEMOIZE`. All recoverable from plan text, since Materialize and Memoize are visible nodes.
- `INDEX_SCAN` names the index as well as the relation, and the parser was discarding index names.
- Most scan tags were invented. 19 has exactly `SEQ_SCAN`, `INDEX_SCAN`, `INDEX_ONLY_SCAN`, `BITMAP_HEAP_SCAN`, `TID_SCAN`, `DO_NOT_SCAN`.
- `GATHER_MERGE` is its own tag; a Gather over a join product is one grouped target, `GATHER((f d))`.
- Repeated aliases get 19's `#occurrence` numbering.
- `JOIN_ORDER` parenthesizes a join on the inner side; a bushy tree was flattening.

Corrected against `pgpa_ast.c` (vocabulary), `pgpa_join.c` (join strategies), the module README (argument shapes) and `pgpa_output_advice()` (line order). Tests are now driven by ten cases lifted verbatim from `contrib/pg_plan_advice/expected/*.out` — one of them caught a bug in my expectation rather than in the code, which is the point of using them.

## Three parser bugs found on the way

- **`EXPLAIN (COSTS OFF)` did not parse at all.** The parser located the plan by looking for the first `(cost=` line, and a COSTS OFF plan has none. That is how the regression suite, most documentation and every `PLAN_ADVICE` example print plans. Falls back to the `QUERY PLAN` header, then the first non-empty line.
- **Bitmap Index Scan prints `on <index>`**, so the parser stored an index name in `Relation` — the only node type where that field is not a relation. It was appearing as a participant in `JOIN_ORDER`.
- **`EXPLAIN (BUFFERS)` prints a `Planning:` block** between the tree and the timings, and the parser stopped dead at it, silently dropping Planning Time and Execution Time from every buffered plan.

## Honest about its limits

Documented in `explain/advice.go` and the README: this is a **comparison key, not a round-trippable advice string**. 19 generates advice inside the planner, which knows everything; this reconstructs from a rendering. Index names are not schema-qualified, there are no `@plan_name`/partition qualifiers, and `DO_NOT_SCAN`/`PARTITIONWISE`/`SEMIJOIN_*`/`FOREIGN_JOIN` are never emitted.

## CLI

The formatter's interface is untouched — `sqlfmt file.sql` still formats. Only a first argument of literally `explain` diverts into the new namespace. Plan work does not fit the formatter's shape: `[flags] [path...]` means "do this to each file independently", which is exactly wrong for a diff, where two plans are one operation on a pair.

## Verification

`go build`, `go vet`, `go test ./...` and `make test` all clean. Verified against the 173 captured plans in the book and course corpus: all parse, and every tag emitted exists in 19's vocabulary.