### PR TITLE
explain: add -canonical, a normal form for cross-source comparison

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,6 +120,47 @@ and worth reading before relying on it — chiefly that index names are not
 schema-qualified, and that this is a **comparison key, not a
 round-trippable advice string**.
 
+### Comparing across sources: `-canonical`
+
+Those differences matter as soon as the two plans did not come from the
+same place — comparing a plan from the server you run today against one a
+PostgreSQL 19 server printed itself, which is what upgrade verification
+looks like. The two agree on the decisions and disagree on how they write
+them down:
+
+- **Relation order inside a line.** 19 emits `NO_GATHER` from a
+  `Bitmapset`, so its targets come out in range-table order, stable per
+  *query*; `sqlfmt` walks the plan tree, stable per *plan*. Neither is
+  recoverable from the other, and for a set-valued tag the order means
+  nothing anyway.
+- **Schema qualifiers.** `pgpa_output_relation_name()` qualifies index
+  names unconditionally — 19 always prints `public.foo_pkey`, text EXPLAIN
+  always prints `foo_pkey`. And `EXPLAIN (VERBOSE)` qualifies *relations*,
+  which 19's identifiers never do.
+
+`-canonical` normalizes both away: set-valued targets are sorted,
+`JOIN_ORDER` is left alone because its order is meaning, index pairs sort
+together as pairs, and schema qualifiers are dropped.
+
+```console
+$ sqlfmt explain advice -canonical pg16-plan.txt     # reconstructed here
+$ sqlfmt explain canonical pg19-plan.txt             # what 19 printed
+$ sqlfmt explain diff -canonical before.txt after.txt
+```
+
+`explain canonical` reads an advice block a server already printed —
+give it a whole `EXPLAIN (PLAN_ADVICE)` capture and it finds the block
+inside — so the two sides can be put next to each other:
+
+```console
+$ diff <(sqlfmt explain advice -canonical pg16-plan.txt) \
+       <(sqlfmt explain canonical pg19-plan.txt)
+```
+
+Canonical output is even further from being valid advice than the default:
+sorting `JOIN_ORDER` would change its meaning, so it is not sorted, and a
+bare index name is ambiguous. It is a comparison key and nothing else.
+
 As a library: `import "github.com/dimitri/sqlfmt/format"` (module path TBD —
 not yet published), `format.Format(io.Reader) (string, error)`, so callers
 like `app.taop.xyz`'s `cmd/sqlbuild` book-build tool can format embedded

