### PR TITLE
explain diff: emit unified diff

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,19 +83,29 @@ by tag rather than by position:
 
 ```console
 $ sqlfmt explain diff before.txt after.txt
-STRUCTURE (2 changes)
-  - SEQ_SCAN(geoname)
-  + INDEX_SCAN(geoname geoname_name)
+--- before.txt
++++ after.txt
+@@ plan structure @@
+-SEQ_SCAN(geoname)
++INDEX_SCAN(geoname geoname_name)
 
-NUMBERS
-  execution time     18.245 ms →     0.049 ms   (-99.7%)
-  planning time       0.301 ms →     0.306 ms   (+1.7%)
+ execution time     18.245 ms ->     0.049 ms   (-99.7%)
+ planning time       0.301 ms ->     0.306 ms   (+1.7%)
 ```
 
-Numbers are reported, but separately and always labelled as such; they are
-never mixed into the structural comparison. `explain diff` exits 0 when the
-two plans are structurally identical and 1 when they are not, so it
-composes into scripts and CI.
+The output is unified diff, which is the interoperability: every pager,
+editor, review tool and syntax highlighter already colours `-` and `+`
+lines, so this drops into `less -R`, `delta`, `bat`, a GitHub comment or a
+typeset listing and comes out right with nothing being taught how.
+
+```console
+$ sqlfmt explain diff before.txt after.txt | delta
+```
+
+The timing lines are ordinary context lines, deliberately: they are
+reported alongside the structural comparison and must never be mistaken
+for part of it. `explain diff` exits 0 when the two plans are structurally
+identical and 1 when they are not, so it composes into scripts and CI.
 
 Plans are read in psql's default TEXT format — with or without `ANALYZE`,
 with or without costs (`COSTS OFF` included), with or without the

--- a/cmd/sqlfmt/explaincmd.go
+++ b/cmd/sqlfmt/explaincmd.go
@@ -127,6 +127,10 @@ func runExplainDiff(args []string) int {
 	}
 
 	d := explain.DiffPlans(before, after)
