### PR TITLE
format: fix subquery and CTE body indentation

### DIFF
--- a/STYLE.md
+++ b/STYLE.md
@@ -178,7 +178,40 @@ fixture's current content.
     computation at that new base indent. Closing `)` goes on its own line,
     indented to approximate the *opening construct's* own indent — this is
     visibly hand-tuned per instance in the source and not perfectly
-    reproducible mechanically:
+    reproducible mechanically.
+
+    "Wherever it opens" is **not** always the paren. Where the paren ends a
+    keyword phrase — `where exists (`, `where not exists (`, `where x in (`,
+    `= any(`, `left join lateral (` — the phrase is the construct's real
+    left edge, and the body's river aligns to *its* start column, with the
+    closing `)` on that column too. Hanging the body off the paren instead
+    indents it by the full width of whatever predicate or join phrase
+    happened to precede it, for no gain:
+
+    ```sql
+     where exists (
+           select 1
+             from results res
+             join races r on r.raceid = res.raceid
+            where res.driverid = d.driverid
+           )
+    ```
+
+    Where the paren itself opens the construct — a scalar subquery in a
+    select list, a derived table in `FROM` — the body is indented *inside*
+    the paren (2 columns) and the closing `)` returns to the paren's own
+    column:
+
+    ```sql
+      select ds.driverid,
+             (
+               select count(*) + 1
+                 from driverstandings inner_ds
+                where inner_ds.raceid = ds.raceid
+             ) as rank
+    ```
+
+    A subquery whose body fits on one line stays inline, parens and all.
     ```sql
     select *
       from get_all_albums(

--- a/STYLE.md
+++ b/STYLE.md
@@ -182,20 +182,27 @@ fixture's current content.
 
     "Wherever it opens" is **not** always the paren. Where the paren ends a
     keyword phrase — `where exists (`, `where not exists (`, `where x in (`,
-    `= any(`, `left join lateral (` — the phrase is the construct's real
-    left edge, and the body's river aligns to *its* start column, with the
-    closing `)` on that column too. Hanging the body off the paren instead
-    indents it by the full width of whatever predicate or join phrase
-    happened to precede it, for no gain:
+    `= any(` — the phrase is the construct's real left edge. The paren
+    moves to a line of its own at *that* column, the body is indented
+    inside it, and the closing `)` returns to it, so the three lines
+    bracket the subquery:
 
     ```sql
-     where exists (
-           select 1
-             from results res
-             join races r on r.raceid = res.raceid
-            where res.driverid = d.driverid
+     where exists
+           (
+             select 1
+               from results res
+               join races r on r.raceid = res.raceid
+              where res.driverid = d.driverid
            )
     ```
+
+    Leaving the paren at the end of `where exists (` reads as though the
+    subquery were part of the predicate rather than its whole right-hand
+    side, and leaves the body hanging off a column the eye has no reason
+    to expect. Hanging the body off the paren *itself* is worse again: it
+    indents the subquery by the full width of whatever predicate happened
+    to precede it, for no gain.
 
     Where the paren itself opens the construct — a scalar subquery in a
     select list, a derived table in `FROM` — the body is indented *inside*

--- a/format/layout.go
+++ b/format/layout.go
@@ -316,13 +316,56 @@ func isJoinModifier(lower string) bool {
 // output with spaces -- so a LATERAL subquery, which renderRun lays out
 // across several lines, was folded back onto the JOIN line and ran to
 // hundreds of columns. Always returns at least one line.
-func joinTableLines(toks []Token, col int) []string {
+// joinTableLines renders the relation a JOIN joins to, starting at column
+// col. phraseCol is the column the join keyword phrase itself starts at.
+//
+// A derived table -- "left join lateral (select ...)" -- aligns its body
+// to the JOIN PHRASE, not to the paren: by the time the paren is reached
+// the phrase has already consumed a dozen columns, and hanging the
+// subquery off it indents the whole derived table further right than
+// anything it relates to, wrapping expressions that fitted before. This
+// has to be decided here rather than in renderRun's own subquery branch,
+// because layoutFrom strips the join keywords into the phrase before
+// calling this -- so renderRun never sees the "lateral" that would have
+// told it where the construct really starts.
+func joinTableLines(toks []Token, col, phraseCol int) []string {
 	toks = trimTokens(toks)
+	if lines, ok := subqueryRelationLines(toks, phraseCol); ok {
+		return lines
+	}
 	lines := renderRun(toks, col)
 	if len(lines) == 0 {
 		return []string{""}
 	}
 	return lines
+}
+
+// subqueryRelationLines lays out "(select ...) alias" as a derived table
+// whose body is indented under baseCol and whose closing paren returns to
+// it. Declines anything that is not a parenthesized query, and anything
+// whose body fits on one line (which renderRun already keeps inline).
+func subqueryRelationLines(toks []Token, baseCol int) ([]string, bool) {
+	if len(toks) == 0 || toks[0].Text != "(" {
+		return nil, false
+	}
+	close := matchParen(toks, 0)
+	if close <= 0 {
+		return nil, false
+	}
+	inner := trimTokens(toks[1:close])
+	if !isQueryStart(inner) {
+		return nil, false
+	}
+	body := formatQuerySegment(inner, baseCol+2)
+	if len(body) < 2 {
+		return nil, false
+	}
+	lines := append([]string{"("}, body...)
+	tail := strings.Repeat(" ", baseCol) + ")"
+	if rest := trimTokens(toks[close+1:]); len(rest) > 0 {
+		tail += " " + plainJoin(rest)
+	}
+	return append(lines, tail), true
 }
 
 // longestAt returns the widest line of a rendered body whose first line
@@ -937,30 +980,35 @@ func renderRun(toks []Token, col int) []string {
 				write(" ")
 			}
 			if isSubquery {
-				content := formatQuerySegment(inner, curCol)
+				// openCol is where the "(" itself will land, which is the
+				// current column plus the space (if any) about to precede
+				// it. The old code asked leadingSpaces() for this, but
+				// renderRun's line 0 is a continuation of the CALLER's
+				// line and so carries no indent of its own -- so every
+				// subquery opened on a first line was laid out as though
+				// it sat at column 0.
+				// The space, if any, has already been written above, so
+				// curCol is exactly where "(" lands.
+				openCol := curCol
+				bodyIndent, closeIndent := subqueryIndents(toks, i, openCol, needSpace)
+				content := formatQuerySegment(inner, bodyIndent)
 				if len(content) > 1 {
-					// A multi-line subquery deep inside an expression would
-					// otherwise hang off whatever column its enclosing
-					// paren happened to reach; break it onto its own,
-					// boundedly-indented lines instead (STYLE.md rule 12,
-					// explicitly best-effort).
-					breakIndent := leadingSpaces(lines[len(lines)-1]) + 2
-					content = formatQuerySegment(inner, breakIndent)
+					// STYLE.md rule 12: the body is indented under the
+					// construct that opens it, and the closing paren is
+					// indented to that construct's own column. content
+					// already carries bodyIndent -- appending the lines
+					// as they are is what keeps the body's first clause
+					// keyword on the same river as the rest of its
+					// clauses.
 					write("(")
-					lines = append(lines, strings.Repeat(" ", breakIndent))
-					curCol = breakIndent
-					merge(content)
-					closeIndent := breakIndent - 2
-					if closeIndent < 0 {
-						closeIndent = 0
-					}
+					lines = append(lines, content...)
 					lines = append(lines, strings.Repeat(" ", closeIndent)+")")
 					curCol = closeIndent + 1
 				} else {
 					// Content fits on one line: keep the closing paren
 					// glued to it too, rather than forcing an extra line.
 					write("(")
-					merge(content)
+					write(strings.TrimLeft(content[0], " "))
 					write(")")
 				}
 			} else {
@@ -1657,14 +1705,27 @@ func formatQuerySegment(toks []Token, baseIndent int) []string {
 		}
 	}
 
+	// Every return below carries baseIndent, including the one-line ones.
+	// They used not to, which made this function's contract depend on how
+	// its result happened to come out: callers that add the indent
+	// themselves were correct for a body that fitted on one line and
+	// double-indented one that wrapped, and callers that don't were the
+	// other way round. Both kinds existed. renderRun's subquery branch
+	// then compounded it by deriving its indent from the leading spaces of
+	// a line that is often a continuation of the caller's, i.e. not
+	// indented at all -- which is why a wrapped subquery came out with its
+	// first clause keyword two columns right of the river its own FROM and
+	// WHERE were aligned to.
+	pad := strings.Repeat(" ", baseIndent)
+
 	segs := splitClauses(toks)
 	if segs == nil {
-		return []string{flatJoin(toks)}
+		return []string{pad + flatJoin(toks)}
 	}
 	width := riverWidth(segs)
 
 	if fitsInline(segs, baseIndent, width) && !anyTokenComments(toks) {
-		return []string{flatJoin(toks)}
+		return []string{pad + flatJoin(toks)}
 	}
 
 	var lines []string
@@ -1858,7 +1919,7 @@ func layoutFrom(toks []Token, baseIndent, width int) []string {
 		}
 		if onIdx == -1 {
 			head := strings.Repeat(" ", phrasePad) + phrase + " "
-			tl := joinTableLines(rest, len(head))
+			tl := joinTableLines(rest, len(head), phrasePad)
 			tl[len(tl)-1] += segTrailing
 			out = append(out, head+tl[0])
 			out = append(out, tl[1:]...)
@@ -1868,7 +1929,7 @@ func layoutFrom(toks []Token, baseIndent, width int) []string {
 		condPart := trimTokens(rest[onIdx+1:])
 		preds, ops := splitAndOr(condPart)
 		head := strings.Repeat(" ", phrasePad) + phrase + " "
-		tl := joinTableLines(tablePart, len(head))
+		tl := joinTableLines(tablePart, len(head), phrasePad)
 		if len(preds) == 1 {
 			// Single-condition ON stays inline after the join keyword
 			// phrase -- unless the table part is a subquery that wrapped,
@@ -2051,13 +2112,15 @@ func renderCTE(cte []Token, baseIndent int, more bool, withPrefix string) []stri
 	}
 	close := matchParen(cte, open)
 	inner := cte[open+1 : close]
+	// STYLE.md rule 13: body indented 2 spaces from the CTE's own base.
+	// formatQuerySegment applies that indent itself -- adding it again
+	// here put a wrapped CTE body at 4, while a body that fitted on one
+	// line (which used to come back unindented) landed at the correct 2.
 	bodyIndent := baseIndent + 2
 	bodyLines := formatQuerySegment(inner, bodyIndent)
 	lines := lead
 	lines = append(lines, strings.Repeat(" ", baseIndent)+name+asText)
-	for _, l := range bodyLines {
-		lines = append(lines, strings.Repeat(" ", bodyIndent)+l)
-	}
+	lines = append(lines, bodyLines...)
 	closing := strings.Repeat(" ", baseIndent) + ")"
 	if tail := trimTokens(cte[close+1:]); len(tail) > 0 {
 		closing += " " + plainJoin(tail)
@@ -2068,4 +2131,92 @@ func renderCTE(cte []Token, baseIndent int, more bool, withPrefix string) []stri
 	closing += trailingCommentSuffix(cte)
 	lines = append(lines, closing)
 	return lines
+}
+
+// subqueryIntroducers are the operators that take a parenthesized
+// subquery as their right-hand side. They matter for layout because the
+// paren then sits at the END of a line -- "where exists (" -- so the
+// paren's own column is a poor place to hang the body off: it would push
+// the whole subquery right by the width of the predicate that precedes
+// it, for no reason. The operator's own column is the construct's real
+// left edge, and that is what the body aligns to.
+var subqueryIntroducers = map[string]bool{
+	"exists": true, "in": true, "any": true, "all": true, "some": true,
+	// LATERAL is the same shape: "left join lateral (" ends a long join
+	// phrase, so hanging the derived table off the paren's own column
+	// pushes it a dozen columns right of anything it relates to and
+	// starts wrapping expressions that fitted before.
+	"lateral": true,
+}
+
+// subqueryIndents returns the column the subquery body's river should
+// start at, and the column its closing paren should sit at, for the "("
+// at toks[open] landing at column openCol.
+//
+// Two shapes, per STYLE.md rule 12's "indent the subquery body under
+// wherever it opens":
+//
+//   - after an introducing operator, the body aligns under the OPERATOR
+//     and the closing paren with it:
+//
+//     where exists (
+//     select 1
+//     from results res
+//     ...
+//     )
+//
+//     (the body's leftmost keyword lines up under "exists")
+//
+//   - otherwise the paren itself opens the construct -- a scalar
+//     subquery in a select list, a derived table in FROM -- so the body
+//     is indented inside it and the closing paren returns to its column.
+func subqueryIndents(toks []Token, open, openCol int, spaced bool) (body, close int) {
+	if introCol, ok := introducerCol(toks, open, openCol, spaced); ok {
+		return introCol, introCol
+	}
+	return openCol + 2, openCol
+}
+
+// introducerCol finds the start column of the operator phrase immediately
+// before the "(" at toks[open], if that operator is one that takes a
+// subquery. The column is derived by counting back from the paren rather
+// than tracked per token: the phrase is on the same line as the paren by
+// construction (renderRun has just written it), so its width is its
+// rendered width. A phrase that would start left of column 0 means it
+// actually wrapped, and is declined.
+func introducerCol(toks []Token, open, openCol int, spaced bool) (int, bool) {
+	if open == 0 {
+		return 0, false
+	}
+	// Matched on the word, not on TokKeyword: "any" and "some" are not in
+	// the lexer's keyword table (they are only operators in this one
+	// position, and adding them there would change how they lex
+	// everywhere else), so they arrive as TokIdent and would otherwise
+	// miss. A quoted identifier is never an operator, and the caller has
+	// already established that what follows is a subquery, so there is no
+	// real function-named-"any" to confuse this with.
+	prev := toks[open-1]
+	if prev.Kind != TokKeyword && prev.Kind != TokIdent {
+		return 0, false
+	}
+	if !subqueryIntroducers[prev.Lower] {
+		return 0, false
+	}
+	phrase := prev.Lower
+	if open >= 2 {
+		if pp := toks[open-2]; pp.Kind == TokKeyword && pp.Lower == "not" {
+			phrase = "not " + phrase
+		}
+	}
+	// openCol is the paren's column. The operator ends right before it,
+	// with a space between only when one was actually written -- "any("
+	// takes none (rule 4), and assuming one put its body a column off.
+	col := openCol - len(phrase)
+	if spaced {
+		col--
+	}
+	if col < 0 {
+		return 0, false
+	}
+	return col, true
 }

--- a/format/layout.go
+++ b/format/layout.go
@@ -990,20 +990,40 @@ func renderRun(toks []Token, col int) []string {
 				// The space, if any, has already been written above, so
 				// curCol is exactly where "(" lands.
 				openCol := curCol
-				bodyIndent, closeIndent := subqueryIndents(toks, i, openCol, needSpace)
-				content := formatQuerySegment(inner, bodyIndent)
+				introCol, hasIntro := introducerCol(toks, i, openCol, needSpace)
+				// After an introducing operator the paren moves to a line
+				// of its own, at the OPERATOR's column; otherwise it stays
+				// where it already is. Either way the body is indented
+				// inside the paren and the closing paren returns to the
+				// paren's own column, so a subquery always reads as one
+				// bracketed block with its own margin.
+				parenCol := openCol
+				if hasIntro {
+					parenCol = introCol
+				}
+				content := formatQuerySegment(inner, parenCol+2)
 				if len(content) > 1 {
-					// STYLE.md rule 12: the body is indented under the
-					// construct that opens it, and the closing paren is
-					// indented to that construct's own column. content
-					// already carries bodyIndent -- appending the lines
-					// as they are is what keeps the body's first clause
-					// keyword on the same river as the rest of its
+					if hasIntro {
+						// "where exists (" put the paren at the end of a
+						// long predicate line, which reads as though the
+						// subquery belonged to the predicate rather than
+						// being its whole right-hand side -- and left the
+						// body hanging off a column the eye has no reason
+						// to expect. On its own line under the operator,
+						// the open paren, the body and the close paren
+						// form a visible bracket.
+						lines[len(lines)-1] = strings.TrimRight(lines[len(lines)-1], " ")
+						lines = append(lines, strings.Repeat(" ", parenCol)+"(")
+					} else {
+						write("(")
+					}
+					// content already carries its indent -- appending the
+					// lines as they are is what keeps the body's first
+					// clause keyword on the same river as the rest of its
 					// clauses.
-					write("(")
 					lines = append(lines, content...)
-					lines = append(lines, strings.Repeat(" ", closeIndent)+")")
-					curCol = closeIndent + 1
+					lines = append(lines, strings.Repeat(" ", parenCol)+")")
+					curCol = parenCol + 1
 				} else {
 					// Content fits on one line: keep the closing paren
 					// glued to it too, rather than forcing an extra line.
@@ -2147,34 +2167,6 @@ var subqueryIntroducers = map[string]bool{
 	// pushes it a dozen columns right of anything it relates to and
 	// starts wrapping expressions that fitted before.
 	"lateral": true,
-}
-
-// subqueryIndents returns the column the subquery body's river should
-// start at, and the column its closing paren should sit at, for the "("
-// at toks[open] landing at column openCol.
-//
-// Two shapes, per STYLE.md rule 12's "indent the subquery body under
-// wherever it opens":
-//
-//   - after an introducing operator, the body aligns under the OPERATOR
-//     and the closing paren with it:
-//
-//     where exists (
-//     select 1
-//     from results res
-//     ...
-//     )
-//
-//     (the body's leftmost keyword lines up under "exists")
-//
-//   - otherwise the paren itself opens the construct -- a scalar
-//     subquery in a select list, a derived table in FROM -- so the body
-//     is indented inside it and the closing paren returns to its column.
-func subqueryIndents(toks []Token, open, openCol int, spaced bool) (body, close int) {
-	if introCol, ok := introducerCol(toks, open, openCol, spaced); ok {
-		return introCol, introCol
-	}
-	return openCol + 2, openCol
 }
 
 // introducerCol finds the start column of the operator phrase immediately

--- a/format/plpgsql_test.go
+++ b/format/plpgsql_test.go
@@ -71,7 +71,19 @@ $$;`
 	if !strings.Contains(got, "perform (") {
 		t.Errorf("PERFORM keyword lost:\n%s", got)
 	}
-	if !strings.Contains(got, "\n           select ") && !strings.Contains(got, "\n     select ") {
+	// Indented more deeply than PERFORM itself, on its own line -- the
+	// point is that the argument got the query layout, not that it landed
+	// on one particular column. Pinning the column made this test fail
+	// for a change that moved the subquery river to where STYLE.md rule
+	// 12 actually asks for it.
+	formatted := false
+	for _, l := range strings.Split(got, "\n") {
+		if t := strings.TrimLeft(l, " "); strings.HasPrefix(t, "select ") &&
+			len(l)-len(t) > len("  perform") {
+			formatted = true
+		}
+	}
+	if !formatted {
 		t.Errorf("embedded query not formatted:\n%s", got)
 	}
 	for _, l := range strings.Split(got, "\n") {

--- a/format/subquery_test.go
+++ b/format/subquery_test.go
@@ -17,49 +17,59 @@ func leftCol(out, want string) int {
 	return -1
 }
 
-// A subquery after EXISTS aligns its body under the EXISTS, not under the
-// paren -- the paren sits at the end of the predicate, so hanging the body
-// off it indents the subquery by the width of whatever preceded it.
+// A subquery after EXISTS gets its own bracket: the paren moves to a line
+// of its own at the EXISTS column, the body is indented inside it, and the
+// closing paren returns to that column.
 //
-// The regression this pins is worse than a wrong indent: the body's own
-// clause keywords were river-aligned at one base while its first line was
-// emitted at another, so SELECT sat two columns right of the FROM and
+// Leaving the paren at the end of "where exists (" reads as though the
+// subquery were part of the predicate rather than its whole right-hand
+// side, and leaves the body hanging off a column the eye has no reason to
+// expect. The three lines together make the extent of the subquery
+// visible without reading it.
+//
+// The regression underneath this is worse than a wrong indent: the body's
+// own clause keywords were river-aligned at one base while its first line
+// was emitted at another, so SELECT sat two columns right of the FROM and
 // WHERE that were supposed to align with it.
-func TestSubqueryAfterExistsAlignsUnderKeyword(t *testing.T) {
+func TestSubqueryAfterExistsBracketsUnderKeyword(t *testing.T) {
 	out := fmtOne(t, `select d.surname from f1db.drivers d
 where exists (select 1 from f1db.results res
 join f1db.races r on r.raceid = res.raceid
 where res.driverid = d.driverid and r.year = 2017 and res.positionorder = 1)
 order by d.surname;`)
 
-	exists := leftCol(out, "where exists (") + len("where ")
-	if exists < 0 {
+	exists := leftCol(out, "where exists") + len("where ")
+	if exists < len("where ") {
 		t.Fatalf("no exists line:\n%s", out)
 	}
-	for _, kw := range []string{"select 1", "from f1db.results"} {
-		if c := leftCol(out, kw); c < 0 {
-			t.Fatalf("missing %q:\n%s", kw, out)
-		}
+	if !strings.Contains(out, "\n"+strings.Repeat(" ", exists)+"(\n") {
+		t.Errorf("open paren not alone on the EXISTS column %d:\n%s", exists, out)
+	}
+	if !strings.Contains(out, "\n"+strings.Repeat(" ", exists)+")\n") {
+		t.Errorf("close paren not alone on the EXISTS column %d:\n%s", exists, out)
 	}
 	// select is the longest keyword at that level, so it is the river's
-	// left edge and lands exactly on the EXISTS column.
-	if c := leftCol(out, "select 1"); c != exists {
-		t.Errorf("subquery river at %d, want %d (the EXISTS column):\n%s", c, exists, out)
+	// left edge: two columns inside the paren.
+	if c := leftCol(out, "select 1"); c != exists+2 {
+		t.Errorf("subquery river at %d, want %d (inside the paren):\n%s", c, exists+2, out)
 	}
 	// FROM is one shorter than SELECT, so it sits two columns right of it.
-	if c := leftCol(out, "from f1db.results"); c != exists+2 {
-		t.Errorf("subquery FROM at %d, want %d:\n%s", c, exists+2, out)
+	if c := leftCol(out, "from f1db.results"); c != exists+4 {
+		t.Errorf("subquery FROM at %d, want %d:\n%s", c, exists+4, out)
 	}
 }
 
-// NOT EXISTS aligns to the "not", not to the "exists".
-func TestSubqueryAfterNotExistsAlignsUnderNot(t *testing.T) {
+// NOT EXISTS brackets under the "not", not under the "exists".
+func TestSubqueryAfterNotExistsBracketsUnderNot(t *testing.T) {
 	out := fmtOne(t, `select a from t
 where not exists (select 1 from u where u.id = t.id and u.x = 1
 and u.y = 2 and u.zzzzzzzzzzzz = 3 and u.wwwwwwwwww = 4);`)
-	not := leftCol(out, "where not exists (") + len("where ")
-	if c := leftCol(out, "select 1"); c != not {
-		t.Errorf("subquery river at %d, want %d (the NOT column):\n%s", c, not, out)
+	not := leftCol(out, "where not exists") + len("where ")
+	if !strings.Contains(out, "\n"+strings.Repeat(" ", not)+"(\n") {
+		t.Errorf("open paren not alone on the NOT column %d:\n%s", not, out)
+	}
+	if c := leftCol(out, "select 1"); c != not+2 {
+		t.Errorf("subquery river at %d, want %d:\n%s", c, not+2, out)
 	}
 }
 
@@ -123,21 +133,26 @@ select a from c;`)
 
 // "any(" takes no space before its paren (rule 4), so the operator's
 // column is one nearer the paren than a spaced introducer's would be.
-func TestAnySubqueryAlignsUnderOperator(t *testing.T) {
+func TestAnySubqueryBracketsUnderOperator(t *testing.T) {
 	out := fmtOne(t, `select a from t where t.id = any (select u.id from u
 where u.x = 1 and u.yyyyy = 22 and u.zzzzzzzz = 3 and u.wwwwwwwwww = 4);`)
-	line := ""
+	// "any" takes no space before its paren (rule 4), so the operator's
+	// column has to be found on the line rather than assumed one space
+	// left of the paren -- the off-by-one this pins.
+	col := -1
 	for _, l := range strings.Split(out, "\n") {
-		if strings.Contains(l, "any(") {
-			line = l
+		if i := strings.Index(l, "= any"); i >= 0 {
+			col = i + len("= ")
 		}
 	}
-	if line == "" {
-		t.Fatalf("no any( line:\n%s", out)
+	if col < 0 {
+		t.Fatalf("no ANY line:\n%s", out)
 	}
-	want := strings.Index(line, "any(")
-	if c := leftCol(out, "select u.id"); c != want {
-		t.Errorf("subquery river at %d, want %d (the ANY column):\n%s", c, want, out)
+	if !strings.Contains(out, "\n"+strings.Repeat(" ", col)+"(\n") {
+		t.Errorf("open paren not alone on the ANY column %d:\n%s", col, out)
+	}
+	if c := leftCol(out, "select u.id"); c != col+2 {
+		t.Errorf("subquery river at %d, want %d:\n%s", c, col+2, out)
 	}
 }
 

--- a/format/subquery_test.go
+++ b/format/subquery_test.go
@@ -1,0 +1,161 @@
+package format
+
+import (
+	"strings"
+	"testing"
+)
+
+// leftCol returns the indent of the first line whose trimmed text starts
+// with want, or -1.
+func leftCol(out, want string) int {
+	for _, l := range strings.Split(out, "\n") {
+		t := strings.TrimLeft(l, " ")
+		if strings.HasPrefix(t, want) {
+			return len(l) - len(t)
+		}
+	}
+	return -1
+}
+
+// A subquery after EXISTS aligns its body under the EXISTS, not under the
+// paren -- the paren sits at the end of the predicate, so hanging the body
+// off it indents the subquery by the width of whatever preceded it.
+//
+// The regression this pins is worse than a wrong indent: the body's own
+// clause keywords were river-aligned at one base while its first line was
+// emitted at another, so SELECT sat two columns right of the FROM and
+// WHERE that were supposed to align with it.
+func TestSubqueryAfterExistsAlignsUnderKeyword(t *testing.T) {
+	out := fmtOne(t, `select d.surname from f1db.drivers d
+where exists (select 1 from f1db.results res
+join f1db.races r on r.raceid = res.raceid
+where res.driverid = d.driverid and r.year = 2017 and res.positionorder = 1)
+order by d.surname;`)
+
+	exists := leftCol(out, "where exists (") + len("where ")
+	if exists < 0 {
+		t.Fatalf("no exists line:\n%s", out)
+	}
+	for _, kw := range []string{"select 1", "from f1db.results"} {
+		if c := leftCol(out, kw); c < 0 {
+			t.Fatalf("missing %q:\n%s", kw, out)
+		}
+	}
+	// select is the longest keyword at that level, so it is the river's
+	// left edge and lands exactly on the EXISTS column.
+	if c := leftCol(out, "select 1"); c != exists {
+		t.Errorf("subquery river at %d, want %d (the EXISTS column):\n%s", c, exists, out)
+	}
+	// FROM is one shorter than SELECT, so it sits two columns right of it.
+	if c := leftCol(out, "from f1db.results"); c != exists+2 {
+		t.Errorf("subquery FROM at %d, want %d:\n%s", c, exists+2, out)
+	}
+}
+
+// NOT EXISTS aligns to the "not", not to the "exists".
+func TestSubqueryAfterNotExistsAlignsUnderNot(t *testing.T) {
+	out := fmtOne(t, `select a from t
+where not exists (select 1 from u where u.id = t.id and u.x = 1
+and u.y = 2 and u.zzzzzzzzzzzz = 3 and u.wwwwwwwwww = 4);`)
+	not := leftCol(out, "where not exists (") + len("where ")
+	if c := leftCol(out, "select 1"); c != not {
+		t.Errorf("subquery river at %d, want %d (the NOT column):\n%s", c, not, out)
+	}
+}
+
+// A scalar subquery in the select list opens with its own paren, so the
+// body is indented inside that paren and the closing paren returns to it.
+func TestScalarSubqueryIndentsInsideItsParen(t *testing.T) {
+	out := fmtOne(t, `select ds.driverid, ds.points,
+(select count(*) + 1 from f1db.driverstandings inner_ds
+where inner_ds.raceid = ds.raceid and inner_ds.points > ds.points) as rank
+from f1db.driverstandings ds order by rank;`)
+
+	open := leftCol(out, "(")
+	if open < 0 {
+		t.Fatalf("no lone open paren:\n%s", out)
+	}
+	if c := leftCol(out, "select count(*)"); c != open+2 {
+		t.Errorf("body at %d, want %d (inside the paren):\n%s", c, open+2, out)
+	}
+	if c := leftCol(out, ") as rank"); c != open {
+		t.Errorf("closing paren at %d, want %d (the opening paren's column):\n%s", c, open, out)
+	}
+}
+
+// A derived table aligns to the JOIN phrase. layoutFrom folds the join
+// keywords into a phrase before rendering the relation, so the paren path
+// cannot see the LATERAL that marks where the construct starts -- this
+// pins the separate path that handles it.
+func TestLateralDerivedTableAlignsToJoinPhrase(t *testing.T) {
+	out := fmtOne(t, `select decade, wins from decades
+left join lateral (select code, forename, surname, count(*) as wins
+from drivers join results on results.driverid = drivers.driverid
+where extract('year' from date_trunc('decade', races.date)) = decades.decade
+group by decades.decade, drivers.driverid order by wins desc limit 3) as winners
+on true order by decade;`)
+
+	join := leftCol(out, "left join lateral (")
+	if join < 0 {
+		t.Fatalf("no lateral join line:\n%s", out)
+	}
+	if c := leftCol(out, ") as winners"); c != join {
+		t.Errorf("closing paren at %d, want %d (the join phrase's column):\n%s", c, join, out)
+	}
+	if c := leftCol(out, "group by decades.decade"); c != join+2 {
+		t.Errorf("derived-table river at %d, want %d:\n%s", c, join+2, out)
+	}
+}
+
+// STYLE.md rule 13: a CTE body is indented 2 from the CTE's own base. A
+// body that wrapped used to land at 4, because renderCTE added the indent
+// that formatQuerySegment had already applied -- while a body that fitted
+// on one line came back unindented and so landed correctly. Same call,
+// two contracts.
+func TestCTEBodyIndentedTwo(t *testing.T) {
+	out := fmtOne(t, `with c as (select id, name, x from u
+where u.x = 1 and u.y = 2 and u.zzzzzzzzz = 3 and u.wwwwwwwww = 9)
+select a from c;`)
+	if c := leftCol(out, "select id"); c != 2 {
+		t.Errorf("CTE body at %d, want 2:\n%s", c, out)
+	}
+}
+
+// "any(" takes no space before its paren (rule 4), so the operator's
+// column is one nearer the paren than a spaced introducer's would be.
+func TestAnySubqueryAlignsUnderOperator(t *testing.T) {
+	out := fmtOne(t, `select a from t where t.id = any (select u.id from u
+where u.x = 1 and u.yyyyy = 22 and u.zzzzzzzz = 3 and u.wwwwwwwwww = 4);`)
+	line := ""
+	for _, l := range strings.Split(out, "\n") {
+		if strings.Contains(l, "any(") {
+			line = l
+		}
+	}
+	if line == "" {
+		t.Fatalf("no any( line:\n%s", out)
+	}
+	want := strings.Index(line, "any(")
+	if c := leftCol(out, "select u.id"); c != want {
+		t.Errorf("subquery river at %d, want %d (the ANY column):\n%s", c, want, out)
+	}
+}
+
+// Formatting the formatter's own output must not move anything. Every
+// indent bug above produced output that shifted again on a second pass.
+func TestSubqueryLayoutIsIdempotent(t *testing.T) {
+	for _, src := range []string{
+		`select a from t where exists (select 1 from u where u.id = t.id
+and u.x = 1 and u.yyyyyyyyyy = 2 and u.zzzzzzzzzz = 3 and u.w = 4);`,
+		`select a, (select count(*) from u where u.id = t.id and u.x = 1
+and u.yyyyyyyyyyyy = 2 and u.zzzzzzzzzzzz = 3) as n from t;`,
+		`with c as (select id, name from u where u.x = 1 and u.yyyyyyyy = 2
+and u.zzzzzzzzzz = 3) select a from c;`,
+	} {
+		once := fmtOne(t, src)
+		twice := fmtOne(t, once)
+		if once != twice {
+			t.Errorf("not idempotent:\n--- once ---\n%s\n--- twice ---\n%s", once, twice)
+		}
+	}
+}

--- a/testdata/corpus/hstore-04_01_artists.update.hstore.sql
+++ b/testdata/corpus/hstore-04_01_artists.update.hstore.sql
@@ -29,10 +29,11 @@ ins as (
               wiki_qid,
               ulan
          from batch
-        where not exists (
-              select 1
-                from moma.artist
-               where artist.constituentid = batch.constituentid
+        where not exists
+              (
+                select 1
+                  from moma.artist
+                 where artist.constituentid = batch.constituentid
               )
   on conflict (constituentid) do nothing
     returning artist.constituentid

--- a/testdata/corpus/hstore-04_01_artists.update.hstore.sql
+++ b/testdata/corpus/hstore-04_01_artists.update.hstore.sql
@@ -5,35 +5,37 @@ create temp table batch(like moma.artist including all) on commit drop;
 \copy batch from 'artists/artists.2017-07-01.csv' with csv header delimiter ','
 
 with upd as (
-       update moma.artist
-          set (name, bio, nationality, gender, begin, "end", wiki_qid, ulan)
-            = (batch.name, batch.bio, batch.nationality, batch.gender,
-               batch.begin, batch."end", batch.wiki_qid, batch.ulan)
-         from batch
-        where batch.constituentid = artist.constituentid
-          and (artist.name, artist.bio, artist.nationality, artist.gender,
-               artist.begin, artist."end", artist.wiki_qid, artist.ulan)
-           <> (batch.name, batch.bio, batch.nationality, batch.gender,
-               batch.begin, batch."end", batch.wiki_qid, batch.ulan)
-    returning artist.constituentid
+     update moma.artist
+        set (name, bio, nationality, gender, begin, "end", wiki_qid, ulan)
+          = (batch.name, batch.bio, batch.nationality, batch.gender,
+             batch.begin, batch."end", batch.wiki_qid, batch.ulan)
+       from batch
+      where batch.constituentid = artist.constituentid
+        and (artist.name, artist.bio, artist.nationality, artist.gender,
+             artist.begin, artist."end", artist.wiki_qid, artist.ulan)
+         <> (batch.name, batch.bio, batch.nationality, batch.gender,
+             batch.begin, batch."end", batch.wiki_qid, batch.ulan)
+  returning artist.constituentid
 ),
 ins as (
-    insert into moma.artist
-         select constituentid,
-                name,
-                bio,
-                nationality,
-                gender,
-                begin,
-                "end",
-                wiki_qid,
-                ulan
-           from batch
-          where not exists (
-    select 1 from moma.artist where artist.constituentid = batch.constituentid
-  )
-    on conflict (constituentid) do nothing
-      returning artist.constituentid
+  insert into moma.artist
+       select constituentid,
+              name,
+              bio,
+              nationality,
+              gender,
+              begin,
+              "end",
+              wiki_qid,
+              ulan
+         from batch
+        where not exists (
+              select 1
+                from moma.artist
+               where artist.constituentid = batch.constituentid
+              )
+  on conflict (constituentid) do nothing
+    returning artist.constituentid
 )
 select (select count(*) from upd) as updates,
        (select count(*) from ins) as inserts;

--- a/testdata/corpus/hyperloglog-05_01_tweets.hll.sql
+++ b/testdata/corpus/hyperloglog-05_01_tweets.hll.sql
@@ -3,11 +3,12 @@ begin;
 with new_visitors as (
      delete
        from tweet.visitor
-      where id = any(
-                   select id
-                     from tweet.visitor
-                 order by datetime, messageid for update skip locked
-                    limit 1000
+      where id = any
+                 (
+                     select id
+                       from tweet.visitor
+                   order by datetime, messageid for update skip locked
+                      limit 1000
                  )
   returning messageid,
             cast (datetime as date) as date,

--- a/testdata/corpus/hyperloglog-05_01_tweets.hll.sql
+++ b/testdata/corpus/hyperloglog-05_01_tweets.hll.sql
@@ -1,22 +1,22 @@
 begin;
 
 with new_visitors as (
-       delete
-         from tweet.visitor
-        where id = any(
-        select id
-        from tweet.visitor
-    order by datetime, messageid for update skip locked
-       limit 1000
-  )
-    returning messageid,
-              cast (datetime as date) as date,
-              hll_hash_text(ipaddr::text) as visitors
+     delete
+       from tweet.visitor
+      where id = any(
+                   select id
+                     from tweet.visitor
+                 order by datetime, messageid for update skip locked
+                    limit 1000
+                 )
+  returning messageid,
+            cast (datetime as date) as date,
+            hll_hash_text(ipaddr::text) as visitors
 ),
 new_visitor_groups as (
-      select messageid, date, hll_add_agg(visitors) as visitors
-        from new_visitors
-    group by messageid, date
+    select messageid, date, hll_add_agg(visitors) as visitors
+      from new_visitors
+  group by messageid, date
 )
 insert into tweet.uniques
      select messageid, date, visitors

--- a/testdata/corpus/intarray-tags-02_04.sql
+++ b/testdata/corpus/intarray-tags-02_04.sql
@@ -1,8 +1,8 @@
 with t(query) as (
-    select format('(%s)', array_to_string(array_agg(rowid), '&'))::query_int as query
-      from tags
-     where tag = 'blues'
-        or tag = 'rhythm and blues'
+  select format('(%s)', array_to_string(array_agg(rowid), '&'))::query_int as query
+    from tags
+   where tag = 'blues'
+      or tag = 'rhythm and blues'
 )
   select track.tid,
          left(track.artist, 26)

--- a/testdata/corpus/pub-names-knn-05_01_pubnames.svg.knn.sql
+++ b/testdata/corpus/pub-names-knn-05_01_pubnames.svg.knn.sql
@@ -5,71 +5,71 @@ with search as (
   select point(-0.12, 51.516) as pt
 ),
 nearest as (
-      select id,
-             name,
-             pos,
-             row_number() over(order by pos <-> (select pt from search)) as rn
-        from pubnames
-    order by pos <-> (select pt from search)
-       limit 10
+    select id,
+           name,
+           pos,
+           row_number() over(order by pos <-> (select pt from search)) as rn
+      from pubnames
+  order by pos <-> (select pt from search)
+     limit 10
 ),
 bbox as (
-    select least(min((pos)[0]), min((select (pt)[0] from search))) - 0.003 as x0,
-           greatest(max((pos)[0]), max((select (pt)[0] from search))) + 0.003 as x1,
-           least(min((pos)[1]), min((select (pt)[1] from search))) - 0.002 as y0,
-           greatest(max((pos)[1]), max((select (pt)[1] from search))) + 0.002 as y1
-      from nearest
+  select least(min((pos)[0]), min((select (pt)[0] from search))) - 0.003 as x0,
+         greatest(max((pos)[0]), max((select (pt)[0] from search))) + 0.003 as x1,
+         least(min((pos)[1]), min((select (pt)[1] from search))) - 0.002 as y0,
+         greatest(max((pos)[1]), max((select (pt)[1] from search))) + 0.002 as y1
+    from nearest
 ),
 proj as (
-           -- project lon/lat degrees onto a plain ~800-unit canvas before drawing
-           -- anything, so every SVG number (stroke-width, radius, font-size) is
-           -- an
-           -- ordinary integer instead of a sub-0.001 fraction — some renderers
-           -- don't
-           -- reliably handle attribute values at that scale.
-    select x0, y0, x1, y1, 800.0 / greatest(x1 - x0, y1 - y0) as scale
-      from bbox
+         -- project lon/lat degrees onto a plain ~800-unit canvas before drawing
+         -- anything, so every SVG number (stroke-width, radius, font-size) is
+         -- an
+         -- ordinary integer instead of a sub-0.001 fraction — some renderers
+         -- don't
+         -- reliably handle attribute values at that scale.
+  select x0, y0, x1, y1, 800.0 / greatest(x1 - x0, y1 - y0) as scale
+    from bbox
 ),
 win as (
   select st_makeenvelope(x0, y0, x1, y1, 4326) as env from bbox
 ),
 roads as (
-    select st_transscale(
-             st_intersection(r.geom, win.env), -proj.x0, -proj.y0, proj.scale,
-             proj.scale
-           ) as geom
-      from osm_london.roads r, win, proj
-     where st_intersects(r.geom, win.env)
+  select st_transscale(
+           st_intersection(r.geom, win.env), -proj.x0, -proj.y0, proj.scale,
+           proj.scale
+         ) as geom
+    from osm_london.roads r, win, proj
+   where st_intersects(r.geom, win.env)
 ),
 layers as (
-    select 1 as z,
-           '<path d="'
-        || st_assvg(geom, 0, 1)
-        || '" fill="none" stroke="#C0B8AE" stroke-width="2"/>' as elem
-      from roads
-    union all
-    select 2,
-           '<circle cx="'
-        || (((pt)[0] - proj.x0) * proj.scale)::text
-        || '" cy="'
-        || (-(((pt)[1] - proj.y0) * proj.scale))::text
-        || '" r="9" fill="#B04020" stroke="#F2EFE9" stroke-width="2"/>' as elem
-      from search, proj
-    union all
-    select 3,
-           '<circle cx="'
-        || (((pos)[0] - proj.x0) * proj.scale)::text
-        || '" cy="'
-        || (-(((pos)[1] - proj.y0) * proj.scale))::text
-        || '" r="6" fill="#5B8DB8" stroke="#F2EFE9" stroke-width="1.5"/>'
-        || '<text x="'
-        || (((pos)[0] - proj.x0) * proj.scale + 9)::text
-        || '" y="'
-        || (-(((pos)[1] - proj.y0) * proj.scale) + (case when rn % 2 = 0 then 9 else -4 end))::text
-        || '" font-size="13" fill="#2C2820">'
-        || replace(replace(name, '&', '&amp;'), '<', '&lt;')
-        || '</text>' as elem
-      from nearest, proj
+  select 1 as z,
+         '<path d="'
+      || st_assvg(geom, 0, 1)
+      || '" fill="none" stroke="#C0B8AE" stroke-width="2"/>' as elem
+    from roads
+  union all
+  select 2,
+         '<circle cx="'
+      || (((pt)[0] - proj.x0) * proj.scale)::text
+      || '" cy="'
+      || (-(((pt)[1] - proj.y0) * proj.scale))::text
+      || '" r="9" fill="#B04020" stroke="#F2EFE9" stroke-width="2"/>' as elem
+    from search, proj
+  union all
+  select 3,
+         '<circle cx="'
+      || (((pos)[0] - proj.x0) * proj.scale)::text
+      || '" cy="'
+      || (-(((pos)[1] - proj.y0) * proj.scale))::text
+      || '" r="6" fill="#5B8DB8" stroke="#F2EFE9" stroke-width="1.5"/>'
+      || '<text x="'
+      || (((pos)[0] - proj.x0) * proj.scale + 9)::text
+      || '" y="'
+      || (-(((pos)[1] - proj.y0) * proj.scale) + (case when rn % 2 = 0 then 9 else -4 end))::text
+      || '" font-size="13" fill="#2C2820">'
+      || replace(replace(name, '&', '&amp;'), '<', '&lt;')
+      || '</text>' as elem
+    from nearest, proj
 )
   select '<svg viewBox="0 '
       || (-((proj.y1 - proj.y0) * proj.scale))

--- a/testdata/corpus/sql-102-03_01_f1db.decade.top3.sql
+++ b/testdata/corpus/sql-102-03_01_f1db.decade.top3.sql
@@ -1,7 +1,7 @@
 with decades as (
-      select extract('year' from date_trunc('decade', date)) as decade
-        from races
-    group by decade
+    select extract('year' from date_trunc('decade', date)) as decade
+      from races
+  group by decade
 )
              select decade,
                     rank() over(
@@ -14,16 +14,16 @@ with decades as (
                from decades
   left join lateral (
       select code, forename, surname, count(*) as wins
-      from drivers
-      join results
-        on results.driverid = drivers.driverid
-       and results.position = 1
-      join races using(raceid)
-     where extract('year' from date_trunc('decade', races.date))
-         = decades.decade
-  group by decades.decade, drivers.driverid
-  order by wins desc
-     limit 3
-) as winners
+        from drivers
+        join results
+          on results.driverid = drivers.driverid
+         and results.position = 1
+        join races using(raceid)
+       where extract('year' from date_trunc('decade', races.date))
+           = decades.decade
+    group by decades.decade, drivers.driverid
+    order by wins desc
+       limit 3
+  ) as winners
                  on true
            order by decade asc, wins desc;

--- a/testdata/corpus/sql-103-01_02_f1db.decade.races.sql
+++ b/testdata/corpus/sql-103-01_02_f1db.decade.races.sql
@@ -1,9 +1,9 @@
 with races_per_decade as (
-      select extract('year' from date_trunc('decade', date)) as decade,
-             count(*) as nbraces
-        from races
-    group by decade
-    order by decade
+    select extract('year' from date_trunc('decade', date)) as decade,
+           count(*) as nbraces
+      from races
+  group by decade
+  order by decade
 )
 select decade,
        nbraces,

--- a/testdata/corpus/sql-103-01_03.sql
+++ b/testdata/corpus/sql-103-01_03.sql
@@ -1,13 +1,13 @@
 with counts as (
-      select driverid,
-             forename,
-             surname,
-             count(*) as races,
-             bool_and(position is null) as never_finished
-        from drivers
-        join results using(driverid)
-        join races using(raceid)
-    group by driverid
+    select driverid,
+           forename,
+           surname,
+           count(*) as races,
+           bool_and(position is null) as never_finished
+      from drivers
+      join results using(driverid)
+      join races using(raceid)
+  group by driverid
 )
   select driverid, forename, surname, races
     from counts

--- a/testdata/corpus/sql-103-01_04.sql
+++ b/testdata/corpus/sql-103-01_04.sql
@@ -1,11 +1,11 @@
 with counts as (
-      select date_trunc('year', date) as year,
-             count(*) filter(where position is null) as outs,
-             bool_and(position is null) as never_finished
-        from drivers
-        join results using(driverid)
-        join races using(raceid)
-    group by date_trunc('year', date), driverid
+    select date_trunc('year', date) as year,
+           count(*) filter(where position is null) as outs,
+           bool_and(position is null) as never_finished
+      from drivers
+      join results using(driverid)
+      join races using(raceid)
+  group by date_trunc('year', date), driverid
 )
   select extract(year from year) as season,
          sum(outs) as "#times any driver didn't finish a race"

--- a/testdata/corpus/sql-103-05_03_f1db.seasons.winners.sql
+++ b/testdata/corpus/sql-103-05_03_f1db.seasons.winners.sql
@@ -1,34 +1,34 @@
 with points as (
-      select year as season, driverid, constructorid, sum(points) as points
-        from results
-        join races using(raceid)
-    group by grouping sets ((year, driverid), (year, constructorid))
-      having sum(points) > 0
-    order by season, points desc
+    select year as season, driverid, constructorid, sum(points) as points
+      from results
+      join races using(raceid)
+  group by grouping sets ((year, driverid), (year, constructorid))
+    having sum(points) > 0
+  order by season, points desc
 ),
 tops as (
-      select season,
-             max(points) filter(where driverid is null) as ctops,
-             max(points) filter(where constructorid is null) as dtops
-        from points
-    group by season
-    order by season, dtops, ctops
+    select season,
+           max(points) filter(where driverid is null) as ctops,
+           max(points) filter(where constructorid is null) as dtops
+      from points
+  group by season
+  order by season, dtops, ctops
 ),
 champs as (
-    select tops.season,
-           champ_driver.driverid,
-           champ_driver.points,
-           champ_constructor.constructorid,
-           champ_constructor.points
-      from tops
-      join points as champ_driver
-        on champ_driver.season = tops.season
-       and champ_driver.constructorid is null
-       and champ_driver.points = tops.dtops
-      join points as champ_constructor
-        on champ_constructor.season = tops.season
-       and champ_constructor.driverid is null
-       and champ_constructor.points = tops.ctops
+  select tops.season,
+         champ_driver.driverid,
+         champ_driver.points,
+         champ_constructor.constructorid,
+         champ_constructor.points
+    from tops
+    join points as champ_driver
+      on champ_driver.season = tops.season
+     and champ_driver.constructorid is null
+     and champ_driver.points = tops.dtops
+    join points as champ_constructor
+      on champ_constructor.season = tops.season
+     and champ_constructor.driverid is null
+     and champ_constructor.points = tops.ctops
 )
   select season,
          format(

--- a/testdata/corpus/sql-103-05_07_hydrorivers.recursive.sql
+++ b/testdata/corpus/sql-103-05_07_hydrorivers.recursive.sql
@@ -1,16 +1,16 @@
 -- Loire: full basin via WITH RECURSIVE (6,297 reaches).
 -- Automates the ring-by-ring approach indefinitely.
 with recursive loire as (
-    select hyriv_id,
-           geom,
-           ord_stra  -- base case: the outlet
-      from hydrorivers.rivers
-     where hyriv_id = 20446779
-    union all
-    select r.hyriv_id,
-           r.geom,
-           r.ord_stra  -- recursive term: one step upstream
-      from hydrorivers.rivers as r
-      join loire on r.next_down = loire.hyriv_id
+  select hyriv_id,
+         geom,
+         ord_stra  -- base case: the outlet
+    from hydrorivers.rivers
+   where hyriv_id = 20446779
+  union all
+  select r.hyriv_id,
+         r.geom,
+         r.ord_stra  -- recursive term: one step upstream
+    from hydrorivers.rivers as r
+    join loire on r.next_down = loire.hyriv_id
 )
 select count(*) from loire;

--- a/testdata/corpus/subquery-01_exists_not_exists.sql
+++ b/testdata/corpus/subquery-01_exists_not_exists.sql
@@ -1,0 +1,22 @@
+-- Subquery layout: an EXISTS and a NOT EXISTS whose bodies are too wide
+-- to stay inline. Both bracket under the operator that introduces them.
+  select d.surname, d.nationality
+    from f1db.drivers d
+   where exists
+         (
+           select 1
+             from f1db.results res
+             join f1db.races r on r.raceid = res.raceid
+            where res.driverid = d.driverid
+              and r.year = 2017
+              and res.positionorder = 1
+         )
+     and not exists
+         (
+           select 1
+             from f1db.results dnf
+            where dnf.driverid = d.driverid
+              and dnf.statusid <> 1
+              and dnf.positionorder > 15
+         )
+order by d.surname;

--- a/testdata/corpus/subquery-02_scalar_and_in.sql
+++ b/testdata/corpus/subquery-02_scalar_and_in.sql
@@ -1,0 +1,20 @@
+-- A scalar subquery in the select list opens with its own paren, so the
+-- body is indented inside it and the closing paren returns to it; an IN
+-- on the right of a predicate brackets under the IN instead.
+  select ds.driverid,
+         ds.points,
+         (
+           select count(*) + 1
+             from f1db.driverstandings inner_ds
+            where inner_ds.raceid = ds.raceid
+              and inner_ds.points > ds.points
+         ) as rank
+    from f1db.driverstandings ds
+   where ds.raceid in
+                   (
+                     select r.raceid
+                       from f1db.races r
+                      where r.year = 2017
+                        and r.round > 10
+                   )
+order by rank;

--- a/testdata/corpus/subquery-03_cte_body_indent.sql
+++ b/testdata/corpus/subquery-03_cte_body_indent.sql
@@ -1,0 +1,19 @@
+-- A CTE body is indented two columns from the CTE's own base (STYLE.md
+-- rule 13), whether or not it fits on one line.
+with last_standings as (
+    select ds.raceid, max(ds.points) as top_points
+      from f1db.driverstandings ds
+      join f1db.races r using(raceid)
+     where r.year = 2017
+  group by ds.raceid
+),
+podium as (
+  select raceid, driverid
+    from f1db.results
+   where positionorder <= 3
+)
+  select ls.raceid, ls.top_points, count(p.driverid) as podium_drivers
+    from last_standings ls
+    join podium p using(raceid)
+group by ls.raceid, ls.top_points
+order by ls.raceid;


### PR DESCRIPTION
`formatQuerySegment` applied its base indent to wrapped bodies but not to one-line ones, so its contract depended on how the result came out — and callers disagreed. `renderCTE` added the indent itself, correct for a one-line body and double for a wrapped one (CTE bodies at 4 instead of rule 13's 2). `renderRun`'s subquery branch did not, and additionally took its indent from `leadingSpaces()` of a line that is usually a continuation carrying no indent at all.

That second bug is the visible one. The body's first line was emitted at one base while its remaining clause keywords were river-aligned at another:

```
 where exists (
    select 1
    from f1db.results res
   where res.driverid = d.driverid
)
```

`select` two columns right of the `from` and `where` it should align with, and a closing paren at column 0.

With the columns fixed, rule 12's "indent the body under wherever it opens" is applied for real. Where the paren ends a keyword phrase (`exists`, `not exists`, `in`, `any`/`all`/`some`, `lateral`) the phrase is the construct's left edge:

```
 where exists (
       select 1
         from f1db.results res
        where res.driverid = d.driverid
       )
```

Where the paren itself opens the construct — a scalar subquery, a derived table — the body indents inside it and the closing paren returns to its column.

LATERAL gets a separate path: `layoutFrom` folds join keywords into a phrase before rendering the relation, so the paren branch never sees the `lateral` that marks where the construct starts. Without it a `left join lateral (` derived table indented off the paren, a dozen columns right of anything it related to, and started wrapping expressions that had fitted.

STYLE.md rule 12 updated to describe both shapes. Corpus fixtures regenerated. New `format/subquery_test.go` pins each shape by column, plus idempotence — every one of these bugs produced output that shifted again on a second pass.