--- a/cmd/sqlfmt/explaincmd.go
+++ b/cmd/sqlfmt/explaincmd.go
@@ -41,6 +41,8 @@ func runExplain(args []string) int {
 		return runExplainAdvice(args[1:])
 	case "diff":
 		return runExplainDiff(args[1:])
+	case "canonical":
+		return runExplainCanonical(args[1:])
 	case "help", "-h", "--help":
 		explainUsage()
 		return 0
@@ -62,6 +64,17 @@ commands:
   diff <before> <after>   compare two plans: what the planner decided
                           differently, and how the timings moved
 
+  canonical [advice]      read an advice block that a server already
+                          printed and normalize it the same way
+
+Both advice and diff take -canonical, which normalizes advice before it is printed or
+compared: set-valued targets are sorted and schema qualifiers dropped.
+Use it when the two plans did not come from the same source — comparing
+one of these reconstructions against PostgreSQL 19's own PLAN_ADVICE
+output, say, where the two agree on the decisions but not on how they
+write them down. Canonical output is a comparison key, not advice you can
+feed back to a server.
+
 Plans are read in psql's default TEXT format, with or without ANALYZE,
 costs, the QUERY PLAN header, or a trailing row count.
 `)
@@ -69,6 +82,8 @@ costs, the QUERY PLAN header, or a trailing row count.
 
 func runExplainAdvice(args []string) int {
 	fs := flag.NewFlagSet("sqlfmt explain advice", flag.ExitOnError)
+	canonical := fs.Bool("canonical", false,
+		"normalize for comparison: sort set-valued targets, strip schema qualifiers")
 	fs.Parse(args)
 
 	var src []byte
@@ -96,6 +111,9 @@ func runExplainAdvice(args []string) int {
 		return 2
 	}
 	out := explain.AdviceString(plan)
+	if *canonical {
+		out = explain.CanonicalAdviceString(plan)
+	}
 	if out == "" {
 		report(fmt.Errorf("%s: no plan advice could be derived", name))
 		return 2
@@ -109,6 +127,9 @@ func runExplainAdvice(args []string) int {
 // does. A real error is 2.
 func runExplainDiff(args []string) int {
 	fs := flag.NewFlagSet("sqlfmt explain diff", flag.ExitOnError)
+	canonical := fs.Bool("canonical", false,
+		"normalize both sides before comparing; use when the two plans did "+
+			"not come from the same source")
 	fs.Parse(args)
 
 	if fs.NArg() != 2 {
@@ -127,6 +148,9 @@ func runExplainDiff(args []string) int {
 	}
 
 	d := explain.DiffPlans(before, after)
+	if *canonical {
+		d = explain.DiffPlansCanonical(before, after)
+	}
 	// Name the two sides after the files, the way diff(1) does: a diff
 	// that does not say what it compared makes the reader remember.
 	d.BeforeName = fs.Arg(0)
@@ -148,4 +172,49 @@ func parsePlanFile(path string) (*explain.Plan, error) {
 		return nil, fmt.Errorf("%s: %w", path, err)
 	}
 	return plan, nil
+}
+
+// runExplainCanonical normalizes advice that already exists, rather than
+// deriving it from a plan.
+//
+// This is the other half of cross-source comparison. "explain advice
+// -canonical" canonicalizes what this package reconstructs; this
+// canonicalizes what PostgreSQL 19 itself printed, so the two can be put
+// side by side:
+//
+//	diff <(sqlfmt explain advice -canonical pg16-plan.txt) \
+//	     <(sqlfmt explain canonical pg19-plan.txt)
+//
+// Input may be a whole EXPLAIN (PLAN_ADVICE) capture — the advice block is
+// found inside it — or just the advice lines.
+func runExplainCanonical(args []string) int {
+	fs := flag.NewFlagSet("sqlfmt explain canonical", flag.ExitOnError)
+	fs.Parse(args)
+
+	var src []byte
+	var name string
+	var err error
+	switch fs.NArg() {
+	case 0:
+		name = "<standard input>"
+		src, err = io.ReadAll(os.Stdin)
+	case 1:
+		name = fs.Arg(0)
+		src, err = os.ReadFile(name)
+	default:
+		fmt.Fprintln(os.Stderr, "usage: sqlfmt explain canonical [advice]")
+		return 2
+	}
+	if err != nil {
+		report(err)
+		return 2
+	}
+
+	out := explain.CanonicalAdviceTextFrom(string(src))
+	if out == "" {
+		report(fmt.Errorf("%s: no advice lines found", name))
+		return 2
+	}
+	fmt.Println(out)
+	return 0
 }

--- a/explain/canonical.go
+++ b/explain/canonical.go
@@ -1,0 +1,304 @@
+package explain
+
+import (
+	"sort"
+	"strings"
+)
+
+// Canonicalization puts two advice blocks into a form where they can be
+// compared even when they came from different places.
+//
+// The case that motivates it is an upgrade. You have a plan captured from
+// the PostgreSQL 16 server you run today, reconstructed by this package,
+// and a plan from a PostgreSQL 19 server printed by pg_plan_advice itself,
+// and the question is whether the planner changed its mind. That is
+// probably the single most valuable plan comparison anybody makes, and it
+// is inherently cross-source.
+//
+// Compared directly, the two disagree in ways that mean nothing:
+//
+//   - Relation ordering inside a line. 19 orders by its internal relation
+//     numbering, which is stable per QUERY; this package orders by walking
+//     the plan tree, which is stable per PLAN. Neither is recoverable from
+//     the other, and for a tag like NO_GATHER(a b c) the order carries no
+//     meaning at all — it is a set written down in some order.
+//   - Schema-qualified index names. 19 prints "public.foo_pkey"; text
+//     EXPLAIN prints "foo_pkey" and the schema is not in it.
+//
+// So canonical form sorts what is a set and strips what is unrecoverable,
+// and does neither to anything where the order is load-bearing. The result
+// is deliberately NOT valid input to pg_plan_advice — sorting JOIN_ORDER
+// would change its meaning, so JOIN_ORDER is left exactly as it was, and
+// stripping the schema from an index name makes it ambiguous. This is a
+// comparison key, not an advice string. Everything in this file exists to
+// make diffs quiet, not to feed a server.
+
+// orderedTags are the tags whose argument order is meaning, not notation.
+//
+// JOIN_ORDER(t1 t2 t3) says t1 drives and is joined to t2 before t3;
+// sorting it would state something different and probably false. Its
+// nested groups are ordered for the same reason: the README's
+// JOIN_ORDER(t1 (t2 t3)) puts t2 on the outer side of the inner join.
+//
+// Every other tag this package emits names a set. HASH_JOIN(a b) says
+// both a and b sit on the inner side of a hash join; which was written
+// first is an artifact of how the plan happened to be walked.
+var orderedTags = map[string]bool{
+	"JOIN_ORDER": true,
+}
+
+// pairedTags take (relation, index) pairs rather than a flat list:
+// INDEX_SCAN(foo foo_a_idx bar bar_b_idx). Sorting the tokens would
+// scramble relations against indexes, so these sort by pair and keep each
+// pair together.
+var pairedTags = map[string]bool{
+	"INDEX_SCAN":      true,
+	"INDEX_ONLY_SCAN": true,
+}
+
+// Canonical returns the line in canonical form. The receiver is unchanged.
+func (l AdviceLine) Canonical() AdviceLine {
+	out := AdviceLine{Kind: l.Kind, Args: make([]string, len(l.Args))}
+	copy(out.Args, l.Args)
+
+	if pairedTags[l.Kind] {
+		out.Args = canonicalPairs(out.Args)
+		return out
+	}
+	if orderedTags[l.Kind] {
+		// Order is meaning: normalize inside groups only, never across.
+		for i, a := range out.Args {
+			out.Args[i] = canonicalArg(a, true)
+		}
+		return out
+	}
+	for i, a := range out.Args {
+		out.Args[i] = canonicalArg(a, false)
+	}
+	sort.Strings(out.Args)
+	return out
+}
+
+// canonicalPairs sorts (relation, index) pairs by relation, keeping each
+// relation next to its index. An odd trailing argument is left in place
+// rather than silently paired with nothing: it means the input was not
+// the shape this tag is documented to have, and quietly reordering it
+// would hide that.
+func canonicalPairs(args []string) []string {
+	if len(args)%2 != 0 {
+		return args
+	}
+	type pair struct{ rel, idx string }
+	pairs := make([]pair, 0, len(args)/2)
+	for i := 0; i < len(args); i += 2 {
+		pairs = append(pairs, pair{stripSchema(args[i]), stripSchema(args[i+1])})
+	}
+	sort.Slice(pairs, func(i, j int) bool {
+		if pairs[i].rel != pairs[j].rel {
+			return pairs[i].rel < pairs[j].rel
+		}
+		return pairs[i].idx < pairs[j].idx
+	})
+	out := make([]string, 0, len(args))
+	for _, p := range pairs {
+		out = append(out, p.rel, p.idx)
+	}
+	return out
+}
+
+// canonicalArg normalizes one argument.
+//
+// An argument is not always one target. JOIN_ORDER renders its whole
+// ordered list into a single pre-rendered string, so "a b (c d)" arrives
+// as one Args entry, and a naive stripSchema over it would treat the
+// entire string as one dotted name and return "d". So this splits on
+// top-level spaces first and recurses, and only ever hands a leaf token —
+// something with no spaces and no parentheses — to stripSchema.
+//
+// A parenthesized group names a join product: "(bletch quux)". Members of
+// a group under a set-like tag are themselves a set; under an ordered tag
+// they are not, because JOIN_ORDER(t1 (t2 t3)) puts t2 on the outer side.
+func canonicalArg(arg string, ordered bool) string {
+	if members := splitTopLevelSpace(arg); len(members) > 1 {
+		for i, m := range members {
+			members[i] = canonicalArg(m, ordered)
+		}
+		if !ordered {
+			sort.Strings(members)
+		}
+		return strings.Join(members, " ")
+	}
+	if !strings.HasPrefix(arg, "(") || !strings.HasSuffix(arg, ")") {
+		return stripSchema(arg)
+	}
+	inner := arg[1 : len(arg)-1]
+	if inner == "" {
+		return arg
+	}
+	members := splitTopLevelSpace(inner)
+	for i, m := range members {
+		members[i] = canonicalArg(m, ordered)
+	}
+	if !ordered {
+		sort.Strings(members)
+	}
+	return "(" + strings.Join(members, " ") + ")"
+}
+
+// splitTopLevelSpace splits on spaces that are not inside parentheses, so
+// a nested group stays one member.
+func splitTopLevelSpace(s string) []string {
+	var out []string
+	depth, start := 0, 0
+	for i, r := range s {
+		switch r {
+		case '(':
+			depth++
+		case ')':
+			depth--
+		case ' ':
+			if depth == 0 {
+				if i > start {
+					out = append(out, s[start:i])
+				}
+				start = i + 1
+			}
+		}
+	}
+	if start < len(s) {
+		out = append(out, s[start:])
+	}
+	return out
+}
+
+// stripSchema drops a schema qualifier, leaving the bare object name.
+//
+// This is needed in both directions, and PostgreSQL's own source says why.
+//
+// For index names, pgpa_output_relation_name() in contrib/pg_plan_advice/
+// pgpa_output.c writes quote_identifier(namespace) + "." +
+// quote_identifier(name) unconditionally — there is no search_path check,
+// so 19 ALWAYS prints public.foo_pkey. Text EXPLAIN always prints the bare
+// foo_pkey. Neither side can produce the other, so both reduce to bare.
+//
+// For relation names it is the other way round. 19 identifies relations by
+// alias, never schema-qualified — the schema appears only in the partition
+// position of alias#occurrence/schema.partition@plan. But EXPLAIN (VERBOSE)
+// prints "Seq Scan on f1db.results", so a plan parsed from verbose output
+// yields "f1db.results" where 19 would say "results". Stripping also makes
+// a VERBOSE and a non-VERBOSE capture of the same plan compare equal, which
+// is worth having on its own.
+//
+// The split is on the last dot at quote depth zero, because either half may
+// be quoted: public."weird idx" must lose "public." and keep the quoted
+// name, while a single quoted identifier that merely contains a dot —
+// "a.b" — is one name and must be left whole.
+func stripSchema(name string) string {
+	last := -1
+	inQuote := false
+	for i := 0; i < len(name); i++ {
+		switch name[i] {
+		case '"':
+			// "" inside a quoted identifier is an escaped quote; either
+			// way toggling twice returns to the same state.
+			inQuote = !inQuote
+		case '.':
+			if !inQuote {
+				last = i
+			}
+		}
+	}
+	if last >= 0 && last+1 < len(name) {
+		return name[last+1:]
+	}
+	return name
+}
+
+// CanonicalAdvice is Advice with every line in canonical form.
+func CanonicalAdvice(p *Plan) []AdviceLine {
+	lines := Advice(p)
+	out := make([]AdviceLine, 0, len(lines))
+	for _, l := range lines {
+		out = append(out, l.Canonical())
+	}
+	return out
+}
+
+// CanonicalAdviceString is AdviceString in canonical form.
+func CanonicalAdviceString(p *Plan) string {
+	lines := CanonicalAdvice(p)
+	out := make([]string, 0, len(lines))
+	for _, l := range lines {
+		out = append(out, l.String())
+	}
+	return strings.Join(out, "\n")
+}
+
+// ParseAdviceLine reads one line of advice text back into an AdviceLine —
+// "HASH_JOIN(races drivers)" — so that a block printed by PostgreSQL 19
+// can be canonicalized and compared against one derived here.
+//
+// It accepts the leading whitespace 19 indents its advice block with, and
+// returns ok=false for anything that is not TAG(args), which is how the
+// surrounding "Generated Plan Advice:" header and blank lines are skipped
+// by a caller scanning a plan.
+func ParseAdviceLine(s string) (AdviceLine, bool) {
+	s = strings.TrimSpace(s)
+	open := strings.IndexByte(s, '(')
+	if open <= 0 || !strings.HasSuffix(s, ")") {
+		return AdviceLine{}, false
+	}
+	kind := s[:open]
+	for _, r := range kind {
+		if (r < 'A' || r > 'Z') && r != '_' {
+			return AdviceLine{}, false
+		}
+	}
+	inner := s[open+1 : len(s)-1]
+	// Reject unbalanced parens rather than producing a half-parsed line.
+	depth := 0
+	for _, r := range inner {
+		switch r {
+		case '(':
+			depth++
+		case ')':
+			depth--
+		}
+		if depth < 0 {
+			return AdviceLine{}, false
+		}
+	}
+	if depth != 0 {
+		return AdviceLine{}, false
+	}
+	var args []string
+	if inner != "" {
+		args = splitTopLevelSpace(inner)
+	}
+	return AdviceLine{Kind: kind, Args: args}, true
+}
+
+// CanonicalAdviceTextFrom extracts an advice block from text and returns it
+// in canonical form.
+//
+// The text can be a whole EXPLAIN (PLAN_ADVICE) capture: PostgreSQL 19
+// prints its block under a "Generated Plan Advice:" header, indented,
+// inside the plan output, and anything that is not TAG(args) is skipped.
+// It can equally be four bare lines someone pasted. Either way what comes
+// back is comparable with CanonicalAdviceString on a plan parsed here,
+// which is the point — one side reconstructed, one side authoritative.
+//
+// A "Supplied Plan Advice" block, which 19 also prints and which carries
+// /* matched */ comments, is deliberately not special-cased: its lines end
+// in a comment rather than ")" and so are skipped as not-advice.
+func CanonicalAdviceTextFrom(s string) string {
+	var out []string
+	for _, line := range strings.Split(s, "\n") {
+		l, ok := ParseAdviceLine(line)
+		if !ok {
+			continue
+		}
+		out = append(out, l.Canonical().String())
+	}
+	return strings.Join(out, "\n")
+}

--- a/explain/canonical_test.go
+++ b/explain/canonical_test.go
@@ -1,0 +1,311 @@
+package explain
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestCanonicalLine(t *testing.T) {
+	cases := []struct {
+		name string
+		in   AdviceLine
+		want string
+		why  string
+	}{
+		{
+			name: "set-valued targets are sorted",
+			in:   AdviceLine{Kind: "NO_GATHER", Args: []string{"drivers", "results", "races"}},
+			want: "NO_GATHER(drivers races results)",
+			why: "19 emits NO_GATHER from a Bitmapset, so its order is range-table " +
+				"order; this package walks the plan tree. Neither is recoverable " +
+				"from the other and neither means anything, so both sort.",
+		},
+		{
+			name: "JOIN_ORDER keeps its order",
+			in:   AdviceLine{Kind: "JOIN_ORDER", Args: []string{"results races drivers"}},
+			want: "JOIN_ORDER(results races drivers)",
+			why:  "t1 drives and is joined to t2 before t3; sorting states something else",
+		},
+		{
+			name: "JOIN_ORDER loses no relations to schema stripping",
+			in:   AdviceLine{Kind: "JOIN_ORDER", Args: []string{"f1db.results f1db.drivers"}},
+			want: "JOIN_ORDER(results drivers)",
+			why: "the whole ordered list arrives as ONE pre-rendered arg, so a " +
+				"stripSchema over the raw string returned just \"drivers\"",
+		},
+		{
+			name: "JOIN_ORDER nested group stays ordered",
+			in:   AdviceLine{Kind: "JOIN_ORDER", Args: []string{"t1 (t3 t2)"}},
+			want: "JOIN_ORDER(t1 (t3 t2))",
+			why:  "JOIN_ORDER(t1 (t2 t3)) puts t2 on the outer side of the inner join",
+		},
+		{
+			name: "set-valued group is sorted inside and out",
+			in:   AdviceLine{Kind: "HASH_JOIN", Args: []string{"(z y)", "a"}},
+			want: "HASH_JOIN((y z) a)",
+			why: "plain byte order, so groups sort ahead of bare names; there is " +
+				"no ground truth to match here since 19 does not sort at all, " +
+				"and the only thing that matters is that both sides agree",
+		},
+		{
+			name: "index pairs sort together, schema stripped",
+			in: AdviceLine{Kind: "INDEX_SCAN", Args: []string{
+				"f", "public.join_fact_dim_id", "d", "public.join_dim_pkey"}},
+			want: "INDEX_SCAN(d join_dim_pkey f join_fact_dim_id)",
+			why:  "sorting the tokens flat would scramble relations against indexes",
+		},
+		{
+			name: "index-only scan pairs likewise",
+			in:   AdviceLine{Kind: "INDEX_ONLY_SCAN", Args: []string{"t", "public.t_pkey"}},
+			want: "INDEX_ONLY_SCAN(t t_pkey)",
+		},
+		{
+			name: "odd argument count is left alone",
+			in:   AdviceLine{Kind: "INDEX_SCAN", Args: []string{"a", "a_idx", "b"}},
+			want: "INDEX_SCAN(a a_idx b)",
+			why:  "not the documented shape; reordering it would hide that",
+		},
+		{
+			name: "occurrence numbering survives sorting",
+			in:   AdviceLine{Kind: "SEQ_SCAN", Args: []string{"a#2", "a"}},
+			want: "SEQ_SCAN(a a#2)",
+		},
+		{
+			name: "relation schema stripped too",
+			in:   AdviceLine{Kind: "SEQ_SCAN", Args: []string{"f1db.results"}},
+			want: "SEQ_SCAN(results)",
+			why:  "EXPLAIN (VERBOSE) qualifies relations; 19's identifiers never do",
+		},
+		{
+			name: "empty group is untouched",
+			in:   AdviceLine{Kind: "GATHER", Args: []string{"()"}},
+			want: "GATHER(())",
+		},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			got := c.in.Canonical().String()
+			if got != c.want {
+				t.Errorf("got  %s\nwant %s\n%s", got, c.want, c.why)
+			}
+		})
+	}
+}
+
+// Canonical must not mutate its receiver: callers hold the original to
+// print alongside the normalized form.
+func TestCanonicalDoesNotMutate(t *testing.T) {
+	in := AdviceLine{Kind: "NO_GATHER", Args: []string{"c", "a", "b"}}
+	before := in.String()
+	_ = in.Canonical()
+	if in.String() != before {
+		t.Errorf("receiver mutated: %s became %s", before, in.String())
+	}
+}
+
+// Normalizing an already-normal line changes nothing, which is what makes
+// it safe to canonicalize both sides of a comparison without knowing where
+// either came from.
+func TestCanonicalIsIdempotent(t *testing.T) {
+	for _, l := range []AdviceLine{
+		{Kind: "NO_GATHER", Args: []string{"c", "a", "b"}},
+		{Kind: "JOIN_ORDER", Args: []string{"t1 (t3 t2)"}},
+		{Kind: "INDEX_SCAN", Args: []string{"f", "public.i", "d", "public.j"}},
+		{Kind: "HASH_JOIN", Args: []string{"(z y)", "a"}},
+	} {
+		once := l.Canonical()
+		twice := once.Canonical()
+		if once.String() != twice.String() {
+			t.Errorf("not idempotent:\nonce  %s\ntwice %s", once.String(), twice.String())
+		}
+	}
+}
+
+// No relation may be dropped or invented. This is the invariant the
+// JOIN_ORDER bug violated, and it is worth checking as a property rather
+// than only on the case that happened to expose it.
+func TestCanonicalPreservesTokens(t *testing.T) {
+	for _, l := range []AdviceLine{
+		{Kind: "JOIN_ORDER", Args: []string{"f1db.a f1db.b (f1db.c f1db.d)"}},
+		{Kind: "NO_GATHER", Args: []string{"s.a", "s.b", "s.c"}},
+		{Kind: "HASH_JOIN", Args: []string{"(s.z s.y)", "s.a"}},
+		{Kind: "INDEX_SCAN", Args: []string{"s.f", "s.i", "s.d", "s.j"}},
+	} {
+		count := func(a AdviceLine) int {
+			f := strings.FieldsFunc(strings.Join(a.Args, " "), func(r rune) bool {
+				return r == ' ' || r == '(' || r == ')'
+			})
+			return len(f)
+		}
+		if got, want := count(l.Canonical()), count(l); got != want {
+			t.Errorf("%s: %d targets in, %d out", l.Kind, want, got)
+		}
+	}
+}
+
+func TestStripSchema(t *testing.T) {
+	cases := []struct{ in, want string }{
+		{"foo_pkey", "foo_pkey"},
+		{"public.foo_pkey", "foo_pkey"},
+		{`public."weird idx"`, `"weird idx"`},
+		{`"My Schema".foo`, "foo"},
+		{`"a.b"`, `"a.b"`}, // one quoted identifier that contains a dot
+		{"a#2", "a#2"},
+		{"", ""},
+		{"trailing.", "trailing."}, // nothing after the dot: not a qualifier
+	}
+	for _, c := range cases {
+		if got := stripSchema(c.in); got != c.want {
+			t.Errorf("stripSchema(%q) = %q, want %q", c.in, got, c.want)
+		}
+	}
+}
+
+func TestSplitTopLevelSpace(t *testing.T) {
+	cases := []struct {
+		in   string
+		want []string
+	}{
+		{"a b c", []string{"a", "b", "c"}},
+		{"a (b c)", []string{"a", "(b c)"}},
+		{"(a (b c)) d", []string{"(a (b c))", "d"}},
+		{"a  b", []string{"a", "b"}}, // runs of spaces do not make empty fields
+		{"solo", []string{"solo"}},
+	}
+	for _, c := range cases {
+		got := splitTopLevelSpace(c.in)
+		if strings.Join(got, "|") != strings.Join(c.want, "|") {
+			t.Errorf("split(%q) = %v, want %v", c.in, got, c.want)
+		}
+	}
+}
+
+func TestParseAdviceLine(t *testing.T) {
+	ok := []struct {
+		in   string
+		kind string
+		args int
+	}{
+		{"HASH_JOIN(races drivers)", "HASH_JOIN", 2},
+		{"   JOIN_ORDER(a b c)", "JOIN_ORDER", 3}, // 19 indents its block
+		{"NO_GATHER(f)", "NO_GATHER", 1},
+		{"GATHER((f d))", "GATHER", 1},
+	}
+	for _, c := range ok {
+		l, got := ParseAdviceLine(c.in)
+		if !got {
+			t.Errorf("ParseAdviceLine(%q) rejected a valid line", c.in)
+			continue
+		}
+		if l.Kind != c.kind || len(l.Args) != c.args {
+			t.Errorf("ParseAdviceLine(%q) = %s with %d args, want %s with %d",
+				c.in, l.Kind, len(l.Args), c.kind, c.args)
+		}
+	}
+
+	// Everything a caller scanning a whole EXPLAIN capture must skip.
+	bad := []string{
+		"",
+		"Generated Plan Advice:",
+		" Hash Join",
+		"   Hash Cond: (results.raceid = races.raceid)",
+		"JOIN_ORDER(a b) /* matched */", // Supplied blocks carry a verdict
+		"lower_case(a)",
+		"HASH_JOIN(a",
+		"HASH_JOIN(a))",
+		"(a b)",
+	}
+	for _, s := range bad {
+		if _, got := ParseAdviceLine(s); got {
+			t.Errorf("ParseAdviceLine(%q) accepted a line that is not advice", s)
+		}
+	}
+}
+
+// The motivating case, end to end: a block PostgreSQL 19 printed and a
+// block this package reconstructed from the same plan agree once both are
+// canonical, and disagree before.
+func TestCanonicalClosesTheCrossSourceGap(t *testing.T) {
+	// The plan, as text EXPLAIN printed it.
+	plan := ` Hash Join
+   Hash Cond: (f.dim_id = d.id)
+   ->  Seq Scan on join_fact f
+   ->  Hash
+         ->  Index Scan using join_dim_pkey on join_dim d
+`
+	// What 19 itself printed for it: relations in range-table order, and
+	// the index name schema-qualified.
+	native := `Generated Plan Advice:
+   JOIN_ORDER(f d)
+   HASH_JOIN(d)
+   SEQ_SCAN(f)
+   INDEX_SCAN(d public.join_dim_pkey)
+   NO_GATHER(d f)
+`
+	p := mustParse(t, plan)
+
+	if AdviceString(p) == CanonicalAdviceTextFrom(native) {
+		t.Fatal("fixture no longer exercises a cross-source difference")
+	}
+	got := CanonicalAdviceString(p)
+	want := CanonicalAdviceTextFrom(native)
+	if got != want {
+		t.Errorf("canonical forms still differ:\nreconstructed:\n%s\nnative:\n%s", got, want)
+	}
+}
+
+// A "Supplied Plan Advice" block must not be mistaken for a generated one:
+// its lines end in a /* matched */ verdict rather than ")".
+func TestCanonicalAdviceTextSkipsSuppliedBlocks(t *testing.T) {
+	in := `Supplied Plan Advice:
+   JOIN_ORDER(drivers results races) /* matched */
+   HASH_JOIN(races) /* matched, failed */
+Generated Plan Advice:
+   JOIN_ORDER(a b)
+`
+	got := CanonicalAdviceTextFrom(in)
+	if got != "JOIN_ORDER(a b)" {
+		t.Errorf("got %q, want only the generated line", got)
+	}
+}
+
+func TestDiffCanonicalIsQuietWhenOnlyNotationDiffers(t *testing.T) {
+	// Same shape, but VERBOSE on one side: relations arrive qualified.
+	plain := mustParse(t, ` Nested Loop
+   ->  Seq Scan on results
+   ->  Index Scan using drivers_pkey on drivers
+`)
+	verbose := mustParse(t, ` Nested Loop
+   ->  Seq Scan on f1db.results
+   ->  Index Scan using drivers_pkey on f1db.drivers
+`)
+
+	if d := DiffPlans(plain, verbose); d.SameStructure() {
+		t.Fatal("fixture no longer exercises a notational difference")
+	}
+	d := DiffPlansCanonical(plain, verbose)
+	if !d.SameStructure() {
+		t.Errorf("canonical diff should be quiet, got:\n%s", d.String())
+	}
+	if !strings.Contains(d.String(), "canonical") {
+		t.Errorf("a canonical diff must say so in its hunk header:\n%s", d.String())
+	}
+}
+
+// Canonicalizing must not hide a real change.
+func TestDiffCanonicalStillSeesRealChanges(t *testing.T) {
+	before := mustParse(t, ` Hash Join
+   Hash Cond: (f.dim_id = d.id)
+   ->  Seq Scan on join_fact f
+   ->  Hash
+         ->  Seq Scan on join_dim d
+`)
+	after := mustParse(t, ` Nested Loop
+   ->  Seq Scan on join_fact f
+   ->  Index Scan using join_dim_pkey on join_dim d
+`)
+	d := DiffPlansCanonical(before, after)
+	if d.SameStructure() {
+		t.Error("a hash join becoming a nested loop is a real change")
+	}
+}

--- a/explain/diff.go
+++ b/explain/diff.go
@@ -35,6 +35,12 @@ type Diff struct {
 	// well-formed header.
 	BeforeName string
 	AfterName  string
+
+	// Canonical records that both sides were canonicalized before
+	// comparison, so the rendered diff can say so: a reader looking at a
+	// quiet diff deserves to know whether it is quiet because nothing
+	// changed or because differences were normalized away.
+	Canonical bool
 }
 
 // AdviceChange is one structural difference: an advice tag whose targets
@@ -52,7 +58,21 @@ func (d *Diff) SameStructure() bool { return len(d.Structural) == 0 }
 // DiffPlans compares two plans. Either may be nil, which is reported as a
 // wholesale appearance or disappearance rather than treated as an error.
 func DiffPlans(before, after *Plan) *Diff {
-	d := &Diff{Before: before, After: after}
+	return diffPlans(before, after, false)
+}
+
+// DiffPlansCanonical is DiffPlans with both sides put into canonical form
+// first, so that advice orderings and schema-qualified index names do not
+// show up as differences. Use it when the two plans did not come from the
+// same source — comparing a plan from the server you run today against one
+// from a PostgreSQL 19 server, for instance, where the two agree on the
+// decisions but not on how they write them down.
+func DiffPlansCanonical(before, after *Plan) *Diff {
+	return diffPlans(before, after, true)
+}
+
+func diffPlans(before, after *Plan, canonical bool) *Diff {
+	d := &Diff{Before: before, After: after, Canonical: canonical}
 
 	type entry struct{ before, after string }
 	// Insertion-ordered so the report follows advice emission order —
@@ -75,8 +95,12 @@ func DiffPlans(before, after *Plan) *Diff {
 			}
 		}
 	}
-	take(Advice(before), false)
-	take(Advice(after), true)
+	advice := Advice
+	if canonical {
+		advice = CanonicalAdvice
+	}
+	take(advice(before), false)
+	take(advice(after), true)
 
 	for _, kind := range order {
 		e := seen[kind]
@@ -119,7 +143,11 @@ func (d *Diff) String() string {
 	var b strings.Builder
 	fmt.Fprintf(&b, "--- %s\n", beforeName)
 	fmt.Fprintf(&b, "+++ %s\n", afterName)
-	b.WriteString("@@ plan structure @@\n")
+	if d.Canonical {
+		b.WriteString("@@ plan structure (canonical) @@\n")
+	} else {
+		b.WriteString("@@ plan structure @@\n")
+	}
 
 	if d.SameStructure() {
 		b.WriteString(" structure unchanged - the planner made the same decisions\n")


### PR DESCRIPTION
Comparing two plans this package derived works, because both sides went through the same code. Comparing one against advice **PostgreSQL 19 printed itself** does not — and that is the comparison worth making: a plan from the server you run today, a plan from a 19 server, and the question of whether the planner changed its mind on upgrade.

## What actually differs, from PostgreSQL's source

- `pgpa_output_no_gather()` emits from a `Bitmapset`, and `pgpa_output_relations()` walks it with `bms_next_member`, so 19's targets come out in **range-table order** — stable per *query*. This package walks the plan tree, stable per *plan*. That is why 19 printed `NO_GATHER(results races drivers)` for both the default and the forced plan of one query, where we printed the second differently.

  19 is not internally consistent here either: `pgpa_output_scan_strategy()` iterates a `List` in plan order while `NO_GATHER` uses a bitmapset. Order is notation, not meaning.

- `pgpa_output_relation_name()` writes `quote_identifier(namespace) "." quote_identifier(name)` with no `search_path` check, so 19 **always** schema-qualifies an index. Text EXPLAIN never does.

- The reverse for relations: 19 identifies them by alias, never qualified — schema appears only in the `/schema.partition` position — while `EXPLAIN (VERBOSE)` prints `Seq Scan on f1db.results`.

## What canonical form does

Sorts what is a set; leaves `JOIN_ORDER` alone because its order *is* meaning; sorts index pairs as pairs rather than as tokens; drops schema qualifiers from relations and indexes both.

Matching 19's own ordering is impossible from text — range-table indexes are not in it — so both sides are normalized to a third order instead. Plain byte order: there is no ground truth to match here, only agreement to reach.

```console
$ sqlfmt explain advice -canonical plan.txt
$ sqlfmt explain diff -canonical before.txt after.txt
$ sqlfmt explain canonical pg19-plan.txt
```

The third is new, and is the other half: the first two normalize what this package derives, that one normalizes advice a server already printed, finding the block inside a whole `EXPLAIN (PLAN_ADVICE)` capture. A `Supplied Plan Advice` block is skipped, since its lines end in a `/* matched */` verdict rather than `)`.

Verified end to end against the real capture behind the blog article: before canonicalization the reconstruction and 19's own block differ on exactly the `NO_GATHER` line; after it they are identical.

## One bug, and why there is a property test

`JOIN_ORDER` renders its whole ordered list into **one** pre-rendered `Args` entry. The first cut handed `"f1db.results f1db.drivers"` to `stripSchema` as if it were a single dotted name and got back `"drivers"` — silently dropping a relation. Arguments are now split on top-level spaces before anything touches them, and only leaf tokens reach `stripSchema`.

That is why `TestCanonicalPreservesTokens` checks the invariant as a property rather than only on the case that exposed it.

## Tests

New `explain/canonical_test.go`: a table over the ordered/set/paired tag classes, receiver immutability, idempotence, the token-preservation property, `stripSchema` quoting edge cases (`public."weird idx"` vs `"a.b"`), `ParseAdviceLine` accept/reject including the `/* matched */` case, the end-to-end cross-source fixture, and two diff tests — canonical is quiet when only notation differs, and still loud when a hash join becomes a nested loop.

`gofmt`, `go vet` and `make test` clean.