### PR TITLE
explain: name BitmapAnd and BitmapOr

### DIFF
--- a/explain/nodetype.go
+++ b/explain/nodetype.go
@@ -35,6 +35,17 @@ var nodeTypeTokens = []struct {
 	{"Index Scan", "index-scan"},
 	{"Bitmap Heap Scan", "bitmap-heap-scan"},
 	{"Bitmap Index Scan", "bitmap-index-scan"},
+	// The two bitmap-combining nodes, which PostgreSQL spells
+	// run-together. They are not scans: they consume the bitmaps their
+	// Bitmap Index Scan children produce and hand one combined bitmap up
+	// to the Bitmap Heap Scan. Missing here, they fell through to
+	// "unknown" and were displayed as a generic "Node", which is exactly
+	// the name a reader is trying to look up when an OR predicate does or
+	// does not use its indexes.
+	{"BitmapAnd", "bitmap-and"},
+	{"Bitmap And", "bitmap-and"},
+	{"BitmapOr", "bitmap-or"},
+	{"Bitmap Or", "bitmap-or"},
 	{"Tid Range Scan", "tid-range-scan"},
 	{"Tid Scan", "tid-scan"},
 	{"Sample Scan", "sample-scan"},
@@ -94,6 +105,7 @@ var nodeTypeTokens = []struct {
 var typeLabelMap = map[string]string{
 	"index-only-scan": "Index Only Scan", "index-scan": "Index Scan",
 	"bitmap-heap-scan": "Bitmap Heap Scan", "bitmap-index-scan": "Bitmap Index Scan",
+	"bitmap-and": "BitmapAnd", "bitmap-or": "BitmapOr",
 	"tid-range-scan": "Tid Range Scan", "tid-scan": "Tid Scan",
 	"sample-scan": "Sample Scan", "function-scan": "Function Scan",
 	"table-function-scan": "Table Function Scan", "values-scan": "Values Scan",

--- a/explain/nodetype_test.go
+++ b/explain/nodetype_test.go
@@ -1,0 +1,47 @@
+package explain
+
+import "testing"
+
+// BitmapAnd and BitmapOr sit between a Bitmap Heap Scan and its Bitmap
+// Index Scan children. They were absent from the token table, so they
+// parsed as "unknown" and every renderer labelled them "Node" — the
+// generic fallback, on precisely the node a reader is looking up when
+// asking whether an OR predicate used its indexes.
+func TestBitmapCombiningNodesAreNamed(t *testing.T) {
+	p, err := Parse(` Bitmap Heap Scan on results  (cost=17.76..446.98 rows=1142 width=40)
+   Recheck Cond: ((points = '25'::double precision) OR (statusid = 3))
+   ->  BitmapOr  (cost=17.76..17.76 rows=1142 width=0)
+         ->  Bitmap Index Scan on results_points_idx  (cost=0.00..4.34 rows=112 width=0)
+               Index Cond: (points = '25'::double precision)
+         ->  Bitmap Index Scan on results_statusid_idx  (cost=0.00..12.85 rows=1030 width=0)
+               Index Cond: (statusid = 3)
+`)
+	if err != nil {
+		t.Fatal(err)
+	}
+	or := p.Root.Children[0]
+	if or.Type != "bitmap-or" {
+		t.Errorf("type = %q, want bitmap-or", or.Type)
+	}
+	if got := NodeLabel(or); got != "BitmapOr" {
+		t.Errorf("label = %q, want BitmapOr", got)
+	}
+	if len(or.Children) != 2 {
+		t.Fatalf("BitmapOr has %d children, want 2", len(or.Children))
+	}
+}
+
+func TestBitmapAndSpellings(t *testing.T) {
+	for _, tok := range []string{"BitmapAnd", "Bitmap And"} {
+		typ, _, _, _ := matchNodeType(tok + "  (cost=0.00..1.00 rows=1 width=0)")
+		if typ != "bitmap-and" {
+			t.Errorf("%q -> %q, want bitmap-and", tok, typ)
+		}
+	}
+	for _, tok := range []string{"BitmapOr", "Bitmap Or"} {
+		typ, _, _, _ := matchNodeType(tok + "  (cost=0.00..1.00 rows=1 width=0)")
+		if typ != "bitmap-or" {
+			t.Errorf("%q -> %q, want bitmap-or", tok, typ)
+		}
+	}
+}


### PR DESCRIPTION
`BitmapAnd` and `BitmapOr` were absent from the node-type token table, so they parsed as `unknown` and `NodeLabel` fell back to the generic "Node" — in diagrams, flat tables and advice output alike, immediately under EXPLAIN text that spells them out.

That fallback is most visible on the node it matters most for: when you are checking whether an `OR` predicate used its indexes, the answer is the presence of a `BitmapOr`, and the renderer was calling it "Node".

Adds both types with the run-together and spaced spellings, matching the table's existing convention, plus tests parsing a real `BitmapOr` subtree.