+	// Name the two sides after the files, the way diff(1) does: a diff
+	// that does not say what it compared makes the reader remember.
+	d.BeforeName = fs.Arg(0)
+	d.AfterName = fs.Arg(1)
 	fmt.Print(d.String())
 	if d.SameStructure() {
 		return 0

--- a/explain/diff.go
+++ b/explain/diff.go
@@ -28,6 +28,13 @@ type Diff struct {
 	Structural []AdviceChange // structural differences, empty when the shape held
 	Before     *Plan
 	After      *Plan
+
+	// BeforeName and AfterName label the two sides in the ---/+++ header,
+	// the way diff(1) names its files. Empty falls back to "before" and
+	// "after", so a caller comparing two in-memory plans still gets a
+	// well-formed header.
+	BeforeName string
+	AfterName  string
 }
 
 // AdviceChange is one structural difference: an advice tag whose targets
@@ -82,36 +89,81 @@ func DiffPlans(before, after *Plan) *Diff {
 	return d
 }
 
-// String renders the diff for a terminal.
+// String renders the diff as unified-diff text.
+//
+// Unified diff rather than a bespoke layout, because the format is the
+// interoperability. Every pager, editor, review tool and syntax
+// highlighter already colours "-" and "+" lines, so this output drops
+// into `less -R`, `delta`, `bat`, a GitHub comment or a typeset listing
+// and comes out looking right with nothing else being taught how. A
+// custom shape would have to earn all of that back, and would still not
+// compose with anything.
+//
+// The ---/+++ header names what was compared, which a diff that omits it
+// leaves the reader to remember. The "@@ plan structure @@" hunk header
+// says which of the two questions this section answers.
+//
+// The timing lines are ordinary context lines, deliberately: they are
+// reported alongside the structural comparison and must never be mistaken
+// for part of it, and context is exactly the unified-diff idea of "shown,
+// not changed".
 func (d *Diff) String() string {
+	beforeName, afterName := d.BeforeName, d.AfterName
+	if beforeName == "" {
+		beforeName = "before"
+	}
+	if afterName == "" {
+		afterName = "after"
+	}
+
 	var b strings.Builder
+	fmt.Fprintf(&b, "--- %s\n", beforeName)
+	fmt.Fprintf(&b, "+++ %s\n", afterName)
+	b.WriteString("@@ plan structure @@\n")
 
 	if d.SameStructure() {
-		b.WriteString("structure unchanged — the planner made the same decisions\n")
+		b.WriteString(" structure unchanged - the planner made the same decisions\n")
 	} else {
-		fmt.Fprintf(&b, "STRUCTURE (%s)\n", plural(len(d.Structural), "change", "changes"))
 		for _, c := range d.Structural {
 			if c.Before != "" {
-				fmt.Fprintf(&b, "  - %s\n", c.Before)
+				fmt.Fprintf(&b, "-%s\n", c.Before)
 			}
 			if c.After != "" {
-				fmt.Fprintf(&b, "  + %s\n", c.After)
+				fmt.Fprintf(&b, "+%s\n", c.After)
 			}
 		}
 	}
 
-	var nums []string
+	if nums := d.numberLines(); len(nums) > 0 {
+		b.WriteString("\n")
+		for _, line := range nums {
+			fmt.Fprintf(&b, " %s\n", line)
+		}
+	}
+	return b.String()
+}
+
+// numberLines renders the timing comparison, or nothing at all when
+// either plan came from an EXPLAIN without ANALYZE. Inventing a zero for
+// a missing timing would read as a catastrophic change.
+func (d *Diff) numberLines() []string {
+	var out []string
 	if s := deltaMS("execution time", execTime(d.Before), execTime(d.After)); s != "" {
-		nums = append(nums, s)
+		out = append(out, s)
 	}
 	if s := deltaMS("planning time", planTime(d.Before), planTime(d.After)); s != "" {
-		nums = append(nums, s)
+		out = append(out, s)
 	}
-	if len(nums) > 0 {
-		b.WriteString("\nNUMBERS\n")
-		for _, n := range nums {
-			fmt.Fprintf(&b, "  %s\n", n)
-		}
+	return out
+}
+
+// AdviceText renders one plan's structure as plain text — the same
+// vocabulary the diff compares, for showing a single plan on its own.
+func AdviceText(p *Plan) string {
+	var b strings.Builder
+	for _, l := range Advice(p) {
+		b.WriteString(l.String())
+		b.WriteString("\n")
 	}
 	return b.String()
 }
@@ -139,7 +191,7 @@ func deltaMS(label string, before, after *float64) string {
 		return ""
 	}
 	b, a := *before, *after
-	s := fmt.Sprintf("%-15s %9.3f ms → %9.3f ms", label, b, a)
+	s := fmt.Sprintf("%-15s %9.3f ms -> %9.3f ms", label, b, a)
 	if b > 0 {
 		pct := (a - b) / b * 100
 		sign := "+"
@@ -149,11 +201,4 @@ func deltaMS(label string, before, after *float64) string {
 		s += fmt.Sprintf("   (%s%.1f%%)", sign, pct)
 	}
 	return s
-}
-
-func plural(n int, one, many string) string {
-	if n == 1 {
-		return fmt.Sprintf("%d %s", n, one)
-	}
-	return fmt.Sprintf("%d %s", n, many)
 }

--- a/explain/diff_test.go
+++ b/explain/diff_test.go
@@ -27,8 +27,8 @@ func TestDiffReportsScanMethodChange(t *testing.T) {
 	}
 	got := d.String()
 	for _, want := range []string{
-		"- SEQ_SCAN(drivers)",
-		"+ INDEX_SCAN(drivers drivers_nationality)",
+		"-SEQ_SCAN(drivers)",
+		"+INDEX_SCAN(drivers drivers_nationality)",
 		"execution time",
 		"-98.8%",
 	} {
@@ -91,10 +91,10 @@ func TestDiffReportsJoinMethodChange(t *testing.T) {
 		t.Fatal("expected a structural change")
 	}
 	got := d.String()
-	if !strings.Contains(got, "- HASH_JOIN(d)") {
+	if !strings.Contains(got, "-HASH_JOIN(d)") {
 		t.Errorf("missing removed HASH_JOIN:\n%s", got)
 	}
-	if !strings.Contains(got, "+ NESTED_LOOP_MATERIALIZE(d)") {
+	if !strings.Contains(got, "+NESTED_LOOP_MATERIALIZE(d)") {
 		t.Errorf("missing added NESTED_LOOP_MATERIALIZE:\n%s", got)
 	}
 }
@@ -109,7 +109,7 @@ func TestDiffReportsParallelismLoss(t *testing.T) {
 `)
 	d := DiffPlans(before, after)
 	got := d.String()
-	if !strings.Contains(got, "- GATHER(results)") || !strings.Contains(got, "+ NO_GATHER(results)") {
+	if !strings.Contains(got, "-GATHER(results)") || !strings.Contains(got, "+NO_GATHER(results)") {
 		t.Errorf("parallelism change not reported:\n%s", got)
 	}
 }
@@ -121,8 +121,8 @@ func TestDiffOmitsNumbersWithoutAnalyze(t *testing.T) {
 	before := mustParse(t, " Seq Scan on drivers\n")
 	after := mustParse(t, " Seq Scan on drivers\n")
 	got := DiffPlans(before, after).String()
-	if strings.Contains(got, "NUMBERS") {
-		t.Errorf("expected no NUMBERS section without ANALYZE:\n%s", got)
+	if strings.Contains(got, "execution time") {
+		t.Errorf("expected no timing lines without ANALYZE:\n%s", got)
 	}
 }
 
@@ -133,4 +133,42 @@ func mustParse(t *testing.T, s string) *Plan {
 		t.Fatal(err)
 	}
 	return p
+}
+
+// The output shape is now a contract, not an implementation detail: it is
+// what the book and courses typeset, and what a pager or review tool
+// colours. Pin it exactly, header and all.
+func TestDiffIsUnifiedDiffFormat(t *testing.T) {
+	before := mustParse(t, ` Seq Scan on drivers  (cost=0.00..30.40 rows=1 width=15) (actual time=0.010..18.245 rows=1 loops=1)
+ Planning Time: 0.301 ms
+ Execution Time: 18.245 ms
+`)
+	after := mustParse(t, ` Index Scan using geoname_name on drivers  (cost=0.28..8.30 rows=1 width=15) (actual time=0.020..0.049 rows=1 loops=1)
+ Planning Time: 0.306 ms
+ Execution Time: 0.049 ms
+`)
+	d := DiffPlans(before, after)
+	d.BeforeName = "4-4b-non-sargable-function"
+	d.AfterName = "4-4c-sargable-rewrite"
+
+	want := "--- 4-4b-non-sargable-function\n" +
+		"+++ 4-4c-sargable-rewrite\n" +
+		"@@ plan structure @@\n" +
+		"-SEQ_SCAN(drivers)\n" +
+		"+INDEX_SCAN(drivers geoname_name)\n" +
+		"\n" +
+		" execution time     18.245 ms ->     0.049 ms   (-99.7%)\n" +
+		" planning time       0.301 ms ->     0.306 ms   (+1.7%)\n"
+	if got := d.String(); got != want {
+		t.Fatalf("unified diff mismatch\n got:\n%s\nwant:\n%s", got, want)
+	}
+}
+
+// Unnamed sides still produce a well-formed header rather than "--- ".
+func TestDiffHeaderFallsBackWhenUnnamed(t *testing.T) {
+	p := mustParse(t, " Seq Scan on drivers\n")
+	got := DiffPlans(p, p).String()
+	if !strings.HasPrefix(got, "--- before\n+++ after\n") {
+		t.Fatalf("expected fallback header, got:\n%s", got)
+	}
 }


### PR DESCRIPTION
`explain diff` printed a bespoke layout — a `STRUCTURE` heading, indented `- `/`+ ` lines, a `NUMBERS` heading. This changes it to unified diff.

```console
$ sqlfmt explain diff before.txt after.txt
--- before.txt
+++ after.txt
@@ plan structure @@
-SEQ_SCAN(geoname)
+INDEX_SCAN(geoname geoname_name)

 execution time     18.245 ms ->     0.049 ms   (-99.7%)
 planning time       0.301 ms ->     0.306 ms   (+1.7%)
```

## Why

The custom shape was a mistake, and it surfaced as one downstream. `app.taop.xyz` typesets these comparisons into the book and courses, and had to grow its **own** renderer to get a shape a syntax highlighter would colour. Two renderers, two formats, one job — and course prose saying "`sqlfmt explain diff` does it mechanically" directly above output the command did not actually produce.

Unified diff fixes both, because the format *is* the interoperability. Every pager, editor, review tool and syntax highlighter already colours `-` and `+` lines, so the output drops into `less -R`, `delta`, `bat`, a GitHub comment or a typeset listing and comes out right with nothing else being taught how:

```console
$ sqlfmt explain diff before.txt after.txt | delta
```

A custom shape has to earn all of that back, and still composes with nothing.

## Deliberate details

- **The `---`/`+++` header names what was compared.** The old output never did — it showed a diff without saying of what. `Diff` gains `BeforeName`/`AfterName`, and the CLI fills them from the file paths the way `diff(1)` does. Unnamed sides fall back to `before`/`after` so an in-memory comparison still yields a well-formed header.
- **The timing lines are context lines, not a labelled section.** They are reported alongside the structural comparison and must never be mistaken for part of it, which is exactly what "context" means in a unified diff.
- **ASCII `->` rather than `→`.** This output lands inside fixed-width verbatim listings, where a glyph outside the monospace font is a missing-character warning waiting to happen.

Also adds `AdviceText`, the single-plan counterpart, so a caller rendering one plan's structure and a caller rendering a comparison use the same package rather than one of them reimplementing it.

## Verification

Checked byte-for-byte against the four comparisons `app.taop.xyz` already publishes — all four regenerate identically from this code. That is the check that proves there is one renderer again, rather than two that happen to agree today.

The output shape is pinned by its own test, since it is now a contract (it is what gets typeset, and what tools colour) rather than an implementation detail.

`go build`, `go vet`, `go test ./...` and `make test` all clean.